### PR TITLE
meta-quanta: olympus-nuvoton: debug-collector: move SEL part

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/debug/olympus-nuvoton-debug-collector/set_olympus_dbus_error.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/debug/olympus-nuvoton-debug-collector/set_olympus_dbus_error.patch
@@ -18,109 +18,114 @@ index 5673284..262ae58 100644
  
      return 0;
 diff --git a/watchdog_timeout.cpp b/watchdog_timeout.cpp
-index c479b35..e5fa5ba 100644
+index c479b35..a696e25 100644
 --- a/watchdog_timeout.cpp
 +++ b/watchdog_timeout.cpp
-@@ -1,13 +1,160 @@
+@@ -1,14 +1,140 @@
 -#include "org/open_power/Host/Boot/error.hpp"
 +#include <xyz/openbmc_project/Control/Boot/error.hpp>
-+#include <xyz/openbmc_project/State/Watchdog/server.hpp>
- #include "phosphor-logging/elog-errors.hpp"
- 
- #include <phosphor-logging/elog.hpp>
 +#include <sdbusplus/bus.hpp>
-+#include <iostream>     // std::cout, std::endl
-+#include <iomanip>
+ #include "phosphor-logging/elog-errors.hpp"
+-
+ #include <phosphor-logging/elog.hpp>
 +#include <map>
++#include <systemd/sd-journal.h>
 +
 +using DbusProperty = std::string;
-+using Value = std::variant<bool, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
-+                                 int64_t, uint64_t, double, std::string>;
++using Value = std::variant<bool, uint8_t, int16_t, uint16_t, int32_t,
++                           uint32_t, int64_t, uint64_t, double, std::string>;
 +using PropertyMap = std::map<DbusProperty, Value>;
 +using namespace phosphor::logging;
-+using namespace sdbusplus;
 +
-+static constexpr char const *selMessageId = "b370836ccf2f4850ac5bee185b77893a";
-+//static constexpr int selPriority = 2; // critical
-+static constexpr size_t selEvtDataMaxSize = 3;
-+// reference SEL_TroubleshootingGuide.pdf Table 1
-+static constexpr uint8_t selRecordTypeSystem = 0x02; 	// system event record
-+static constexpr uint8_t selRecordTypeOEM = 0xC0; 
-+static constexpr uint16_t selBMCGenID = 0x0020;	// BMC firmware
-+static constexpr char const *watchdogPath = "/xyz/openbmc_project/watchdog/host0";
-+static constexpr uint8_t selIpmiWatchdogAssert = 1 << 7 | 0x6F;
-+/* IPMI SEL format
-+template(name="IPMISELTemplate" type="list") {
-+    property(name="timereported" dateFormat="rfc3339")
-+    constant(value=" ")
-+    property(name="$!IPMI_SEL_RECORD_ID")   // %d
-+    constant(value=",")
-+    property(name="$!IPMI_SEL_RECORD_TYPE") // %x
-+    constant(value=",")
-+    property(name="$!IPMI_SEL_DATA")		// %s
-+    constant(value=",")
-+    property(name="$!IPMI_SEL_GENERATOR_ID")// %x
-+    constant(value=",")
-+    property(name="$!IPMI_SEL_SENSOR_PATH") // %s
-+    constant(value=",")
-+    property(name="$!IPMI_SEL_EVENT_DIR")   // %s
-+    constant(value="\n")
-+}*/
-+namespace StateServer = sdbusplus::xyz::openbmc_project::State::server;
-+// for event data 2 [3:0], [7:4] = 0xF unspecified
-+static const std::map<StateServer::Watchdog::TimerUse, uint8_t> timerUseMap={
-+    {StateServer::Watchdog::TimerUse::Reserved, 0x0},
-+    {StateServer::Watchdog::TimerUse::BIOSFRB2, 0x1},
-+    {StateServer::Watchdog::TimerUse::BIOSPOST, 0x2},
-+    {StateServer::Watchdog::TimerUse::OSLoad,   0x3},
-+    {StateServer::Watchdog::TimerUse::SMSOS,    0x4},
-+    {StateServer::Watchdog::TimerUse::OEM,      0x5},
-+};
++static constexpr auto WATCHDOG_MESSAGE = "watchdog: Timed out";
 +
