### PR TITLE
meta-quanta: olympus-nuvoton : patch for passing test_ldap_configurat…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0001-meta-quanta-meta-olypmus-nuvoton-bmcweb-patch-for-au.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0001-meta-quanta-meta-olypmus-nuvoton-bmcweb-patch-for-au.patch
@@ -1,0 +1,79 @@
+From 5f6ef64d69032db86f0c6062b22edc9a043da646 Mon Sep 17 00:00:00 2001
+From: kfting <kfting@nuvoton.com>
+Date: Fri, 27 Dec 2019 13:03:10 +0800
+Subject: [PATCH] meta-quanta:meta-olypmus-nuvoton:bmcweb patch for automation
+ test
+
+1. Reference from https://gerrit.openbmc-project.xyz/c/openbmc/bmcweb/+/23538
+2. test_ldap_configuration.robot
+
+Signed-off-by: kfting <kfting@nuvoton.com>
+---
+ include/sessions.hpp | 44 ++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 44 insertions(+)
+
+diff --git a/include/sessions.hpp b/include/sessions.hpp
+index 6e74f259..d65dbdcf 100644
+--- a/include/sessions.hpp
++++ b/include/sessions.hpp
+@@ -59,6 +59,7 @@ struct UserRoleMap
+     std::string getUserRole(std::string_view name)
+     {
+         auto it = roleMap.find(std::string(name));
++#if 0
+         if (it == roleMap.end())
+         {
+             BMCWEB_LOG_ERROR << "User name " << name
+@@ -66,6 +67,49 @@ struct UserRoleMap
+             return "";
+         }
+         return it->second;
++#endif
++        if (it != roleMap.end())
++        {
++            return it->second;
++        }
++        auto method = crow::connections::systemBus->new_method_call(
++                userService, userObjPath, userService, "GetUserInfo");
++        // string_view is not support by this dbus call. Hence, need to create
++        // a temporary string object.
++        method.append(std::string(name));
++        std::map<std::string, sdbusplus::message::variant<
++              bool, std::string, std::vector<std::string>>>
++              userInfo;
++        try
++        {
++            auto reply = crow::connections::systemBus->call(method);
++            reply.read(userInfo);
++        }
++        catch (const sdbusplus::exception::SdBusError& ex)
++        {
++            return "";
++        }
++        const std::string* userRole = nullptr;
++        auto userInfoIter = userInfo.find("UserPrivilege");
++        if (userInfoIter != userInfo.end())
++        {
++            userRole = std::get_if<std::string>(&userInfoIter->second);
++        }
++
++        if (userRole != nullptr)
++        {
++            BMCWEB_LOG_DEBUG << "user name " << name << " role is "
++                << *userRole;
++            return *userRole;
++        }
++        else
++        {
++            BMCWEB_LOG_ERROR << "Unable to find the userRole for the user "
++                << name;
++        }
++
++        return "";
++
+     }
+ 
+     std::string
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/users/phosphor-user-manager/0001-meta-quanta-meta-olympus-nuvoton-phosphor-user-manag.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/users/phosphor-user-manager/0001-meta-quanta-meta-olympus-nuvoton-phosphor-user-manag.patch
@@ -1,0 +1,112 @@
+From a79690132728407f4605dccd1d65c9253279126a Mon Sep 17 00:00:00 2001
+From: kfting <kfting@nuvoton.com>
+Date: Fri, 27 Dec 2019 13:14:38 +0800
+Subject: [PATCH] meta-quanta:meta-olympus-nuvoton:phosphor-user-manager pass
+ test_ldap_configuration.robot
+
+1. Deal with the group id and name consistency
+
+Signed-off-by: kfting <kfting@nuvoton.com>
+---
+ user_mgr.cpp | 65 +++++++++++++++++++++++++++++++++++++++++++++++++++-
+ user_mgr.hpp |  1 +
+ 2 files changed, 65 insertions(+), 1 deletion(-)
+
+diff --git a/user_mgr.cpp b/user_mgr.cpp
+index 2f22323..694ef99 100644
+--- a/user_mgr.cpp
++++ b/user_mgr.cpp
+@@ -864,6 +864,54 @@ DbusUserObj UserMgr::getPrivilegeMapperObject(void)
+     return objects;
+ }
+ 
++std::string UserMgr::getLdapGroupNameEx(const std::string &userName, const std::string &grpName)
++{
++    struct passwd pwd
++    {
++    };
++    struct passwd *pwdPtr = nullptr;
++    auto buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++    if (buflen < -1)
++    {
++        // Use a default size if there is no hard limit suggested by sysconf()
++        buflen = 1024;
++    }
++    std::vector<char> buffer(buflen);
++    gid_t gid = 0;
++
++    auto status =
++        getpwnam_r(userName.c_str(), &pwd, buffer.data(), buflen, &pwdPtr);
++    // On success, getpwnam_r() returns zero, and set *pwdPtr to pwd.
++    // If no matching password record was found, these functions return 0
++    // and store NULL in *pwdPtr
++    if (!status && (&pwd == pwdPtr))
++    {
++        gid = pwd.pw_gid;
++    }
++    else
++    {
++        log<level::ERR>("User does not exist",
++                        entry("USER_NAME=%s", userName.c_str()));
++        elog<UserNameDoesNotExist>();
++    }
++
++    struct group *groups = nullptr;
++    std::string ldapGroupName;
++
++    while ((groups = getgrent()) != NULL)
++    {
++        if ( (groups->gr_gid == gid) && (0 == strcmp(groups->gr_name, grpName.c_str())) )
++        {
++            ldapGroupName = groups->gr_name;
++            break;
++        }
++    }
++    // Call endgrent() to close the group database.
++    endgrent();
++
++    return ldapGroupName;
++}
++
+ std::string UserMgr::getLdapGroupName(const std::string &userName)
+ {
+     struct passwd pwd
+@@ -1038,7 +1086,22 @@ UserInfoMap UserMgr::getUserInfo(std::string userName)
+ 
+             if (priv.empty())
+             {
+-                log<level::ERR>("LDAP group privilege mapping does not exist");
++                if(!groupName.empty())
++                {
++                    std::string ldapGroupName = getLdapGroupNameEx(userName, groupName);
++                    if(!ldapGroupName.empty())
++                    {
++                        userInfo["UserPrivilege"] = privilege;
++                    }
++                    else
++                    {
++                        log<level::ERR>("LDAP group privilege mapping does not exist");
++                    }
++                }
++                else
++                {
++                    log<level::ERR>("LDAP group privilege mapping does not exist");
++                }
+             }
+         }
+         catch (const std::bad_variant_access &e)
+diff --git a/user_mgr.hpp b/user_mgr.hpp
+index c008cea..00eb530 100644
+--- a/user_mgr.hpp
++++ b/user_mgr.hpp
+@@ -331,6 +331,7 @@ class UserMgr : public Ifaces
+      *  @return - group name
+      */
+     virtual std::string getLdapGroupName(const std::string &userName);
++    virtual std::string getLdapGroupNameEx(const std::string &userName, const std::string &grpName);
+ 
+     /** @brief get privilege mapper object
+      *  method to get dbus privilege mapper object
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/users/phosphor-user-manager_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/users/phosphor-user-manager_%.bbappend
@@ -1,0 +1,5 @@
+
+FILESEXTRAPATHS_append := "${THISDIR}/${PN}:"
+
+#SRC_URI_append_olympus-nuvoton = " file://0002-meta-quanta-meta-olympus-nuvoton-phosphor-user-manag.patch \
+#                      "


### PR DESCRIPTION
…ion.robot with OpenBMC ldap implementation

The patches inside are not built by default. The user has to enable these patches in the corresponding
bbappend file.

Signed-off-by: kfting <kfting@nuvoton.com>