### PR TITLE
meta-quanta: olympus-nuvoton: add mac-address package

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-olympus-nuvoton/mac-address/files/config.txt
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-olympus-nuvoton/mac-address/files/config.txt
@@ -1,0 +1,4 @@
+fruBusNum=13
+fruAddr=0x51
+numberMac=1
+mac1=eth1

--- a/meta-quanta/meta-olympus-nuvoton/recipes-olympus-nuvoton/mac-address/files/mac-address.service
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-olympus-nuvoton/mac-address/files/mac-address.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Initialize MAC Address
+Before=usb_network.service network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/mac-address
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-quanta/meta-olympus-nuvoton/recipes-olympus-nuvoton/mac-address/mac-address.bb
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-olympus-nuvoton/mac-address/mac-address.bb
@@ -1,0 +1,34 @@
+SRC_URI = "git://github.com/quanta-bmc/mac-address.git;protocol=git"
+SRCREV = "${AUTOREV}"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit autotools pkgconfig
+inherit systemd
+
+DEPENDS += "systemd"
+DEPENDS += "autoconf-archive-native"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI_append = " file://mac-address.service"
+SRC_URI_append = " file://config.txt"
+
+FILES_${PN}_append = " ${datadir}/mac-address/config.txt"
+
+HASHSTYLE = "gnu"
+S = "${WORKDIR}/git"
+CXXFLAGS += "-std=c++17"
+
+do_install_append() {
+    install -d ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/mac-address.service \
+        ${D}${systemd_unitdir}/system
+    
+    install -d ${D}${datadir}/mac-address
+    install -m 0644 -D ${WORKDIR}/config.txt \
+        ${D}${datadir}/mac-address/config.txt
+}
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE_${PN} += "mac-address.service"

--- a/meta-quanta/meta-olympus-nuvoton/recipes-olympus-nuvoton/packagegroups/packagegroup-olympus-nuvoton-apps.bb
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-olympus-nuvoton/packagegroups/packagegroup-olympus-nuvoton-apps.bb
@@ -51,7 +51,6 @@ RDEPENDS_${PN}-system = " \
         olympus-nuvoton-powerctrl \
         ipmitool \
         phosphor-sel-logger \
-        first-boot-set-mac \
         first-boot-set-psu \
         phosphor-node-manager-proxy \
         phosphor-image-signing \
@@ -66,4 +65,5 @@ RDEPENDS_${PN}-system = " \
         intel-dbus-interfaces \
         adm1278-hotswap-power-cycle \
         google-ipmi-sys \
+        mac-address \
         "


### PR DESCRIPTION
1. Set eth1 mac address from bmc fru
2. This package is using to replace first-boot-set-mac

Signed-off-by: Tim Lee <timlee660101@gmail.com>