-+// for event data 1 [3:0], [7:4] = 1100b
-+static const std::map<StateServer::Watchdog::Action, uint8_t> actionMap={
-+    {StateServer::Watchdog::Action::None,       0x0},
-+    {StateServer::Watchdog::Action::HardReset,  0x1},
-+    {StateServer::Watchdog::Action::PowerOff,   0x2},
-+    {StateServer::Watchdog::Action::PowerCycle, 0x3},
-+};
-+
-+static void toHexStr(const std::vector<uint8_t> &data, std::string &hexStr)
++static int getJournalMetadata(sd_journal* journal,
++                              const std::string_view& field,
++                              std::string& contents)
 +{
-+    std::stringstream stream;
-+    stream << std::hex << std::uppercase << std::setfill('0');
-+    for (const int &v : data)
++    const char* data = nullptr;
++    size_t length = 0;
++
++    // Get the metadata from the requested field of the journal entry
++    if (int ret = sd_journal_get_data(journal, field.data(),
++                                      (const void**)&data, &length);
++        ret < 0)
 +    {
-+        stream << std::setw(2) << v;
++        return ret;
 +    }
-+    hexStr = stream.str();
++    std::string_view metadata(data, length);
++    // Only use the content after the "=" character.
++    metadata.remove_prefix(std::min(metadata.find("=") + 1, metadata.size()));
++    contents = std::string(metadata);
++    return 0;
 +}
 +
-+// TODO: move SEL relative function to independent header file
-+int getId()
++// TODO: should not get elder watchdog log
++void getJournalInfo(std::string& action,
++                        std::string& timerUse)
 +{
-+    unsigned int transactionId = sdbusplus::server::transaction::get_id();
-+    auto _id = (transactionId >> 2) % 100000;
-+    return static_cast<int>(_id);
++    sd_journal* journalTmp;
++    if (int ret = sd_journal_open(&journalTmp, SD_JOURNAL_LOCAL_ONLY); ret < 0)
++    {
++        log<level::ERR>("Failed to open journal: ",
++                        entry("ERRNO=%s", strerror(-ret)));
++        return;
++    }
++    std::unique_ptr<sd_journal, decltype(&sd_journal_close)> journal(
++        journalTmp, sd_journal_close);
++    journalTmp = nullptr;
++
++    std::string match = "MESSAGE=" + std::string(WATCHDOG_MESSAGE);
++    sd_journal_add_match(journal.get(), match.c_str(), 0);
++
++	// get last log info
++    int r = 1;
++    SD_JOURNAL_FOREACH_BACKWARDS(journal.get())
++    {
++        r = getJournalMetadata(journal.get(), "ACTION", action);
++        if (r < 0)
++        {
++            log<level::ERR>("Cannot find watchdog log meta in journal",
++                            entry("ERRNO=%s", strerror(-r)));
++            return;
++        }
++        if(getJournalMetadata(journal.get(), "TIMER_USE", timerUse) < 0)
++        {
++            log<level::ERR>("Watchdog log metadata error");
++            return;
++        }
++        // only need the last one
++        break;
++    }
++    if (r > 0)
++    {
++        log<level::ERR>("Cannot find watchdog log in journal");
++        return;
++    }
++    auto msg = "Successful get watchdog info from journal, Action:" +
++                action + ", Timer Use: " + timerUse;
++    log<level::INFO>(msg.c_str());
 +}
 +
