### PR TITLE
meta-quanta: olympus-nuvoton: ipmi: add kcs device

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-kcs/99-ipmi-kcs.rules.rules
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-kcs/99-ipmi-kcs.rules.rules
@@ -1,0 +1,1 @@
+KERNEL=="ipmi-kcs1", SYMLINK+="ipmi_kcs1"


### PR DESCRIPTION
1. The referenced link is "https://gerrit.openbmc-project.xyz/c/openbmc/meta-quanta/+/33798".

Signed-off-by: kfting <kfting@nuvoton.com>
