### PR TITLE
meta-quanta: olympus-nuvoton: post-code-manager: enable to monitor po…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-olympus-nuvoton/packagegroups/packagegroup-olympus-nuvoton-apps.bb
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-olympus-nuvoton/packagegroups/packagegroup-olympus-nuvoton-apps.bb
@@ -59,4 +59,5 @@ RDEPENDS_${PN}-system = " \
         iptables \
         iptable-save \
         pch-time-sync \
+        phosphor-post-code-manager \
         "


### PR DESCRIPTION
…st code

This daemon monitors post code posted on dbus interface /xyz/openbmc_project/state/boot/raw by snoopd daemon

Signed-off-by: Tim Lee <timlee660101@gmail.com>