### PR TITLE
meta-evb-npcm750: x86-power-control: enable all server power operatio…

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-core/systemd/obmc-targets.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-core/systemd/obmc-targets.bbappend
@@ -1,0 +1,9 @@
+# Remove these files since they are provided by x86-power-control repo
+SYSTEMD_SERVICE_${PN}_remove += " obmc-host-start@.target"
+SYSTEMD_SERVICE_${PN}_remove += " obmc-host-stop@.target"
+SYSTEMD_SERVICE_${PN}_remove += " obmc-host-reboot@.target"
+SYSTEMD_SERVICE_${PN}_remove += " obmc-host-startmin@.target"
+SYSTEMD_SERVICE_${PN}_remove += " obmc-chassis-poweron@.target"
+SYSTEMD_SERVICE_${PN}_remove += " obmc-chassis-poweroff@.target"
+SYSTEMD_SERVICE_${PN}_remove += " obmc-chassis-hard-poweroff@.target"
+SYSTEMD_SERVICE_${PN}_remove += " obmc-chassis-powerreset@.target"

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/0001-power-control-WAR-pull-up-for-1.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/0001-power-control-WAR-pull-up-for-1.patch
@@ -1,0 +1,34 @@
+From db795475fa666e90f69402786ff474d4fd6817c8 Mon Sep 17 00:00:00 2001
+From: kwliu <kwliu@nuvoton.com>
+Date: Mon, 19 Nov 2018 13:26:13 +0800
+Subject: [PATCH] power-control: WAR: pull-up for 1
+
+---
+ power-control/src/power_control.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/power-control/src/power_control.cpp b/power-control/src/power_control.cpp
+index 9d15a06..3b9a3c7 100644
+--- a/power-control/src/power_control.cpp
++++ b/power-control/src/power_control.cpp
+@@ -55,7 +55,7 @@ int32_t PowerControl::setPowerState(int32_t newState)
+     For BMC (power control), just need to notify host (PCH) to switch
+     power, don't need to judge it should power on or off.
+     */
+-    buf = '0';
++    buf = '1';
+     ret = ::write(power_up_fd, &buf, sizeof(buf));
+     if (ret < 0)
+     {
+@@ -68,7 +68,7 @@ int32_t PowerControl::setPowerState(int32_t newState)
+     std::this_thread::sleep_for(
+         std::chrono::milliseconds(POWER_UP_PIN_PULSE_TIME_MS));
+ 
+-    buf = '1';
++    buf = '0';
+     ret = ::write(power_up_fd, &buf, sizeof(buf));
+     if (ret < 0)
+     {
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/intel-power-start@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/intel-power-start@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Start Power%i on
+Wants=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+After=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+Conflicts=obmc-chassis-poweroff@%i.target
+ConditionPathExists=!/run/openbmc/chassis@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "busctl call `mapper get-service /xyz/openbmc_project/Chassis/Control/Power%i` \
+          /xyz/openbmc_project/Chassis/Control/Power%i xyz.openbmc_project.Chassis.Control.Power setPowerState i 1"
+SyslogIdentifier=intel-power-start
+StartLimitInterval=0
+
+[Install]
+WantedBy=obmc-host-start@%i.target

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/intel-power-stop@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/intel-power-stop@.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Stop Power%i
+Wants=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+After=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+Conflicts=obmc-chassis-poweron@%i.target
+Conflicts=obmc-host-start@%i.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "busctl call `mapper get-service /xyz/openbmc_project/Chassis/Control/Power%i` \
+          /xyz/openbmc_project/Chassis/Control/Power%i xyz.openbmc_project.Chassis.Control.Power setPowerState i 0"
+SyslogIdentifier=intel-power-stop
+StartLimitInterval=0
+
+ExecStart=/bin/rm -f /run/openbmc/chassis@%i-on
+ExecStart=/bin/rm -f /run/openbmc/host@%i-on
+ExecStart=/bin/rm -f /run/openbmc/host@%i-request
+
+[Install]
+WantedBy=obmc-chassis-poweroff@%i.target

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/intel-power-warm-reset@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/intel-power-warm-reset@.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Power%i warm reset
+Wants=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+After=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+Conflicts=obmc-chassis-poweroff@%i.target
+ConditionPathExists=!/run/openbmc/chassis@%i-on
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "busctl call `mapper get-service /xyz/openbmc_project/Chassis/Control/Power%i` \
+          /xyz/openbmc_project/Chassis/Control/Power%i xyz.openbmc_project.Chassis.Control.Power setPowerState i 2"
+SyslogIdentifier=intel-power-warm-reset
+
+[Install]
+WantedBy=obmc-host-warm-reset@%i.target

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-chassis-hard-poweroff@.target
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-chassis-hard-poweroff@.target
@@ -1,0 +1,12 @@
+[Unit]
+Description=Chassis%i (Hard Power Off)
+Wants={SYSTEMD_DEFAULT_TARGET}
+After={SYSTEMD_DEFAULT_TARGET}
+Wants=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+After=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+Conflicts=obmc-chassis-poweron@%i.target
+Conflicts=obmc-chassis-reset@%i.target
+Conflicts=obmc-host-shutdown@%i.target
+Conflicts=xyz.openbmc_project.Ipmi.Internal.SoftPowerOff.service
+RefuseManualStop=yes
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-chassis-poweroff@.target
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-chassis-poweroff@.target
@@ -1,0 +1,10 @@
+[Unit]
+Description=Chassis%i (Power Off)
+Wants={SYSTEMD_DEFAULT_TARGET}
+After={SYSTEMD_DEFAULT_TARGET}
+Wants=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+After=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+Conflicts=obmc-chassis-poweron@%i.target
+Conflicts=obmc-chassis-reset@%i.target
+RefuseManualStop=yes
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-chassis-poweron@.target
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-chassis-poweron@.target
@@ -1,0 +1,10 @@
+[Unit]
+Description=Chassis%i (Power On)
+Wants={SYSTEMD_DEFAULT_TARGET}
+After={SYSTEMD_DEFAULT_TARGET}
+Wants=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+After=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+Conflicts=obmc-chassis-poweroff@%i.target
+RefuseManualStop=yes
+OnFailure=obmc-chassis-poweroff@%i.target
+OnFailureJobMode=flush

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-chassis-powerreset@.target
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-chassis-powerreset@.target
@@ -1,0 +1,7 @@
+[Unit]
+Description=Chassis%i (Reset Check)
+Conflicts=obmc-chassis-poweroff@%i.target
+RefuseManualStop=yes
+
+[Install]
+WantedBy={SYSTEMD_DEFAULT_TARGET}

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-host-reboot@.target
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-host-reboot@.target
@@ -1,0 +1,10 @@
+[Unit]
+Description=Reboot Host%i
+Wants={SYSTEMD_DEFAULT_TARGET}
+After={SYSTEMD_DEFAULT_TARGET}
+Wants=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+After=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+Conflicts=obmc-host-startmin@%i.target
+RefuseManualStop=yes
+OnFailure=obmc-chassis-poweroff@%i.target
+OnFailureJobMode=flush

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-host-soft-reboot@.target
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-host-soft-reboot@.target
@@ -1,0 +1,10 @@
+[Unit]
+Description=Soft Reboot Host%i
+Wants={SYSTEMD_DEFAULT_TARGET}
+After={SYSTEMD_DEFAULT_TARGET}
+Wants=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+After=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+Conflicts=obmc-host-startmin@%i.target
+RefuseManualStop=yes
+OnFailure=obmc-chassis-poweroff@%i.target
+OnFailureJobMode=flush

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-host-start@.target
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-host-start@.target
@@ -1,0 +1,10 @@
+[Unit]
+Description=Start Host%i
+Wants={SYSTEMD_DEFAULT_TARGET}
+After={SYSTEMD_DEFAULT_TARGET}
+Wants=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+After=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+Conflicts=obmc-host-stop@%i.target
+RefuseManualStop=yes
+OnFailure=obmc-host-quiesce@%i.target
+OnFailureJobMode=flush

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-host-startmin@.target
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-host-startmin@.target
@@ -1,0 +1,6 @@
+[Unit]
+Description=Start Host%i Minimum
+Wants={SYSTEMD_DEFAULT_TARGET}
+After={SYSTEMD_DEFAULT_TARGET}
+Wants=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+After=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-host-stop@.target
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-host-stop@.target
@@ -1,0 +1,10 @@
+[Unit]
+Description=Stop Host%i
+Wants={SYSTEMD_DEFAULT_TARGET}
+After={SYSTEMD_DEFAULT_TARGET}
+Wants=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+After=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+Conflicts=obmc-host-startmin@%i.target
+RefuseManualStop=yes
+OnFailure=obmc-chassis-poweroff@%i.target
+OnFailureJobMode=flush

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-host-warm-reset@.target
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-host-warm-reset@.target
@@ -1,0 +1,10 @@
+[Unit]
+Description=Warm reset Host%i
+Wants={SYSTEMD_DEFAULT_TARGET}
+After={SYSTEMD_DEFAULT_TARGET}
+Wants=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+After=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+Conflicts=obmc-host-stop@%i.target
+RefuseManualStop=yes
+OnFailure=obmc-host-quiesce@%i.target
+OnFailureJobMode=flush

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-send-signal-host-starting@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-send-signal-host-starting@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Broadcast host starting signal to dbus
+Wants=mapper-wait@-xyz-openbmc_project-state-host%i.service
+After=mapper-wait@-xyz-openbmc_project-state-host%i.service
+
+[Service]
+Restart=no
+Type=oneshot
+ExecStart=/bin/sh -c "dbus-send --system --type=signal /xyz/openbmc_project/state/host0 xyz.openbmc_project.State.Host.HostStarting"
+SyslogIdentifier=hoststartingsignal
+
+[Install]
+WantedBy=obmc-host-starting@%i.target

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-send-signal-host-stopping@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-send-signal-host-stopping@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Broadcast host stopping signal to dbus
+Wants=mapper-wait@-xyz-openbmc_project-state-host%i.service
+After=mapper-wait@-xyz-openbmc_project-state-host%i.service
+
+[Service]
+Restart=no
+Type=oneshot
+ExecStart=/bin/sh -c "dbus-send --system --type=signal /xyz/openbmc_project/state/host0 xyz.openbmc_project.State.Host.HostStoping"
+SyslogIdentifier=hoststoppingsignal
+
+[Install]
+WantedBy=obmc-host-stopping@%i.target

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-send-signal-post-host-start@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-send-signal-post-host-start@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Broadcast post host start signal to dbus
+Wants=mapper-wait@-xyz-openbmc_project-state-host%i.service
+After=mapper-wait@-xyz-openbmc_project-state-host%i.service
+
+[Service]
+Restart=no
+Type=oneshot
+ExecStart=/bin/sh -c "dbus-send --system --type=signal /xyz/openbmc_project/state/host0 xyz.openbmc_project.State.Host.PostHostStart"
+SyslogIdentifier=posthoststartsignal
+
+[Install]
+WantedBy=obmc-host-started@%i.target

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-send-signal-post-host-stop@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-send-signal-post-host-stop@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Broadcast post host stop signal to dbus
+Wants=mapper-wait@-xyz-openbmc_project-state-host%i.service
+After=mapper-wait@-xyz-openbmc_project-state-host%i.service
+
+[Service]
+Restart=no
+Type=oneshot
+ExecStart=/bin/sh -c "dbus-send --system --type=signal /xyz/openbmc_project/state/host0 xyz.openbmc_project.State.Host.PostHostStop"
+SyslogIdentifier=posthoststopsignal
+
+[Install]
+WantedBy=obmc-host-stopped@%i.target

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-send-signal-pre-host-start@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-send-signal-pre-host-start@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Broadcast pre host start signal to dbus
+Wants=mapper-wait@-xyz-openbmc_project-state-host%i.service
+After=mapper-wait@-xyz-openbmc_project-state-host%i.service
+
+[Service]
+Restart=no
+Type=oneshot
+ExecStart=/bin/sh -c "dbus-send --system --type=signal /xyz/openbmc_project/state/host0 xyz.openbmc_project.State.Host.PreHostStart"
+SyslogIdentifier=prehoststartsignal
+
+[Install]
+WantedBy=obmc-host-start-pre@%i.target

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-send-signal-pre-host-stop@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/obmc-send-signal-pre-host-stop@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Broadcast pre host stop signal to dbus
+Wants=mapper-wait@-xyz-openbmc_project-state-host%i.service
+After=mapper-wait@-xyz-openbmc_project-state-host%i.service
+
+[Service]
+Restart=no
+Type=oneshot
+ExecStart=/bin/sh -c "dbus-send --system --type=signal /xyz/openbmc_project/state/host0 xyz.openbmc_project.State.Host.PreHostStop"
+SyslogIdentifier=prehoststopsignal
+
+[Install]
+WantedBy=obmc-host-stop-pre@%i.target
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/op-reset-chassis-on@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/op-reset-chassis-on@.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Start chassis%i on after BMC reset
+Requires=op-reset-chassis-running@%i.service
+After=op-reset-chassis-running@%i.service
+After=obmc-power-reset-on@%i.target
+Requires=obmc-power-reset-on@%i.target
+ConditionPathExists=/run/openbmc/chassis@%i-on
+
+[Service]
+RemainAfterExit=no
+ExecStart=/bin/systemctl start obmc-host-start@%i.target
+
+
+[Install]
+WantedBy=obmc-chassis-powerreset@%i.target

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/op-reset-chassis-running@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/op-reset-chassis-running@.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Check Chassis%i pgood and create a file to indicate it
+Wants=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+After=mapper-wait@-xyz-openbmc_project-Chassis-Control-Power%i.service
+Wants=obmc-power-reset-on@%i.target
+Before=obmc-power-reset-on@%i.target
+Conflicts=obmc-chassis-poweroff@%i.target
+
+[Service]
+RemainAfterExit=no
+Type=oneshot
+ExecStart=/bin/sh -c "if [ $(busctl get-property `mapper get-service /xyz/openbmc_project/Chassis/Control/Power%i` /xyz/openbmc_project/Chassis/Control/Power%i xyz.openbmc_project.Chassis.Control.Power pgood | sed 's/i\s*[1]/on/' | grep on | wc -l) != 0 ]; then mkdir -p /run/openbmc/ && touch /run/openbmc/chassis@%i-on; fi"
+
+[Install]
+WantedBy=obmc-chassis-powerreset@%i.target

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/xyz.openbmc_project.Chassis.Control.Power@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control/xyz.openbmc_project.Chassis.Control.Power@.service
@@ -1,0 +1,17 @@
+
+[Unit]
+Description=Intel Power Control%i
+Wants=mapper-wait@-org-openbmc-managers-System.service
+After=mapper-wait@-org-openbmc-managers-System.service
+
+[Service]
+Restart=always
+RestartSec=3
+ExecStart=/usr/bin/env power-control
+SyslogIdentifier=power-control
+Type=dbus
+BusName={BUSNAME}
+
+[Install]
+WantedBy={SYSTEMD_DEFAULT_TARGET}
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-power-control-WAR-pull-up-for-1.patch"

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control_git.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/chassis/x86-power-control_git.bb
@@ -1,0 +1,171 @@
+SUMMARY = "Power Control service for Intel based platform"
+DESCRIPTION = "Power Control service for Intel based platfrom"
+PR = "r1"
+PV = "1.0+git${SRCPV}"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
+
+S = "${WORKDIR}/git"
+SRC_URI += "git://github.com/openbmc/x86-power-control.git"
+SRCREV = "80f6d927c220be0e638a0674a986429825a070aa"
+
+inherit cmake pkgconfig pythonnative systemd
+inherit obmc-phosphor-dbus-service
+
+DBUS_SERVICE_${PN} += "xyz.openbmc_project.Chassis.Control.Power@.service"
+
+# Force the standby target to run these services
+SYSD_TGT = "${SYSTEMD_DEFAULT_TARGET}"
+
+POWER_TMPL_CTRL = "xyz.openbmc_project.Chassis.Control.Power@.service"
+#SYSD_TGT = "${SYSTEMD_DEFAULT_TARGET}"
+POWER_INSTFMT_CTRL = "xyz.openbmc_project.Chassis.Control.Power@{0}.service"
+POWER_FMT_CTRL = "../${POWER_TMPL_CTRL}:${SYSD_TGT}.wants/${POWER_INSTFMT_CTRL}"
+SYSTEMD_LINK_${PN} += "${@compose_list_zip(d, 'POWER_FMT_CTRL', 'OBMC_HOST_INSTANCES')}"
+
+SYSTEMD_SERVICE_${PN} += " \
+        obmc-host-start@.target \
+        obmc-host-startmin@.target \
+        obmc-host-stop@.target \
+        obmc-host-reboot@.target \
+        obmc-chassis-poweroff@.target \
+        obmc-chassis-poweron@.target \
+        obmc-chassis-hard-poweroff@.target \
+        obmc-host-soft-reboot@.target \
+        obmc-host-warm-reset@.target \
+        obmc-chassis-powerreset@.target \
+        "
+
+RESET_TGTFMT = "obmc-chassis-powerreset@{0}.target"
+
+RESET_ON_TMPL = "op-reset-chassis-running@.service"
+RESET_ON_INSTFMT = "op-reset-chassis-running@{0}.service"
+RESET_ON_FMT = "../${RESET_ON_TMPL}:${RESET_TGTFMT}.requires/${RESET_ON_INSTFMT}"
+SYSTEMD_SERVICE_${PN} += "${RESET_ON_TMPL}"
+SYSTEMD_LINK_${PN} += "${@compose_list_zip(d, 'RESET_ON_FMT', 'OBMC_CHASSIS_INSTANCES')}"
+
+RESET_ON_CHASSIS_TMPL = "op-reset-chassis-on@.service"
+RESET_ON_CHASSIS_INSTFMT = "op-reset-chassis-on@{0}.service"
+RESET_ON_CHASSIS_FMT = "../${RESET_ON_CHASSIS_TMPL}:${RESET_TGTFMT}.requires/${RESET_ON_CHASSIS_INSTFMT}"
+SYSTEMD_SERVICE_${PN} += "${RESET_ON_CHASSIS_TMPL}"
+SYSTEMD_LINK_${PN} += "${@compose_list_zip(d, 'RESET_ON_CHASSIS_FMT', 'OBMC_CHASSIS_INSTANCES')}"
+
+# Force the standby target to run the chassis reset check target
+RESET_TMPL_CTRL = "obmc-chassis-powerreset@.target"
+SYSD_TGT = "${SYSTEMD_DEFAULT_TARGET}"
+RESET_INSTFMT_CTRL = "obmc-chassis-powerreset@{0}.target"
+RESET_FMT_CTRL = "../${RESET_TMPL_CTRL}:${SYSD_TGT}.wants/${RESET_INSTFMT_CTRL}"
+SYSTEMD_LINK_${PN} += "${@compose_list_zip(d, 'RESET_FMT_CTRL', 'OBMC_CHASSIS_INSTANCES')}"
+
+START_TMPL = "intel-power-start@.service"
+START_TGTFMT = "obmc-chassis-poweron@{0}.target"
+START_INSTFMT = "intel-power-start@{0}.service"
+START_FMT = "../${START_TMPL}:${START_TGTFMT}.requires/${START_INSTFMT}"
+SYSTEMD_SERVICE_${PN} += "${START_TMPL}"
+
+STOP_TMPL = "intel-power-stop@.service"
+STOP_TGTFMT = "obmc-chassis-poweroff@{0}.target"
+STOP_INSTFMT = "intel-power-stop@{0}.service"
+STOP_FMT = "../${STOP_TMPL}:${STOP_TGTFMT}.requires/${STOP_INSTFMT}"
+SYSTEMD_SERVICE_${PN} += "${STOP_TMPL}"
+
+WARM_RESET_TMPL = "intel-power-warm-reset@.service"
+WARM_RESET_TGTFMT = "obmc-host-warm-reset@{0}.target"
+WARM_RESET_INSTFMT = "intel-power-warm-reset@{0}.service"
+WARM_RESET_FMT = "../${WARM_RESET_TMPL}:${WARM_RESET_TGTFMT}.requires/${WARM_RESET_INSTFMT}"
+SYSTEMD_SERVICE_${PN} += "${WARM_RESET_TMPL}"
+
+# Build up requires relationship for START_TGTFMT and STOP_TGTFMT
+SYSTEMD_LINK_${PN} += "${@compose_list(d, 'START_FMT', 'OBMC_CHASSIS_INSTANCES')}"
+SYSTEMD_LINK_${PN} += "${@compose_list(d, 'STOP_FMT',  'OBMC_CHASSIS_INSTANCES')}"
+SYSTEMD_LINK_${PN} += "${@compose_list(d, 'WARM_RESET_FMT',  'OBMC_CHASSIS_INSTANCES')}"
+
+#The main control target requires these power targets
+START_TMPL_CTRL = "obmc-chassis-poweron@.target"
+START_TGTFMT_CTRL = "obmc-host-startmin@{0}.target"
+START_INSTFMT_CTRL = "obmc-chassis-poweron@{0}.target"
+START_FMT_CTRL = "../${START_TMPL_CTRL}:${START_TGTFMT_CTRL}.requires/${START_INSTFMT_CTRL}"
+SYSTEMD_LINK_${PN} += "${@compose_list(d, 'START_FMT_CTRL', 'OBMC_CHASSIS_INSTANCES')}"
+
+# Chassis off requires host off
+STOP_TMPL_CTRL = "obmc-host-stop@.target"
+STOP_TGTFMT_CTRL = "obmc-chassis-poweroff@{0}.target"
+STOP_INSTFMT_CTRL = "obmc-host-stop@{0}.target"
+STOP_FMT_CTRL = "../${STOP_TMPL_CTRL}:${STOP_TGTFMT_CTRL}.requires/${STOP_INSTFMT_CTRL}"
+SYSTEMD_LINK_${PN} += "${@compose_list(d, 'STOP_FMT_CTRL', 'OBMC_CHASSIS_INSTANCES')}"
+
+# Hard power off requires chassis off
+HARD_OFF_TMPL_CTRL = "obmc-chassis-poweroff@.target"
+HARD_OFF_TGTFMT_CTRL = "obmc-chassis-hard-poweroff@{0}.target"
+HARD_OFF_INSTFMT_CTRL = "obmc-chassis-poweroff@{0}.target"
+HARD_OFF_FMT_CTRL = "../${HARD_OFF_TMPL_CTRL}:${HARD_OFF_TGTFMT_CTRL}.requires/${HARD_OFF_INSTFMT_CTRL}"
+SYSTEMD_LINK_${PN} += "${@compose_list_zip(d, 'HARD_OFF_FMT_CTRL', 'OBMC_CHASSIS_INSTANCES')}"
+
+# Host soft reboot to run the shutdown target
+HOST_SHUTDOWN_TMPL = "obmc-host-shutdown@.target"
+HOST_SOFT_REBOOT_TMPL = "obmc-host-soft-reboot@.target"
+HOST_SOFT_REBOOT_TGTFMT = "obmc-host-soft-reboot@{0}.target"
+HOST_SHUTDOWN_INSTFMT = "obmc-host-shutdown@{0}.target"
+HOST_SOFT_REBOOT_FMT = "../${HOST_SHUTDOWN_TMPL}:${HOST_SOFT_REBOOT_TGTFMT}.requires/${HOST_SHUTDOWN_INSTFMT}"
+SYSTEMD_LINK_${PN} += "${@compose_list_zip(d, 'HOST_SOFT_REBOOT_FMT', 'OBMC_HOST_INSTANCES')}"
+# And also to call the host startmin service
+HOST_SOFT_REBOOT_SVC = "phosphor-reboot-host@.service"
+HOST_SOFT_REBOOT_SVC_INST = "phosphor-reboot-host@{0}.service"
+HOST_SOFT_REBOOT_SVC_FMT = "../${HOST_SOFT_REBOOT_SVC}:${HOST_SOFT_REBOOT_TGTFMT}.requires/${HOST_SOFT_REBOOT_SVC_INST}"
+SYSTEMD_LINK_${PN} += "${@compose_list_zip(d, 'HOST_SOFT_REBOOT_SVC_FMT', 'OBMC_HOST_INSTANCES')}"
+
+#Broadcast Host state
+PRE_HOST_START_TMPL = "obmc-send-signal-pre-host-start@.service"
+PRE_HOST_START_TGTFMT = "obmc-host-start-pre@{0}.target"
+PRE_HOST_START_INSTFMT = "obmc-send-signal-pre-host-start@{0}.service"
+PRE_HOST_START_FMT = "../${PRE_HOST_START_TMPL}:${PRE_HOST_START_TGTFMT}.requires/${PRE_HOST_START_INSTFMT}"
+SYSTEMD_SERVICE_${PN} += "${PRE_HOST_START_TMPL}"
+SYSTEMD_LINK_${PN} += "${@compose_list_zip(d, 'PRE_HOST_START_FMT', 'OBMC_HOST_INSTANCES')}"
+
+POST_HOST_START_TMPL = "obmc-send-signal-post-host-start@.service"
+POST_HOST_START_TGTFMT = "obmc-host-started@{0}.target"
+POST_HOST_START_INSTFMT = "obmc-send-signal-post-host-start@{0}.service"
+POST_HOST_START_FMT = "../${POST_HOST_START_TMPL}:${POST_HOST_START_TGTFMT}.requires/${POST_HOST_START_INSTFMT}"
+SYSTEMD_SERVICE_${PN} += "${POST_HOST_START_TMPL}"
+SYSTEMD_LINK_${PN} += "${@compose_list_zip(d, 'POST_HOST_START_FMT', 'OBMC_HOST_INSTANCES')}"
+
+HOST_STARTING_TMPL = "obmc-send-signal-host-starting@.service"
+HOST_STARTING_TGTFMT = "obmc-host-starting@{0}.target"
+HOST_STARTING_INSTFMT = "obmc-send-signal-host-starting@{0}.service"
+HOST_STARTING_FMT = "../${HOST_STARTING_TMPL}:${HOST_STARTING_TGTFMT}.requires/${HOST_STARTING_INSTFMT}"
+SYSTEMD_SERVICE_${PN} += "${HOST_STARTING_TMPL}"
+SYSTEMD_LINK_${PN} += "${@compose_list_zip(d, 'HOST_STARTING_FMT', 'OBMC_HOST_INSTANCES')}"
+
+PRE_HOST_STOP_TMPL = "obmc-send-signal-pre-host-stop@.service"
+PRE_HOST_STOP_TGTFMT = "obmc-host-stop-pre@{0}.target"
+PRE_HOST_STOP_INSTFMT = "obmc-send-signal-pre-host-stop@{0}.service"
+PRE_HOST_STOP_FMT = "../${PRE_HOST_STOP_TMPL}:${PRE_HOST_STOP_TGTFMT}.requires/${PRE_HOST_STOP_INSTFMT}"
+SYSTEMD_SERVICE_${PN} += "${PRE_HOST_STOP_TMPL}"
+SYSTEMD_LINK_${PN} += "${@compose_list_zip(d, 'PRE_HOST_STOP_FMT', 'OBMC_HOST_INSTANCES')}"
+
+POST_HOST_STOP_TMPL = "obmc-send-signal-post-host-stop@.service"
+POST_HOST_STOP_TGTFMT = "obmc-host-stopped@{0}.target"
+POST_HOST_STOP_INSTFMT = "obmc-send-signal-post-host-stop@{0}.service"
+POST_HOST_STOP_FMT = "../${POST_HOST_STOP_TMPL}:${POST_HOST_STOP_TGTFMT}.requires/${POST_HOST_STOP_INSTFMT}"
+SYSTEMD_SERVICE_${PN} += "${POST_HOST_STOP_TMPL}"
+SYSTEMD_LINK_${PN} += "${@compose_list_zip(d, 'POST_HOST_STOP_FMT', 'OBMC_HOST_INSTANCES')}"
+
+HOST_STOPPING_TMPL = "obmc-send-signal-host-stopping@.service"
+HOST_STOPPING_TGTFMT = "obmc-host-stopping@{0}.target"
+HOST_STOPPING_INSTFMT = "obmc-send-signal-host-stopping@{0}.service"
+HOST_STOPPING_FMT = "../${HOST_STOPPING_TMPL}:${HOST_STOPPING_TGTFMT}.requires/${HOST_STOPPING_INSTFMT}"
+SYSTEMD_SERVICE_${PN} += "${HOST_STOPPING_TMPL}"
+SYSTEMD_LINK_${PN} += "${@compose_list_zip(d, 'HOST_STOPPING_FMT', 'OBMC_HOST_INSTANCES')}"
+
+DEPENDS += " \
+    autoconf-archive-native \
+    boost \
+    systemd \
+    sdbusplus \
+    sdbusplus-native \
+    phosphor-dbus-interfaces \
+    phosphor-dbus-interfaces-native \
+    phosphor-logging \
+    "
+
+EXTRA_OECMAKE = " -DENABLE_GTEST=OFF -DCMAKE_SKIP_RPATH=ON"

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/dbus/phosphor-dbus-interfaces/0001-Add-power-control-interface.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/dbus/phosphor-dbus-interfaces/0001-Add-power-control-interface.patch
@@ -1,0 +1,96 @@
+From ec4dbc686a4840e3680d812269c7a8f5ac97c245 Mon Sep 17 00:00:00 2001
+From: Kuiying Wang <kuiying.wang@intel.com>
+Date: Tue, 23 Oct 2018 11:55:14 +0800
+Subject: [PATCH] Add power control interface
+
+methods:
+    setPowerState
+    getPowerState
+    forcePowerOff
+properties:
+    PGood
+    State
+
+Note:
+All the interfaces are  the low level interface to handle HW.
+And provides supporting the high level interface like state-manager.
+They are the common interfaces and all the platforms implement them all.
+
+Change-Id: I6d90439879f5a4940cad03fd588dd233f81f2802
+Signed-off-by: Kuiying Wang <kuiying.wang@intel.com>
+---
+ .../Chassis/Control/Power.interface.yaml           | 61 ++++++++++++++++++++++
+ 1 file changed, 61 insertions(+)
+ create mode 100644 xyz/openbmc_project/Chassis/Control/Power.interface.yaml
+
+diff --git a/xyz/openbmc_project/Chassis/Control/Power.interface.yaml b/xyz/openbmc_project/Chassis/Control/Power.interface.yaml
+new file mode 100644
+index 0000000..740a1c0
+--- /dev/null
++++ b/xyz/openbmc_project/Chassis/Control/Power.interface.yaml
+@@ -0,0 +1,61 @@
++description: >
++    Power control service
++methods:
++    - name: setPowerState
++      description: >
++        set host power state.
++      parameters:
++        - name: state
++          type: int32
++          description: >
++            0 for force power off host
++            1 for power on host
++      returns:
++        - name: status
++          type: int32
++          description: >
++            0: means success
++            -1: means other errors not throwing out.
++      errors:
++       - xyz.openbmc_project.Chassis.Common.Error.UnsupportedCommand
++       - xyz.openbmc_project.Chassis.Common.Error.IOError
++
++    - name: getPowerState
++      description: >
++        Get current host power status.
++      returns:
++        - name: status
++          type: int32
++          description: >
++            Current host status,
++            0 for host power off
++            1 for host power on
++      errors:
++       - xyz.openbmc_project.Chassis.Common.Error.UnsupportedCommand
++       - xyz.openbmc_project.Chassis.Common.Error.IOError
++
++    - name: forcePowerOff
++      description: >
++        Force power off the host.
++      returns:
++        - name: status
++          type: int32
++          description: >
++            The result of power off command.
++      errors:
++       - xyz.openbmc_project.Chassis.Common.Error.UnsupportedCommand
++       - xyz.openbmc_project.Chassis.Common.Error.IOError
++
++properties:
++    - name: PGood
++      type: int32
++      default: 0
++      description: >
++       PSU Power good property
++    - name: State
++      type: int32
++      default: 0
++      description: >
++       System power status,
++       0: power is off
++       1: power is on
+\ No newline at end of file
+-- 
+2.7.4
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/dbus/phosphor-dbus-interfaces/0001-Set-Watchdog-ExpireAction-as-None.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/dbus/phosphor-dbus-interfaces/0001-Set-Watchdog-ExpireAction-as-None.patch
@@ -1,0 +1,25 @@
+From d400fe39b99a191afd073331dd4e6ed2e40f022c Mon Sep 17 00:00:00 2001
+From: CH Li <chli30@nuvoton.com>
+Date: Thu, 22 Nov 2018 11:20:33 +0800
+Subject: [PATCH] Set Watchdog ExpireAction as None
+
+---
+ xyz/openbmc_project/State/Watchdog.interface.yaml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xyz/openbmc_project/State/Watchdog.interface.yaml b/xyz/openbmc_project/State/Watchdog.interface.yaml
+index f76dbf2..a8459f1 100644
+--- a/xyz/openbmc_project/State/Watchdog.interface.yaml
++++ b/xyz/openbmc_project/State/Watchdog.interface.yaml
+@@ -32,7 +32,7 @@ properties:
+       type: enum[self.Action]
+       description: >
+           The action the watchdog should perform when it expires.
+-      default: 'HardReset'
++      default: 'None'
+     - name: Interval
+       type: uint64
+       description: >
+-- 
+2.7.4
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/dbus/phosphor-dbus-interfaces_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/dbus/phosphor-dbus-interfaces_%.bbappend
@@ -2,3 +2,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 #SRCREV = "06b4df97b7f271154abb1d28716cb3a782a27e96"
 SRC_URI += "file://0001-sensor-add-property.patch"
+SRC_URI += "file://0001-Add-power-control-interface.patch"
+SRC_URI += "file://0001-Set-Watchdog-ExpireAction-as-None.patch"

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/images/obmc-phosphor-image.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/images/obmc-phosphor-image.bbappend
@@ -29,6 +29,10 @@ IMAGE_INSTALL_append = " bmcweb \
                          lmsensors-sensors \
                          iperf2 \
                          phosphor-image-signing \
+                         x86-power-control \
+                         obmc-mgr-system \
+                         obmc-mgr-inventory \
+                         evb-npcm750-config \
                        "
 
 # start generate mtd image only after scrits, tools and inputs are ready 

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/state/phosphor-state-manager/0001-chassis_state_manager_patch.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/state/phosphor-state-manager/0001-chassis_state_manager_patch.patch
@@ -1,0 +1,79 @@
+From 1db74893be5c2fbb3eb788ff37add21b87e33bdd Mon Sep 17 00:00:00 2001
+From: CH Li <chli30@nuvoton.com>
+Date: Thu, 15 Nov 2018 17:53:07 +0800
+Subject: [PATCH] chassis_state_manager_patch
+
+---
+ chassis_state_manager.cpp | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/chassis_state_manager.cpp b/chassis_state_manager.cpp
+index d721460..b22db35 100644
+--- a/chassis_state_manager.cpp
++++ b/chassis_state_manager.cpp
+@@ -61,35 +61,35 @@ void Chassis::subscribeToSystemdSignals()
+ //        has read property function
+ void Chassis::determineInitialState()
+ {
+-    sdbusplus::message::variant<int> pgood = -1;
++    sdbusplus::message::variant<int> PGood = -1;
+     auto method = this->bus.new_method_call(
+-        "org.openbmc.control.Power", "/org/openbmc/control/power0",
++        "xyz.openbmc_project.Chassis.Control.Power", "/xyz/openbmc_project/Chassis/Control/Power0",
+         "org.freedesktop.DBus.Properties", "Get");
+ 
+-    method.append("org.openbmc.control.Power", "pgood");
++    method.append("xyz.openbmc_project.Chassis.Control.Power", "PGood");
+     try
+     {
+         auto reply = this->bus.call(method);
+         if (reply.is_method_error())
+         {
+             log<level::ERR>(
+-                "Error in response message - could not get initial pgood");
++                "Error in response message - could not get initial PGood");
+             goto fail;
+         }
+ 
+         try
+         {
+-            reply.read(pgood);
++            reply.read(PGood);
+         }
+         catch (const SdBusError& e)
+         {
+-            log<level::ERR>("Error in bus response - bad encoding of pgood",
++            log<level::ERR>("Error in bus response - bad encoding of PGood",
+                             entry("ERROR=%s", e.what()),
+                             entry("REPLY_SIG=%s", reply.get_signature()));
+             goto fail;
+         }
+ 
+-        if (pgood == 1)
++        if (PGood == 1)
+         {
+             log<level::INFO>("Initial Chassis State will be On",
+                              entry("CHASSIS_CURRENT_POWER_STATE=%s",
+@@ -117,8 +117,8 @@ void Chassis::determineInitialState()
+     }
+     catch (const SdBusError& e)
+     {
+-        // It's acceptable for the pgood state service to not be available
+-        // since it will notify us of the pgood state when it comes up.
++        // It's acceptable for the PGood state service to not be available
++        // since it will notify us of the PGood state when it comes up.
+         if (e.name() != nullptr &&
+             strcmp("org.freedesktop.DBus.Error.ServiceUnknown", e.name()) == 0)
+         {
+@@ -126,7 +126,7 @@ void Chassis::determineInitialState()
+         }
+ 
+         // Only log for unexpected error types.
+-        log<level::ERR>("Error performing call to get pgood",
++        log<level::ERR>("Error performing call to get PGood",
+                         entry("ERROR=%s", e.what()));
+         goto fail;
+     }
+-- 
+2.7.4
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/state/phosphor-state-manager_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/state/phosphor-state-manager_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-chassis_state_manager_patch.patch \
+            "

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/system/obmc-mgr-system/0001-obmc-mgt-system-WAR-support-nuvoton-gpio.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/system/obmc-mgr-system/0001-obmc-mgt-system-WAR-support-nuvoton-gpio.patch
@@ -1,0 +1,36 @@
+From 0eb0bd9fbc19661f155f79db46ba46550055a85e Mon Sep 17 00:00:00 2001
+From: kwliu <kwliu@nuvoton.com>
+Date: Mon, 19 Nov 2018 12:59:41 +0800
+Subject: [PATCH] obmc-mgt-system: WAR: support nuvoton gpio
+
+---
+ pysystemmgr/obmc/system/__init__.py | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/obmc/system/__init__.py b/obmc/system/__init__.py
+index 7bcea9e..c186561 100644
+--- a/obmc/system/__init__.py
++++ b/obmc/system/__init__.py
+@@ -7,7 +7,7 @@ def find_gpio_base(path="/sys/class/gpio/"):
+     for gc in glob(join(path, pattern)):
+         with open(join(gc, "label")) as f:
+             label = f.readline().strip()
+-        if label == "1e780000.gpio":
++        if label == "/pinctrl@f0800000/gpio@f0010000":
+             with open(join(gc, "base")) as f:
+                 return int(f.readline().strip())
+     # trigger a file not found exception
+@@ -19,9 +19,4 @@ GPIO_BASE = find_gpio_base()
+ 
+ def convertGpio(name):
+     offset = int(''.join(list(filter(str.isdigit, name))))
+-    port = list(filter(str.isalpha, name.upper()))
+-    a = ord(port[-1]) - ord('A')
+-    if len(port) > 1:
+-        a += 26
+-    base = a * 8 + GPIO_BASE
+-    return base + offset
++    return GPIO_BASE + offset
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/system/obmc-mgr-system_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/system/obmc-mgr-system_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+
+SRC_URI += "file://0001-obmc-mgt-system-WAR-support-nuvoton-gpio.patch"
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/workbook/evb-npcm750-config.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/workbook/evb-npcm750-config.bb
@@ -1,0 +1,35 @@
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${PHOSPHORBASE}/COPYING.apache-2.0;md5=34400b68072d710fecd0a2940a0d1658"
+
+inherit allarch
+inherit setuptools
+inherit pythonnative
+
+PROVIDES += "virtual/obmc-inventory-data"
+RPROVIDES_${PN} += "virtual-obmc-inventory-data"
+
+DEPENDS += "python"
+
+S = "${WORKDIR}"
+SRC_URI += "file://Evb-npcm750.py"
+
+python() {
+        machine = d.getVar('MACHINE', True).capitalize() + '.py'
+        d.setVar('_config_in_skeleton', machine)
+}
+
+do_make_setup() {
+        cp ${S}/${_config_in_skeleton} \
+                ${S}/obmc_system_config.py
+        cat <<EOF > ${S}/setup.py
+from distutils.core import setup
+
+setup(name='${BPN}',
+    version='${PR}',
+    py_modules=['obmc_system_config'],
+    )
+EOF
+}
+
+addtask make_setup after do_patch before do_configure
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/workbook/evb-npcm750-config/Evb-npcm750.py
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/workbook/evb-npcm750-config/Evb-npcm750.py
@@ -1,0 +1,36 @@
+## System states
+##   state can change to next state in 2 ways:
+##   - a process emits a GotoSystemState signal with state name to goto
+##   - objects specified in EXIT_STATE_DEPEND have started
+SYSTEM_STATES = [
+]
+
+FRU_INSTANCES = {
+'<inventory_root>/system/chassis/motherboard/bmc' : { 'fru_type' : 'BMC','is_fru' : False, 'manufacturer' : 'NUVOTON' },
+}
+
+# I believe these numbers need to match the yaml file used to create the c++ ipmi map.
+# the devices have types, but I don't believe that factors in here, I think these are
+# just unique IDs.
+ID_LOOKUP = {
+    'FRU' : {},
+    # The number at the end needs to match the FRU ID.
+    # https://github.com/openbmc/skeleton/blob/master/pysystemmgr/system_manager.py#L143
+    # The paramter for it is of type 'y' (unsigned 8-bit integer) presumably decimal?
+    'FRU_STR' : {},
+    'SENSOR' : {},
+    'GPIO_PRESENT' : {}
+}
+
+GPIO_CONFIG = {}
+GPIO_CONFIG['POWER_UP_PIN'] = { 'gpio_pin': '219', 'direction': 'out' }
+GPIO_CONFIG['PGOOD'] = { 'gpio_pin': '218', 'direction': 'in' }
+
+
+# Miscellaneous non-poll sensor with system specific properties.
+# The sensor id is the same as those defined in ID_LOOKUP['SENSOR'].
+
+MISC_SENSORS = {
+
+}
+


### PR DESCRIPTION
…ns in webui

1. phosphor-dbus-interfaces: add power control interface and set watchdog expire action as none
2. phosphor-state-manager: modify chassis state manager for new chassis power control service
3. obmc-mgr-system: enable system managers for gpio related functions
4. workbook: add evb-npcm750-config for gpio definition of npcm750