### PR TITLE
meta-quanta: olympus-nuvoton: networkd: add channel specific privileg…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-fix-get-property-failed-when-executing-channel-acces.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-fix-get-property-failed-when-executing-channel-acces.patch
@@ -1,0 +1,51 @@
+From b7996db2ce6006fe53806020e6911fc5f8c0ddcd Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Tue, 10 Dec 2019 14:32:28 +0800
+Subject: [PATCH] fix get property failed when executing channel access command
+
+---
+ user_channel/channel_mgmt.cpp | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/user_channel/channel_mgmt.cpp b/user_channel/channel_mgmt.cpp
+index b56da33..3fd7faa 100644
+--- a/user_channel/channel_mgmt.cpp
++++ b/user_channel/channel_mgmt.cpp
+@@ -1244,18 +1244,15 @@ int ChannelConfig::getDbusProperty(const std::string& service,
+                                    const std::string& property,
+                                    DbusVariant& value)
+ {
+-    try
+-    {
+-        auto method =
+-            bus.new_method_call(service.c_str(), objPath.c_str(),
++    auto method =
++        bus.new_method_call(service.c_str(), objPath.c_str(),
+                                 "org.freedesktop.DBus.Properties", "Get");
+ 
+-        method.append(interface, property);
++    method.append(interface, property);
+ 
+-        auto reply = bus.call(method);
+-        reply.read(value);
+-    }
+-    catch (const sdbusplus::exception::SdBusError& e)
++    auto reply = bus.call(method);
++
++    if (reply.is_method_error())
+     {
+         log<level::DEBUG>("get-property failed",
+                           entry("SERVICE=%s", service.c_str()),
+@@ -1264,6 +1261,9 @@ int ChannelConfig::getDbusProperty(const std::string& service,
+                           entry("PROP=%s", property.c_str()));
+         return -EIO;
+     }
++
++    reply.read(value);
++
+     return 0;
+ }
+ 
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -15,6 +15,7 @@ EXTRA_OECONF_olympus-nuvoton = " \
 
 SRC_URI_append_olympus-nuvoton = " file://phosphor-ipmi-host.service"
 SRC_URI_append_olympus-nuvoton = " file://xyz.openbmc_project.Ipmi.Internal.SoftPowerOff.service"
+SRC_URI_append_olympus-nuvoton = " file://0001-fix-get-property-failed-when-executing-channel-acces.patch"
 
 SYSTEMD_SERVICE_${PN}_append_olympus-nuvoton = " phosphor-ipmi-host.service"
 SYSTEMD_SERVICE_${PN}_append_olympus-nuvoton = " xyz.openbmc_project.Ipmi.Internal.SoftPowerOff.service"

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/network/phosphor-network/0003-Adding-channel-specific-privilege-to-network.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/network/phosphor-network/0003-Adding-channel-specific-privilege-to-network.patch
@@ -1,0 +1,405 @@
+From 8a127e2054683479d3999ad99ba7ff76c193aa1a Mon Sep 17 00:00:00 2001
+From: AppaRao Puli <apparao.puli@linux.intel.com>
+Date: Wed, 5 Sep 2018 14:16:54 +0530
+Subject: [PATCH] Adding channel specific privilege to network
+
+ - Adding the channel access information to the network
+   interface object. This privilege will be used in
+   channel specific authorization.
+ - Get supported priv from user manager service dynamically.
+ - Signal handling for capturing the supported priv list
+   changes from user managerment.
+
+Tested-by:
+Verified channel access through ipmitool get/set channel
+access command
+
+Change-Id: I3b592a19363eef684e31d5f7c34dad8f2f9211df
+Signed-off-by: AppaRao Puli <apparao.puli@linux.intel.com>
+Signed-off-by: Yong Li <yong.b.li@linux.intel.com>
+---
+ ethernet_interface.cpp | 116 +++++++++++++++++++++++++++++++++++++++++
+ ethernet_interface.hpp |  39 +++++++++++++-
+ network_manager.cpp    | 104 ++++++++++++++++++++++++++++++++++++
+ network_manager.hpp    |   9 ++++
+ 4 files changed, 267 insertions(+), 1 deletion(-)
+
+diff --git a/ethernet_interface.cpp b/ethernet_interface.cpp
+index 2375482..c3edd4b 100644
+--- a/ethernet_interface.cpp
++++ b/ethernet_interface.cpp
+@@ -37,6 +37,9 @@ using namespace phosphor::logging;
+ using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+ using Argument = xyz::openbmc_project::Common::InvalidArgument;
+ 
++static constexpr const char* networkChannelCfgFile =
++    "/var/channel_intf_data.json";
++static constexpr const char* defaultChannelPriv = "priv-admin";
+ EthernetInterface::EthernetInterface(sdbusplus::bus::bus& bus,
+                                      const std::string& objPath,
+                                      bool dhcpEnabled, Manager& parent,
+@@ -56,6 +59,7 @@ EthernetInterface::EthernetInterface(sdbusplus::bus::bus& bus,
+ 
+     EthernetInterfaceIntf::autoNeg(std::get<2>(ifInfo));
+     EthernetInterfaceIntf::speed(std::get<0>(ifInfo));
++    getChannelPrivilege(intfName);
+ 
+     // Emit deferred signal.
+     if (emitSignal)
+@@ -823,5 +827,117 @@ void EthernetInterface::deleteAll()
+     manager.writeToConfigurationFile();
+ }
+ 
++nlohmann::json EthernetInterface::readJsonFile(const std::string& configFile)
++{
++    std::ifstream jsonFile(configFile);
++    if (!jsonFile.good())
++    {
++        log<level::ERR>("JSON file not found");
++        return nullptr;
++    }
++
++    nlohmann::json data = nullptr;
++    try
++    {
++        data = nlohmann::json::parse(jsonFile, nullptr, false);
++    }
++    catch (nlohmann::json::parse_error& e)
++    {
++        log<level::DEBUG>("Corrupted channel config.",
++                          entry("MSG: %s", e.what()));
++        throw std::runtime_error("Corrupted channel config file");
++    }
++
++    return data;
++}
++
++int EthernetInterface::writeJsonFile(const std::string& configFile,
++                                     const nlohmann::json& jsonData)
++{
++    std::ofstream jsonFile(configFile);
++    if (!jsonFile.good())
++    {
++        log<level::ERR>("JSON file open failed",
++                        entry("FILE=%s", networkChannelCfgFile));
++        return -1;
++    }
++
++    // Write JSON to file
++    jsonFile << jsonData;
++
++    jsonFile.flush();
++    return 0;
++}
++
++std::string
++    EthernetInterface::getChannelPrivilege(const std::string& interfaceName)
++{
++    std::string priv(defaultChannelPriv);
++    std::string retPriv;
++
++    nlohmann::json jsonData = readJsonFile(networkChannelCfgFile);
++    if (jsonData != nullptr)
++    {
++        try
++        {
++            priv = jsonData[interfaceName].get<std::string>();
++            retPriv = ChannelAccessIntf::maxPrivilege(std::move(priv));
++            return retPriv;
++        }
++        catch (const nlohmann::json::exception& e)
++        {
++            jsonData[interfaceName] = priv;
++        }
++    }
++    else
++    {
++        jsonData[interfaceName] = priv;
++    }
++
++    if (writeJsonFile(networkChannelCfgFile, jsonData) != 0)
++    {
++        log<level::DEBUG>("Error in write JSON data to file",
++                          entry("FILE=%s", networkChannelCfgFile));
++        elog<InternalFailure>();
++    }
++
++    retPriv = ChannelAccessIntf::maxPrivilege(std::move(priv));
++
++    return retPriv;
++}
++
++std::string EthernetInterface::maxPrivilege(std::string priv)
++{
++    std::string intfName = interfaceName();
++
++    if (!priv.empty() && (std::find(manager.supportedPrivList.begin(),
++                                    manager.supportedPrivList.end(),
++                                    priv) == manager.supportedPrivList.end()))
++    {
++        log<level::ERR>("Invalid privilege");
++        elog<InvalidArgument>(Argument::ARGUMENT_NAME("Privilege"),
++                              Argument::ARGUMENT_VALUE(priv.c_str()));
++    }
++
++    if (ChannelAccessIntf::maxPrivilege() == priv)
++    {
++        // No change in privilege so just return.
++        return priv;
++    }
++
++    nlohmann::json jsonData = readJsonFile(networkChannelCfgFile);
++    jsonData[intfName] = priv;
++
++    if (writeJsonFile(networkChannelCfgFile, jsonData) != 0)
++    {
++        log<level::DEBUG>("Error in write JSON data to file",
++                          entry("FILE=%s", networkChannelCfgFile));
++        elog<InternalFailure>();
++    }
++
++    // Property change signal will be sent
++    return ChannelAccessIntf::maxPrivilege(std::move(priv));
++}
++
+ } // namespace network
+ } // namespace phosphor
+diff --git a/ethernet_interface.hpp b/ethernet_interface.hpp
+index 60c56e3..3e4cf12 100644
+--- a/ethernet_interface.hpp
++++ b/ethernet_interface.hpp
+@@ -2,11 +2,14 @@
+ 
+ #include "types.hpp"
+ #include "util.hpp"
++#include "xyz/openbmc_project/Channel/ChannelAccess/server.hpp"
+ #include "xyz/openbmc_project/Network/IP/Create/server.hpp"
+ #include "xyz/openbmc_project/Network/Neighbor/CreateStatic/server.hpp"
+ 
+ #include <experimental/filesystem>
++#include <nlohmann/json.hpp>
+ #include <sdbusplus/bus.hpp>
++#include <sdbusplus/bus/match.hpp>
+ #include <sdbusplus/server/object.hpp>
+ #include <string>
+ #include <xyz/openbmc_project/Collection/DeleteAll/server.hpp>
+@@ -23,7 +26,8 @@ using Ifaces = sdbusplus::server::object::object<
+     sdbusplus::xyz::openbmc_project::Network::server::MACAddress,
+     sdbusplus::xyz::openbmc_project::Network::IP::server::Create,
+     sdbusplus::xyz::openbmc_project::Network::Neighbor::server::CreateStatic,
+-    sdbusplus::xyz::openbmc_project::Collection::server::DeleteAll>;
++    sdbusplus::xyz::openbmc_project::Collection::server::DeleteAll,
++    sdbusplus::xyz::openbmc_project::Channel::server::ChannelAccess>;
+ 
+ using IP = sdbusplus::xyz::openbmc_project::Network::server::IP;
+ 
+@@ -31,10 +35,15 @@ using EthernetInterfaceIntf =
+     sdbusplus::xyz::openbmc_project::Network::server::EthernetInterface;
+ using MacAddressIntf =
+     sdbusplus::xyz::openbmc_project::Network::server::MACAddress;
++using ChannelAccessIntf =
++    sdbusplus::xyz::openbmc_project::Channel::server::ChannelAccess;
+ 
+ using ServerList = std::vector<std::string>;
+ using ObjectPath = sdbusplus::message::object_path;
+ 
++using DbusVariant =
++    sdbusplus::message::variant<std::string, std::vector<std::string>>;
++
+ namespace fs = std::experimental::filesystem;
+ 
+ class Manager; // forward declaration of network manager.
+@@ -195,6 +204,14 @@ class EthernetInterface : public Ifaces
+      */
+     void deleteAll();
+ 
++    /** @brief sets the channel maxium privilege.
++     *  @param[in] value - Channel privilege which needs to be set on the
++     * system.
++     *  @returns privilege of the interface or throws an error.
++     */
++    std::string maxPrivilege(std::string value) override;
++
++    using ChannelAccessIntf::maxPrivilege;
+     using EthernetInterfaceIntf::dHCPEnabled;
+     using EthernetInterfaceIntf::interfaceName;
+     using MacAddressIntf::mACAddress;
+@@ -291,6 +308,26 @@ class EthernetInterface : public Ifaces
+     std::string objPath;
+ 
+     friend class TestEthernetInterface;
++
++    /** @brief gets the channel privilege.
++     *  @param[in] interfaceName - Network interface name.
++     *  @returns privilege of the interface
++     */
++    std::string getChannelPrivilege(const std::string& interfaceName);
++
++    /** @brief reads the channel access info from file.
++     *  @param[in] configFile - channel access filename
++     *  @returns json file data
++     */
++    nlohmann::json readJsonFile(const std::string& configFile);
++
++    /** @brief writes the channel access info to file.
++     *  @param[in] configFile - channel access filename
++     *  @param[in] jsonData - json data to write
++     *  @returns success or failure
++     */
++    int writeJsonFile(const std::string& configFile,
++                      const nlohmann::json& jsonData);
+ };
+ 
+ } // namespace network
+diff --git a/network_manager.cpp b/network_manager.cpp
+index 043d7a2..75f4e5f 100644
+--- a/network_manager.cpp
++++ b/network_manager.cpp
+@@ -34,6 +34,13 @@ extern std::unique_ptr<Timer> restartTimer;
+ using namespace phosphor::logging;
+ using namespace sdbusplus::xyz::openbmc_project::Common::Error;
+ 
++static constexpr const char* userMgrObjBasePath = "/xyz/openbmc_project/user";
++static constexpr const char* userMgrInterface =
++    "xyz.openbmc_project.User.Manager";
++static constexpr const char* propNameAllPrivileges = "AllPrivileges";
++
++std::unique_ptr<sdbusplus::bus::match_t> usrMgmtSignal(nullptr);
++
+ Manager::Manager(sdbusplus::bus::bus& bus, const char* objPath,
+                  const std::string& path) :
+     details::VLANCreateIface(bus, objPath, true),
+@@ -41,6 +48,103 @@ Manager::Manager(sdbusplus::bus::bus& bus, const char* objPath,
+ {
+     fs::path confDir(path);
+     setConfDir(confDir);
++    initSupportedPrivilges();
++}
++
++std::string getUserService(sdbusplus::bus::bus& bus, const std::string& intf,
++                           const std::string& path)
++{
++    auto mapperCall =
++        bus.new_method_call("xyz.openbmc_project.ObjectMapper",
++                            "/xyz/openbmc_project/object_mapper",
++                            "xyz.openbmc_project.ObjectMapper", "GetObject");
++
++    mapperCall.append(path);
++    mapperCall.append(std::vector<std::string>({intf}));
++
++    auto mapperResponseMsg = bus.call(mapperCall);
++
++    std::map<std::string, std::vector<std::string>> mapperResponse;
++    mapperResponseMsg.read(mapperResponse);
++
++    if (mapperResponse.begin() == mapperResponse.end())
++    {
++        throw std::runtime_error("ERROR in reading the mapper response");
++    }
++
++    return mapperResponse.begin()->first;
++}
++
++std::string Manager::getUserServiceName()
++{
++    static std::string userMgmtService;
++    if (userMgmtService.empty())
++    {
++        try
++        {
++            userMgmtService =
++                getUserService(bus, userMgrInterface, userMgrObjBasePath);
++        }
++        catch (const std::exception& e)
++        {
++            log<level::ERR>("Exception caught in getUserServiceName.");
++            userMgmtService.clear();
++        }
++    }
++    return userMgmtService;
++}
++
++void Manager::initSupportedPrivilges()
++{
++    std::string userServiceName = getUserServiceName();
++    if (!userServiceName.empty())
++    {
++        auto method = bus.new_method_call(
++            getUserServiceName().c_str(), userMgrObjBasePath,
++            "org.freedesktop.DBus.Properties", "Get");
++        method.append(userMgrInterface, propNameAllPrivileges);
++
++        auto reply = bus.call(method);
++        if (reply.is_method_error())
++        {
++            log<level::DEBUG>("get-property AllPrivileges failed",
++                              entry("OBJPATH:%s", userMgrObjBasePath),
++                              entry("INTERFACE:%s", userMgrInterface));
++            return;
++        }
++
++        sdbusplus::message::variant<std::vector<std::string>> result;
++        reply.read(result);
++
++        supportedPrivList =
++            sdbusplus::message::variant_ns::get<std::vector<std::string>>(
++                result);
++    }
++
++    // Resgister the signal
++    if (usrMgmtSignal == nullptr)
++    {
++        log<level::DEBUG>("Registering User.Manager propertychange signal.");
++        usrMgmtSignal = std::make_unique<sdbusplus::bus::match_t>(
++            bus,
++            sdbusplus::bus::match::rules::propertiesChanged(userMgrObjBasePath,
++                                                            userMgrInterface),
++            [&](sdbusplus::message::message& msg) {
++                log<level::DEBUG>("UserMgr properties changed signal");
++                std::map<std::string, DbusVariant> props;
++                std::string iface;
++                msg.read(iface, props);
++                for (const auto& t : props)
++                {
++                    if (t.first == propNameAllPrivileges)
++                    {
++                        supportedPrivList = sdbusplus::message::variant_ns::get<
++                            std::vector<std::string>>(t.second);
++                    }
++                }
++            });
++    }
++    return;
+ }
+ 
+ bool Manager::createDefaultNetworkFiles(bool force)
+diff --git a/network_manager.hpp b/network_manager.hpp
+index edb341f..e16b205 100644
+--- a/network_manager.hpp
++++ b/network_manager.hpp
+@@ -137,6 +137,9 @@ class Manager : public details::VLANCreateIface
+         return (interfaces.find(intf) != interfaces.end());
+     }
+ 
++    /** supported privilege list **/
++    std::vector<std::string> supportedPrivList;
++
+   protected:
+     /** @brief Persistent sdbusplus DBus bus connection. */
+     sdbusplus::bus::bus& bus;
+@@ -159,6 +162,12 @@ class Manager : public details::VLANCreateIface
+ 
+     /** @brief Network Configuration directory. */
+     fs::path confDir;
++
++    /** Get the user management service name dynamically **/
++    std::string getUserServiceName();
++
++    /** @brief initializes the supportedPrivilege List */
++    void initSupportedPrivilges();
+ };
+ 
+ } // namespace network
+-- 
+2.21.0
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/network/phosphor-network_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/network/phosphor-network_%.bbappend
@@ -1,1 +1,10 @@
 EXTRA_OECONF_olympus-nuvoton += " --disable-link-local-autoconfiguration"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+DEPENDS += "nlohmann-json"
+
+SRC_URI += "git://github.com/openbmc/phosphor-networkd"
+SRC_URI += "file://0003-Adding-channel-specific-privilege-to-network.patch \
+            "
+SRCREV = "cb42fe26febc9e457a9c4279278bd8c85f60851a"


### PR DESCRIPTION
…e to network

1. phosphor-network: Add the channel access information to the network interface object. This privilege will be used in channel specific authorization.
2. phosphor-ipmi-host: Fix get property failed from ChannelConfig::getDbusProperty() when sync network channel config through syncNetworkChannelConfig() function.

Issue symptom:
ipmitool command fail when executing "ipmitool lan set 1 access on/off"
IPMI command failed: Unspecified error
Unable to Set Channel Access(non-volatile) for channel 1

Tested-by:
Verified channel access on/off through ipmitool set channel access command:
1. ipmitool lan set 1 access on
2. ipmitool lan set 1 access off

Signed-off-by: Tim Lee <timlee660101@gmail.com>