-+void getWatchdogInfo()
++void handleWatchdogInfo(std::string& action,
++                        std::string& timerUse, uint64_t* interval)
 +{
 +    PropertyMap properties;
-+    std::vector<uint8_t> eventData(selEvtDataMaxSize, 0xFF);
-+    log<level::INFO>("getWatchdogInfo");
-+    auto bus = bus::new_default_system();
++    log<level::INFO>("handleWatchdogInfo");
++    auto bus = sdbusplus::bus::new_default_system();
 +    auto method = bus.new_method_call("xyz.openbmc_project.Watchdog",
 +            "/xyz/openbmc_project/watchdog/host0",
 +            "org.freedesktop.DBus.Properties", "GetAll");
 +    method.append("xyz.openbmc_project.State.Watchdog");
 +
-+    std::string action = "Unknow";
-+    std::string timerUse = "Unknow";
-+    //uint64_t interval = 18000;
++	// set default value
++    action = "xyz.openbmc_project.State.Watchdog.Action.None";
++    timerUse = "xyz.openbmc_project.State.Watchdog.TimerUse.Reserved";
++    *interval = 18000;
 +
 +    try
 +    {
++        // read watch dog parameters
 +        auto reply = bus.call(method);
 +        if (reply.is_method_error())
 +        {
@@ -131,56 +136,34 @@ index c479b35..e5fa5ba 100644
 +            reply.read(properties);
 +            action = std::get<std::string>(properties["ExpireAction"]);
 +            timerUse = std::get<std::string>(properties["ExpiredTimerUse"]);
-+            //interval = std::get<uint64_t>(properties["Interval"]);
-+            // fill up the event data
-+            auto _timerUse = StateServer::Watchdog::convertTimerUseFromString(timerUse);
-+            auto _action = StateServer::Watchdog::convertActionFromString(action);
-+            auto ita = actionMap.find(_action);
-+            if (ita != actionMap.end())
-+            {
-+                eventData[1] = ita->second | 0xC0;
-+            }
-+            auto itt = timerUseMap.find(_timerUse);
-+            if (itt != timerUseMap.end())
-+            {
-+                eventData[2] = itt->second | 0xF0;
-+            }
++            *interval = std::get<uint64_t>(properties["Interval"]);
++
 +        }
 +    }
 +    catch (const std::exception& e)
 +    {
 +        log<level::ERR>("Failed to get watch dog service",
 +            entry("WHAT=%s", e.what()));
++        // try to get info from journal log
++        getJournalInfo(action, timerUse);
 +    }
-+
-+    // convert event data to string
-+    std::string selDataStr;
-+    toHexStr(eventData, selDataStr);
-+
-+    // write log to redfish via rsyslog
-+    // log format: (bmcweb)
-+    //     redfish-core/include/registries/openbmc_message_registry.hpp
-+    log<level::ERR>("Host power on watch dog time out.",
-+            entry("MESSAGE_ID=%s", selMessageId),
-+            entry("IPMI_SEL_RECORD_ID=%d", getId()),
-+            entry("IPMI_SEL_GENERATOR_ID=%x", selBMCGenID),
-+            entry("IPMI_SEL_RECORD_TYPE=%x", selRecordTypeOEM),
-+            entry("IPMI_SEL_SENSOR_PATH=%s", watchdogPath),
-+            entry("IPMI_SEL_EVENT_DIR=%x", selIpmiWatchdogAssert),
-+            entry("IPMI_SEL_DATA=%s", selDataStr.c_str()),
-+            entry("REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.IPMIWatchdog"),
-+            entry("REDFISH_MESSAGE_ARGS=%s", action.c_str()));
 +}
-+
  
  int main(int argc, char* argv[])
  {
-     using namespace phosphor::logging;
+-    using namespace phosphor::logging;
      using error =
 -        sdbusplus::org::open_power::Host::Boot::Error::WatchdogTimedOut;
+-    report<error>();
 +        sdbusplus::xyz::openbmc_project::Control::Boot::Error::WatchdogTimedOut;
-+    // get more information for sync log to redfish system event log
-+    getWatchdogInfo();
-     report<error>();
++    using namespace xyz::openbmc_project::Control::Boot;
++    std::string action;
++    std::string timerUse;
++    uint64_t interval;
++    handleWatchdogInfo(action, timerUse, &interval);
++    report<error>(WatchdogTimedOut::WATCHDOG_ACTION(action.c_str()),
++                  WatchdogTimedOut::WATCHDOG_TIMER_USE(timerUse.c_str()),
++                  WatchdogTimedOut::WATCHDOG_INTERVAL(interval));
  
      return 0;
+ }


### PR DESCRIPTION
1. move set SEL log part to phosphor-sel-logger
2. get watchdog information from journal if watchdog D-bus object is
gone
3. report watchdog event with metadata for pass information to phosphor
sel logger

Signed-off-by: Brian_Ma <chma0@nuvoton.com>