### PR TITLE
Change IPMI flash BIOS update service type to oneshot

### DIFF
--- a/meta-phosphor/nuvoton-layer/recipes-phosphor/ipmi/phosphor-ipmi-flash/phosphor-ipmi-flash-bios-update.service
+++ b/meta-phosphor/nuvoton-layer/recipes-phosphor/ipmi/phosphor-ipmi-flash/phosphor-ipmi-flash-bios-update.service
@@ -4,6 +4,7 @@ Description=Phosphor-ipmi-flash update BISO service
 [Service]
 ExecStart=/usr/sbin/bios-update.sh
 SyslogIdentifier=bios-update.sh
+Type=oneshot
 
 [Install]
 WantedBy=phosphor-ipmi-flash-bios-update.target


### PR DESCRIPTION
To avoid software manager get JobRemoved signal just started
BIOS update service, change service type to oneshot

Signed-off-by: Brian_Ma <chma0@nuvoton.com>