### PR TITLE
meta-quanta: olympus-nuvoton: settings: enable sol by default

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/settings/phosphor-settings-manager_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/settings/phosphor-settings-manager_%.bbappend
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_append_olympus-nuvoton := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS_prepend_olympus-nuvoton := "${THISDIR}/${PN}:"
 
 SRC_URI_append_olympus-nuvoton = " file://chassis-cap.override.yml"
 SRC_URI_append_olympus-nuvoton = " file://sol-default.override.yml"


### PR DESCRIPTION
1. Referenced link: https://gerrit.openbmc-project.xyz/c/openbmc/meta-quanta/+/33641

Signed-off-by: Joseph Liu <kwliu@nuvoton.com>
Signed-off-by: kfting <kfting@nuvoton.com>


