### PR TITLE
meta-quanta: runbmc-nuvoton: console: configure SOL parameters

### DIFF
--- a/meta-quanta/meta-runbmc-nuvoton/recipes-phosphor/console/files/obmc-console.conf
+++ b/meta-quanta/meta-runbmc-nuvoton/recipes-phosphor/console/files/obmc-console.conf
@@ -1,2 +1,1 @@
-local-tty = ttyS2
-local-tty-baud = 57600
+baud = 57600


### PR DESCRIPTION
The parameters are specified in obmc-console related settings.

It's updated according to https://gerrit.openbmc-project.xyz/c/openbmc/meta-quanta/+/25269.

Signed-off-by: kfting <kfting@nuvoton.com>