### PR TITLE
meta-quanta: olympus-nuvoton: phosphor-state-manager: add default sta…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/state/phosphor-state-manager/0001-add-default-state-for-ProgressStages-and-OSStatus.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/state/phosphor-state-manager/0001-add-default-state-for-ProgressStages-and-OSStatus.patch
@@ -1,0 +1,25 @@
+From 16dae182347ed4d021ab403b42e91fdfaf79560d Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Fri, 13 Dec 2019 17:49:16 +0800
+Subject: [PATCH] add default state for ProgressStages and OSStatus
+
+---
+ host_state_manager.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/host_state_manager.cpp b/host_state_manager.cpp
+index e640cbb..f991636 100644
+--- a/host_state_manager.cpp
++++ b/host_state_manager.cpp
+@@ -272,6 +272,8 @@ void Host::sysStateChange(sdbusplus::message::message& msg)
+     {
+         log<level::INFO>("Received signal that host is running");
+         this->currentHostState(server::Host::HostState::Running);
++        this->bootProgress(bootprogress::Progress::ProgressStages::OSStart);
++        this->operatingSystemState(osstatus::Status::OSStatus::Standby);
+     }
+     else if ((newStateUnit == HOST_STATE_QUIESCE_TGT) &&
+              (newStateResult == "done") &&
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/state/phosphor-state-manager_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/state/phosphor-state-manager_%.bbappend
@@ -1,3 +1,4 @@
 FILESEXTRAPATHS_prepend_olympus-nuvoton := "${THISDIR}/${PN}:"
 
 SRC_URI_append_olympus-nuvoton = " file://0001-fix-host-power-state-inconsisent-issue.patch"
+SRC_URI_append_olympus-nuvoton = " file://0001-add-default-state-for-ProgressStages-and-OSStatus.patch"


### PR DESCRIPTION
…te for ProgressStages and OSStatus

Solution:
Add default state for ProgressStages and OSStatus when host power target already exist.

Symptom:
These states doesn't be updated normally when reboot bmc then cause some auto test items fail.

Tested-by:
When host already power on then reboot bmc by reboot command and check those states are correct as below.
ProgressStages: ""xyz.openbmc_project.State.Boot.Progress.ProgressStages.OSStart"
OSStatus: "xyz.openbmc_project.State.OperatingSystem.Status.OSStatus.Standby"

Signed-off-by: Tim Lee <timlee660101@gmail.com>