### PR TITLE
meta-quanta: olympus-nuvoton: olympus-nuvoton-boot-error-native

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/logging/olympus-nuvoton-boot-error-native.bb
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/logging/olympus-nuvoton-boot-error-native.bb
@@ -9,10 +9,14 @@ inherit phosphor-dbus-yaml
 
 S = "${WORKDIR}"
 CONFIG_YAML_PATH="xyz/openbmc_project/Control"
-SRC_URI = "file://Boot.errors.yaml"
+SRC_URI = "file://Boot.errors.yaml \
+           file://Boot.metadata.yaml \
+"
 
 do_install_append() {
     DEST=${D}${yaml_dir}/${CONFIG_YAML_PATH}
+    SRC=${S}
     install -d ${DEST}
-    install Boot.errors.yaml ${DEST}
+    install ${SRC}/*.errors.yaml ${DEST}
+    install ${SRC}/*.metadata.yaml ${DEST}
 }

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/logging/olympus-nuvoton-boot-error/Boot.metadata.yaml
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/logging/olympus-nuvoton-boot-error/Boot.metadata.yaml
@@ -1,0 +1,11 @@
+- name: WatchdogTimedOut
+  level: ERR
+  meta:
+    - str: WATCHDOG_ACTION=%s
+      type: string
+
+    - str: WATCHDOG_TIMER_USE=%s
+      type: string
+
+    - str: WATCHDOG_INTERVAL=%llu
+      type: uint64


### PR DESCRIPTION
update watchdog metadata
Add watchdog error metadata for sel logger can get watchdog information
from D-Bus signal

Signed-off-by: Brian_Ma <chma0@nuvoton.com>