### PR TITLE
meta-phosphor: nuvoton-layer: recipes-phosphor: ipmi: phosphor-ipmi-f…

### DIFF
--- a/meta-phosphor/nuvoton-layer/recipes-phosphor/ipmi/phosphor-ipmi-flash/bios-verify.sh
+++ b/meta-phosphor/nuvoton-layer/recipes-phosphor/ipmi/phosphor-ipmi-flash/bios-verify.sh
@@ -9,9 +9,12 @@ if [ -f $publickey ];then
 	echo "$r" > /tmp/update-bios.log
 	if [ "Verified OK" == "$r" ]; then
 		echo "success" > /tmp/bios.verify
+		exit 0
 	else
 		echo "failed" > /tmp/bios.verify
+		exit 1
 	fi
 else
 	echo "No $publickey file" > /tmp/update-bios.log
+	exit 1
 fi

--- a/meta-phosphor/nuvoton-layer/recipes-phosphor/ipmi/phosphor-ipmi-flash/bmc-verify.sh
+++ b/meta-phosphor/nuvoton-layer/recipes-phosphor/ipmi/phosphor-ipmi-flash/bmc-verify.sh
@@ -11,9 +11,12 @@ if [ -f $publickey ];then
 	if [ "Verified OK" == "$r" ]; then
 		mv $bmcimage $imagebmc
 		echo "success" > /tmp/bmc.verify
+		exit 0
 	else
 		echo "failed" > /tmp/bmc.verify
+		exit 1
 	fi
 else
 	echo "No $publickey file" > /tmp/update-bmc.log
+	exit 1
 fi

--- a/meta-phosphor/nuvoton-layer/recipes-phosphor/ipmi/phosphor-ipmi-flash/phosphor-ipmi-flash-bios-update.service
+++ b/meta-phosphor/nuvoton-layer/recipes-phosphor/ipmi/phosphor-ipmi-flash/phosphor-ipmi-flash-bios-update.service
@@ -7,4 +7,4 @@ SyslogIdentifier=bios-update.sh
 Type=oneshot
 
 [Install]
-WantedBy=phosphor-ipmi-flash-bios-update.target
+RequiredBy=phosphor-ipmi-flash-bios-update.target

--- a/meta-phosphor/nuvoton-layer/recipes-phosphor/ipmi/phosphor-ipmi-flash/phosphor-ipmi-flash-bios-verify.service
+++ b/meta-phosphor/nuvoton-layer/recipes-phosphor/ipmi/phosphor-ipmi-flash/phosphor-ipmi-flash-bios-verify.service
@@ -4,6 +4,7 @@ Description=Phosphor-ipmi-flash verify BISO service
 [Service]
 ExecStart=/usr/sbin/bios-verify.sh
 SyslogIdentifier=bios-verify.sh
+Type=oneshot
 
 [Install]
-WantedBy=phosphor-ipmi-flash-bios-verify.target
+RequiredBy=phosphor-ipmi-flash-bios-verify.target

--- a/meta-phosphor/nuvoton-layer/recipes-phosphor/ipmi/phosphor-ipmi-flash/phosphor-ipmi-flash-bmc-verify.service
+++ b/meta-phosphor/nuvoton-layer/recipes-phosphor/ipmi/phosphor-ipmi-flash/phosphor-ipmi-flash-bmc-verify.service
@@ -4,6 +4,7 @@ Description=Phosphor-ipmi-flash bmc verify service
 [Service]
 ExecStart=/usr/sbin/bmc-verify.sh
 SyslogIdentifier=bmc-verify.sh
+Type=oneshot
 
 [Install]
-WantedBy=phosphor-ipmi-flash-bmc-verify.target
+RequiredBy=phosphor-ipmi-flash-bmc-verify.target

--- a/meta-phosphor/nuvoton-layer/recipes-phosphor/ipmi/phosphor-ipmi-flash_%.bbappend
+++ b/meta-phosphor/nuvoton-layer/recipes-phosphor/ipmi/phosphor-ipmi-flash_%.bbappend
@@ -4,13 +4,11 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 PACKAGECONFIG_append_nuvoton = " static-bmc reboot-update host-bios"
 
-NUVOTON_FLASH_PCIVGA  = "0x7FC00000"
 NUVOTON_FLASH_PCIMBOX = "0xF0848000"
 NUVOTON_FLASH_LPC     = "0xc0008000"
 
 PACKAGECONFIG_append_nuvoton = " nuvoton-lpc"
