### PR TITLE
meta-quanta: olympus-nuvoton: networkd: fix MAC address missing left …

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/network/phosphor-network/0001-fix-mac-address-missing-left-zeros.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/network/phosphor-network/0001-fix-mac-address-missing-left-zeros.patch
@@ -1,0 +1,32 @@
+From f53ee2b2ab37cf32dad4d707588d11fc3f79574d Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Thu, 26 Dec 2019 10:33:27 +0800
+Subject: [PATCH] fix mac address missing left zeros
+
+---
+ util.cpp | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/util.cpp b/util.cpp
+index afbc229..b0dd526 100644
+--- a/util.cpp
++++ b/util.cpp
+@@ -612,7 +612,14 @@ ether_addr fromString(const char* str)
+ 
+ std::string toString(const ether_addr& mac)
+ {
+-    return ether_ntoa(&mac);
++    // 12 digits + 5 colons + null terminator
++    char buf[18] = {0};
++
++    snprintf(buf, 18, "%02x:%02x:%02x:%02x:%02x:%02x", mac.ether_addr_octet[0],
++             mac.ether_addr_octet[1], mac.ether_addr_octet[2],
++             mac.ether_addr_octet[3], mac.ether_addr_octet[4],
++             mac.ether_addr_octet[5]);
++    return buf;
+ }
+ 
+ bool isEmpty(const ether_addr& mac)
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/network/phosphor-network_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/network/phosphor-network_%.bbappend
@@ -7,4 +7,6 @@ DEPENDS += "nlohmann-json"
 SRC_URI += "git://github.com/openbmc/phosphor-networkd"
 SRC_URI += "file://0003-Adding-channel-specific-privilege-to-network.patch \
             "
+SRC_URI += "file://0001-fix-mac-address-missing-left-zeros.patch"
+
 SRCREV = "cb42fe26febc9e457a9c4279278bd8c85f60851a"


### PR DESCRIPTION
…zeros

Symptom:
When enumerate network, the MAC address format missing left zeros then cause auto test fail.
https://BMC_IP/xyz/openbmc_project/network/enumerate
"/xyz/openbmc_project/network/eth0": {
    "MACAddress": "0:0:f7:a0:1:c0"

Root cause:
networkd using ether_ntoa() to get MAC address, but this function will missing left zeros.

Solution:
Padding left zeros to fit MAC address format.

Tested-by:
https://BMC_IP/xyz/openbmc_project/network/enumerate
"/xyz/openbmc_project/network/eth0": {
    "MACAddress": "00:00:f7:a0:01:c0"

Signed-off-by: Tim Lee <timlee660101@gmail.com>