-#XTRA_OECONF_append = " --enable-nuvoton-p2a-mbox"
-#EXTRA_OECONF_append = " --enable-nuvoton-p2a-vga"
+#EXTRA_OECONF_append = " --enable-nuvoton-p2a-mbox"
 
 IPMI_FLASH_BMC_ADDRESS_nuvoton = "${NUVOTON_FLASH_LPC}"
 
@@ -40,24 +38,24 @@ SYSTEMD_SERVICE_${PN}_append_nuvoton = " \
     "
 
 pkg_postinst_${PN}_nuvoton() {
-	LINK_BMC="$D$systemd_system_unitdir/phosphor-ipmi-flash-bmc-verify.wants/phosphor-ipmi-flash-bmc-verify.service"
-	LINK_BIOS_UPDATE="$D$systemd_system_unitdir/phosphor-ipmi-flash-bios-update.wants/phosphor-ipmi-flash-bios-update.service"
-	LINK_BIOS_VERIFY="$D$systemd_system_unitdir/phosphor-ipmi-flash-bios-verify.wants/phosphor-ipmi-flash-bios-verify.service"
+	LINK_BMC="$D$systemd_system_unitdir/phosphor-ipmi-flash-bmc-verify.requires/phosphor-ipmi-flash-bmc-verify.service"
+	LINK_BIOS_UPDATE="$D$systemd_system_unitdir/phosphor-ipmi-flash-bios-update.requires/phosphor-ipmi-flash-bios-update.service"
+	LINK_BIOS_VERIFY="$D$systemd_system_unitdir/phosphor-ipmi-flash-bios-verify.requires/phosphor-ipmi-flash-bios-verify.service"
 	TARGET_BMC="../phosphor-ipmi-flash-bmc-verify.service"
 	TARGET_BIOS_UPDATE="../phosphor-ipmi-flash-bios-update.service"
 	TARGET_BIOS_VERIFY="../phosphor-ipmi-flash-bios-verify.service"
-	mkdir -p $D$systemd_system_unitdir/phosphor-ipmi-flash-bmc-verify.wants
-	mkdir -p $D$systemd_system_unitdir/phosphor-ipmi-flash-bios-update.wants
-	mkdir -p $D$systemd_system_unitdir/phosphor-ipmi-flash-bios-verify.wants
+	mkdir -p $D$systemd_system_unitdir/phosphor-ipmi-flash-bmc-verify.requires
+	mkdir -p $D$systemd_system_unitdir/phosphor-ipmi-flash-bios-update.requires
+	mkdir -p $D$systemd_system_unitdir/phosphor-ipmi-flash-bios-verify.requires
 	ln -s $TARGET_BMC $LINK_BMC
 	ln -s $TARGET_BIOS_UPDATE $LINK_BIOS_UPDATE
 	ln -s $TARGET_BIOS_VERIFY $LINK_BIOS_VERIFY
 }
 
 pkg_prerm_${PN}_nuvoton() {
-	LINK_BMC="$D$systemd_system_unitdir/phosphor-ipmi-flash-bmc-verify.wants/phosphor-ipmi-flash-bmc-verify.service"
-	LINK_BIOS_UPDATE="$D$systemd_system_unitdir/phosphor-ipmi-flash-bios-update.wants/phosphor-ipmi-flash-bios-update.service"
-	LINK_BIOS_VERIFY="$D$systemd_system_unitdir/phosphor-ipmi-flash-bios-verify.wants/phosphor-ipmi-flash-bios-verify.service"
+	LINK_BMC="$D$systemd_system_unitdir/phosphor-ipmi-flash-bmc-verify.requires/phosphor-ipmi-flash-bmc-verify.service"
+	LINK_BIOS_UPDATE="$D$systemd_system_unitdir/phosphor-ipmi-flash-bios-update.requires/phosphor-ipmi-flash-bios-update.service"
+	LINK_BIOS_VERIFY="$D$systemd_system_unitdir/phosphor-ipmi-flash-bios-verify.requires/phosphor-ipmi-flash-bios-verify.service"
 	rm $LINK_BMC
 	rm $LINK_BIOS_UPDATE
 	rm $LINK_BIOS_VERIFY


### PR DESCRIPTION
…lash: Update ipmi-flash

	1. return 0 when verfify success, and return > 0 when fail in verify script for both bmc and bios
	2. remove pci vga
	3. use requires instead of wants in service file

Signed-off-by: Medad CChien <ctcchien@nuvoton.com>