### PR TITLE
meta-nuvoton: recipes-bsp: images: Support MFG Test

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm7xx-ddr4si-test_1.0.0.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm7xx-ddr4si-test_1.0.0.bb
@@ -1,0 +1,26 @@
+SUMMARY = "DDR4 SI Standalone Test for NPCM7XX (Poleg) devices"
+DESCRIPTION = "DDR4 SI Standalone Test for NPCM7XX (Poleg) devices"
+HOMEPAGE = "https://github.com/Nuvoton-Israel/openbmc-util"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+FILENAME = "DDRSI-${PV}.bin"
+
+S = "${WORKDIR}"
+
+SRCREV = "c778925bf09b175a6a5e6f2b32bab8a7b4c52077"
+SRC_URI = " \
+    https://raw.githubusercontent.com/Nuvoton-Israel/openbmc-util/${SRCREV}/LICENSE;name=lic \
+    https://github.com/Nuvoton-Israel/openbmc-util/releases/download/DDRSI-${PV}/DDRSI.bin;downloadfilename=${FILENAME};name=bin \
+"
+
+SRC_URI[lic.md5sum] = "b234ee4d69f5fce4486a80fdaf4a4263"
+SRC_URI[bin.sha256sum] = "9c8c2c7a1533d0eff6e9e64f5e150136973df84c67bf2711f1cc7065728ee099"
+
+inherit deploy
+
+do_deploy () {
+	install -D -m 644 ${WORKDIR}/${FILENAME} ${DEPLOYDIR}/DDRSI.bin
+}
+
+addtask deploy before do_build after do_compile

--- a/meta-nuvoton/recipes-bsp/images/npcm7xx-gfx-test_1.0.0.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm7xx-gfx-test_1.0.0.bb
@@ -1,0 +1,26 @@
+SUMMARY = "DDR4 SI Standalone Test for NPCM7XX (Poleg) devices"
+DESCRIPTION = "DDR4 SI Standalone Test for NPCM7XX (Poleg) devices"
+HOMEPAGE = "https://github.com/medadyoung/DDR4-SI"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+FILENAME = "GFX-${PV}.bin"
+
+S = "${WORKDIR}"
+
+SRCREV = "c778925bf09b175a6a5e6f2b32bab8a7b4c52077"
+SRC_URI = " \
+    https://raw.githubusercontent.com/Nuvoton-Israel/openbmc-util/${SRCREV}/LICENSE;name=lic \
+    https://github.com/Nuvoton-Israel/openbmc-util/releases/download/GFX-${PV}/gfx.bin;downloadfilename=${FILENAME};name=bin \
+"
+
+SRC_URI[lic.md5sum] = "b234ee4d69f5fce4486a80fdaf4a4263"
+SRC_URI[bin.sha256sum] = "92e8a5d7b187def6d1db125dfb96b31ca0ee710a95b8cb26cd6a2cf227efdfcb"
+
+inherit deploy
+
+do_deploy () {
+	install -D -m 644 ${WORKDIR}/${FILENAME} ${DEPLOYDIR}/GFX.bin
+}
+
+addtask deploy before do_build after do_compile

--- a/meta-nuvoton/recipes-bsp/images/npcm7xx-igps-native_02.01.12.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm7xx-igps-native_02.01.12.bb
@@ -7,6 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 SRC_URI = " \
     git://github.com/Nuvoton-Israel/igps \
     file://0001-Adjust-paths-for-use-with-Bitbake.patch \
+    file://0002-MFG-Test.patch \
 "
 # tag IGPS_02.01.12
 SRCREV = "2fb1a3b0d61164ed1157e27889a4ec2292cbc760"
@@ -20,6 +21,12 @@ do_install() {
 	install ImageGeneration/references/BootBlockAndHeader_${IGPS_MACHINE}.xml ${DEST}
 	install ImageGeneration/references/UbootHeader_${IGPS_MACHINE}.xml ${DEST}
 	install ImageGeneration/inputs/mergedBootBlockAndUboot.xml ${DEST}
+	install ImageGeneration/inputs/MEMTest.xml ${DEST}
+	install ImageGeneration/inputs/DDRSITest.xml ${DEST}
+	install ImageGeneration/inputs/GFXTest.xml ${DEST}
+	install ImageGeneration/inputs/mergedTests12.xml ${DEST}
+	install ImageGeneration/inputs/mergedTests123.xml ${DEST}
+	install ImageGeneration/inputs/mergedBootBlockAndUbootAndTests.xml ${DEST}
 }
 
 inherit native

--- a/meta-nuvoton/recipes-bsp/images/npcm7xx-igps/0002-MFG-Test.patch
+++ b/meta-nuvoton/recipes-bsp/images/npcm7xx-igps/0002-MFG-Test.patch
@@ -1,0 +1,363 @@
+commit 221246224b53f07018093880cb0180c03b9bc266
+Author: Medad CChien <ctcchien@nuvoton.com>
+Date:   Mon Jul 6 16:47:29 2020 +0800
+
+    MFG Test
+
+diff --git a/ImageGeneration/inputs/DDRSITest.xml b/ImageGeneration/inputs/DDRSITest.xml
+new file mode 100644
+index 0000000..3a3a2fb
+--- /dev/null
++++ b/ImageGeneration/inputs/DDRSITest.xml
+@@ -0,0 +1,75 @@
++<!-- SPDX-License-Identifier: GPL-2.0
++#
++# Nuvoton IGPS: Image Generation And Programming Scripts For Poleg BMC
++#
++# Copyright (C) 2019 Nuvoton Technologies, All Rights Reserved
++#--------------------------------------------------------------------------->
++
++<?xml version="1.0" encoding="UTF-8"?>
++
++<Bin_Ecc_Map>
++	<!-- BMC mandatory fields -->
++	<ImageProperties>
++		<BinSize>0</BinSize>         <!-- If 0 the binary size will be calculated by the tool -->
++		<PadValue>0xFF</PadValue>	<!-- Byte value to pad the empty areas, default is 0 -->
++	</ImageProperties>
++	
++	<BinField>
++		<name>TestBINTag</name>         <!-- name of field -->
++		<config>
++			<offset>0x0</offset>            <!-- offset in the header -->
++			<size>0x8</size>              <!-- size in the header -->
++		</config>
++		<content format='bytes'>0x53 0x54 0x44 0x41 0x4C 0x54 0x53 0x54</content>  <!-- content the user should fill -->
++	</BinField>
++	
++	<BinField>
++		<!-- BootBlock or u-boot Code size -->
++		<name>CodeSize</name>         
++		<config>
++			<offset>0x8</offset>       
++			<size>0x4</size> 
++		</config>
++		<content format='FileSize'>DDRSI.bin</content>	<!-- content the user should fill -->
++	</BinField>
++	
++	<BinField>
++		<!-- Code destination address, 32-bit aligned: for DDR should be 0xFFFD0000 -->
++		<name>DestAddr</name>
++		<config>
++			<offset>0xC</offset>
++			<size>0x4</size>
++		</config>
++		<content format='32bit'>0xFFFD0000</content>     <!-- content the user should fill -->
++	</BinField>
++	
++	<BinField>
++		<!-- Code destination address, 32-bit aligned: for DDR should be 0xFFFD0000 -->
++		<name>Description</name>
++		<config>
++			<offset>0x10</offset>
++			<size>0x40</size> 
++		</config>
++		<content format='bytes'>0x44 0x44 0x52 0x53 0x49 0x54 0x53 0x54</content>     <!-- content the user should fill -->
++	</BinField>
++	
++	<BinField>
++		<!-- Code destination address, 32-bit aligned: for DDR should be 0xFFFD0000 -->
++		<name>TestResult</name>
++		<config>
++			<offset>0x50</offset>
++			<size>0x4</size> 
++		</config>
++		<content format='bytes'>0xFF 0xFF 0xFF 0xFF</content>     <!-- content the user should fill -->
++	</BinField>
++	
++	<BinField>
++		<name>test-bin</name>             <!-- name of field -->
++		<config>
++			<offset>0x100</offset>        <!-- offset in the header -->
++			<size format='FileSize'>DDRSI.bin</size>                 <!-- size in the header calculated by tool-->
++		</config>
++		<content format='FileContent'>DDRSI.bin</content>  <!-- content the user should fill -->
++	</BinField>
++	
++</Bin_Ecc_Map>
+diff --git a/ImageGeneration/inputs/GFXTest.xml b/ImageGeneration/inputs/GFXTest.xml
+new file mode 100644
+index 0000000..b29f791
+--- /dev/null
++++ b/ImageGeneration/inputs/GFXTest.xml
+@@ -0,0 +1,75 @@
++<!-- SPDX-License-Identifier: GPL-2.0
++#
++# Nuvoton IGPS: Image Generation And Programming Scripts For Poleg BMC
++#
++# Copyright (C) 2019 Nuvoton Technologies, All Rights Reserved
++#--------------------------------------------------------------------------->
++
++<?xml version="1.0" encoding="UTF-8"?>
++
++<Bin_Ecc_Map>
++	<!-- BMC mandatory fields -->
++	<ImageProperties>
++		<BinSize>0</BinSize>         <!-- If 0 the binary size will be calculated by the tool -->
++		<PadValue>0xFF</PadValue>	<!-- Byte value to pad the empty areas, default is 0 -->
++	</ImageProperties>
++	
++	<BinField>
++		<name>TestBINTag</name>         <!-- name of field -->
++		<config>
++			<offset>0x0</offset>            <!-- offset in the header -->
++			<size>0x8</size>              <!-- size in the header -->
++		</config>
++		<content format='bytes'>0x53 0x54 0x44 0x41 0x4C 0x54 0x53 0x54</content>  <!-- content the user should fill -->
++	</BinField>
++	
++	<BinField>
++		<!-- BootBlock or u-boot Code size -->
++		<name>CodeSize</name>         
++		<config>
++			<offset>0x8</offset>       
++			<size>0x4</size> 
++		</config>
++		<content format='FileSize'>GFX.bin</content>	<!-- content the user should fill -->
++	</BinField>
++	
++	<BinField>
++		<!-- Code destination address, 32-bit aligned: for DDR should be 0xFFFD0000 -->
++		<name>DestAddr</name>         
++		<config>
++			<offset>0xC</offset>       
++			<size>0x4</size> 
++		</config>
++		<content format='32bit'>0xFFFD0000</content>     <!-- content the user should fill -->
++	</BinField>
++	
++	<BinField>
++		<!-- Code destination address, 32-bit aligned: for DDR should be 0xFFFD0000 -->
++		<name>Description</name>         
++		<config>
++			<offset>0x10</offset>       
++			<size>0x40</size> 
++		</config>
++		<content format='bytes'>0x47 0x46 0x58 0x53 0x41 0x54 0x53 0x54</content>     <!-- content the user should fill -->
++	</BinField>
++	
++	<BinField>
++		<!-- Code destination address, 32-bit aligned: for DDR should be 0xFFFD0000 -->
++		<name>TestResult</name>
++		<config>
++			<offset>0x50</offset>
++			<size>0x4</size> 
++		</config>
++		<content format='bytes'>0xFF 0xFF 0xFF 0xFF</content>     <!-- content the user should fill -->
++	</BinField>
++	
++	<BinField>
++		<name>test-bin</name>             <!-- name of field -->
++		<config>
++			<offset>0x100</offset>        <!-- offset in the header -->
++			<size format='FileSize'>GFX.bin</size>                 <!-- size in the header calculated by tool-->
++		</config>
++		<content format='FileContent'>GFX.bin</content>  <!-- content the user should fill -->
++	</BinField>
++	
++</Bin_Ecc_Map>
+diff --git a/ImageGeneration/inputs/MEMTest.xml b/ImageGeneration/inputs/MEMTest.xml
+new file mode 100644
+index 0000000..528d3c1
+--- /dev/null
++++ b/ImageGeneration/inputs/MEMTest.xml
+@@ -0,0 +1,66 @@
++<!-- SPDX-License-Identifier: GPL-2.0
++#
++# Nuvoton IGPS: Image Generation And Programming Scripts For Poleg BMC
++#
++# Copyright (C) 2019 Nuvoton Technologies, All Rights Reserved
++#--------------------------------------------------------------------------->
++
++<?xml version="1.0" encoding="UTF-8"?>
++
++<Bin_Ecc_Map>
++	<!-- BMC mandatory fields -->
++	<ImageProperties>
++		<BinSize>0</BinSize>         <!-- If 0 the binary size will be calculated by the tool -->
++		<PadValue>0xFF</PadValue>	<!-- Byte value to pad the empty areas, default is 0 -->
++	</ImageProperties>
++	
++	<BinField>
++		<name>TestBINTag</name>         <!-- name of field -->
++		<config>
++			<offset>0x0</offset>            <!-- offset in the header -->
++			<size>0x8</size>              <!-- size in the header -->
++		</config>
++		<content format='bytes'>0x53 0x54 0x44 0x41 0x4C 0x54 0x53 0x54</content>  <!-- content the user should fill -->
++	</BinField>
++	
++	<BinField>
++		<!-- BootBlock or u-boot Code size -->
++		<name>CodeSize</name>         
++		<config>
++			<offset>0x8</offset>       
++			<size>0x4</size> 
++		</config>
++		<content format='32bit'>0x0</content>	<!-- content the user should fill -->
++	</BinField>
++	
++	<BinField>
++		<!-- Code destination address, 32-bit aligned: for DDR should be 0xFFFD0000 -->
++		<name>DestAddr</name>
++		<config>
++			<offset>0xC</offset>
++			<size>0x4</size>
++		</config>
++		<content format='32bit'>0xFFFFFFFF</content>     <!-- content the user should fill -->
++	</BinField>
++	
++	<BinField>
++		<!-- Code destination address, 32-bit aligned: for DDR should be 0xFFFD0000 -->
++		<name>Description</name>
++		<config>
++			<offset>0x10</offset>
++			<size>0x40</size> 
++		</config>
++		<content format='bytes'>0x75 0x62 0x6F 0x6F 0x74 0x2D 0x63 0x6D 0x64 0x2D 0x6D 0x74 0x65 0x73 0x74 0x2D 0x72 0x65 0x73 0x75 0x6C 0x74 0x2D 0x6F 0x6E 0x6C 0x79</content>     <!-- content the user should fill -->
++	</BinField>
++	
++	<BinField>
++		<!-- Code destination address, 32-bit aligned: for DDR should be 0xFFFD0000 -->
++		<name>TestResult</name>
++		<config>
++			<offset>0x50</offset>
++			<size>0x4</size> 
++		</config>
++		<content format='bytes'>0xFF 0xFF 0xFF 0xFF</content>     <!-- content the user should fill -->
++	</BinField>
++	
++</Bin_Ecc_Map>
+diff --git a/ImageGeneration/inputs/mergedBootBlockAndUbootAndTests.xml b/ImageGeneration/inputs/mergedBootBlockAndUbootAndTests.xml
+new file mode 100644
+index 0000000..7647a63
+--- /dev/null
++++ b/ImageGeneration/inputs/mergedBootBlockAndUbootAndTests.xml
+@@ -0,0 +1,35 @@
++<!-- SPDX-License-Identifier: GPL-2.0
++#
++# Nuvoton IGPS: Image Generation And Programming Scripts For Poleg BMC
++#
++# Copyright (C) 2018 Nuvoton Technologies, All Rights Reserved
++#--------------------------------------------------------------------------->
++
++<?xml version="1.0" encoding="UTF-8"?>
++
++<Bin_Ecc_Map>
++	<!-- BMC mandatory fields -->
++	<ImageProperties>
++		<BinSize>0</BinSize>         <!-- If 0 the binary size will be calculated by the tool -->
++		<PadValue>0xFF</PadValue>	<!-- Byte value to pad the empty areas, default is 0 -->
++	</ImageProperties>
++		
++	<BinField>
++		<name>BootBlockAndUboot</name>         <!-- name of field -->
++		<config>
++			<offset>0</offset>            <!-- offset in the header -->
++			<size format='FileSize'>u-boot.bin.merged</size>              <!-- size in the header -->
++		</config>
++		<content format='FileContent'>u-boot.bin.merged</content>  <!-- content the user should fill -->
++	</BinField>
++		
++	<BinField>
++		<name>tests</name>         <!-- name of field -->
++		<config>
++			<offset format='FileSize' align='0x1000'>u-boot.bin.merged</offset>            <!-- offset in the header -->
++			<size format='FileSize'>mergedTests123.bin</size>              <!-- size in the header -->
++		</config>
++		<content format='FileContent'>mergedTests123.bin</content>  <!-- content the user should fill -->
++	</BinField>
++	
++</Bin_Ecc_Map>
+diff --git a/ImageGeneration/inputs/mergedTests12.xml b/ImageGeneration/inputs/mergedTests12.xml
+new file mode 100644
+index 0000000..58e81ae
+--- /dev/null
++++ b/ImageGeneration/inputs/mergedTests12.xml
+@@ -0,0 +1,35 @@
++<!-- SPDX-License-Identifier: GPL-2.0
++#
++# Nuvoton IGPS: Image Generation And Programming Scripts For Poleg BMC
++#
++# Copyright (C) 2018 Nuvoton Technologies, All Rights Reserved
++#--------------------------------------------------------------------------->
++
++<?xml version="1.0" encoding="UTF-8"?>
++
++<Bin_Ecc_Map>
++	<!-- BMC mandatory fields -->
++	<ImageProperties>
++		<BinSize>0</BinSize>         <!-- If 0 the binary size will be calculated by the tool -->
++		<PadValue>0xFF</PadValue>	<!-- Byte value to pad the empty areas, default is 0 -->
++	</ImageProperties>
++		
++	<BinField>
++		<name>Test1</name>         <!-- name of field -->
++		<config>
++			<offset>0x0</offset>            <!-- offset in the header -->
++			<size format='FileSize'>MEMTest.bin</size>              <!-- size in the header -->
++		</config>
++		<content format='FileContent'>MEMTest.bin</content>  <!-- content the user should fill -->
++	</BinField>
++		
++	<BinField>
++		<name>Test2</name>         <!-- name of field -->
++		<config>
++			<offset format='FileSize' align='0x1000'>MEMTest.bin</offset>            <!-- offset in the header -->
++			<size format='FileSize'>DDRSITest.bin</size>              <!-- size in the header -->
++		</config>
++		<content format='FileContent'>DDRSITest.bin</content>  <!-- content the user should fill -->
++	</BinField>
++	
++</Bin_Ecc_Map>
+diff --git a/ImageGeneration/inputs/mergedTests123.xml b/ImageGeneration/inputs/mergedTests123.xml
+new file mode 100644
+index 0000000..c62b3d2
+--- /dev/null
++++ b/ImageGeneration/inputs/mergedTests123.xml
+@@ -0,0 +1,35 @@
++<!-- SPDX-License-Identifier: GPL-2.0
++#
++# Nuvoton IGPS: Image Generation And Programming Scripts For Poleg BMC
++#
++# Copyright (C) 2018 Nuvoton Technologies, All Rights Reserved
++#--------------------------------------------------------------------------->
++
++<?xml version="1.0" encoding="UTF-8"?>
++
++<Bin_Ecc_Map>
++	<!-- BMC mandatory fields -->
++	<ImageProperties>
++		<BinSize>0</BinSize>         <!-- If 0 the binary size will be calculated by the tool -->
++		<PadValue>0xFF</PadValue>	<!-- Byte value to pad the empty areas, default is 0 -->
++	</ImageProperties>
++		
++	<BinField>
++		<name>Test12</name>         <!-- name of field -->
++		<config>
++			<offset>0</offset>            <!-- offset in the header -->
++			<size format='FileSize'>mergedTests12.bin</size>              <!-- size in the header -->
++		</config>
++		<content format='FileContent'>mergedTests12.bin</content>  <!-- content the user should fill -->
++	</BinField>
++		
++	<BinField>
++		<name>Test3</name>         <!-- name of field -->
++		<config>
++			<offset format='FileSize' align='0x1000'>mergedTests12.bin</offset>            <!-- offset in the header -->
++			<size format='FileSize'>GFXTest.bin</size>              <!-- size in the header -->
++		</config>
++		<content format='FileContent'>GFXTest.bin</content>  <!-- content the user should fill -->
++	</BinField>
++	
++</Bin_Ecc_Map>

--- a/meta-phosphor/classes/image_types_phosphor_nuvoton.bbclass
+++ b/meta-phosphor/classes/image_types_phosphor_nuvoton.bbclass
@@ -4,6 +4,13 @@ FULL_SUFFIX = "full"
 MERGED_SUFFIX = "merged"
 UBOOT_SUFFIX_append = ".${MERGED_SUFFIX}"
 
+TEST1_BINARY = "MEMTest.bin"
+TEST2_BINARY = "DDRSITest.bin"
+TEST3_BINARY = "GFXTest.bin"
+TEST12_BINARY = "mergedTests12.bin"
+TEST123_BINARY = "mergedTests123.bin"
+MERGED_BB_UBOOT_TEST_BINARY = "mergedBootBlockAndUbootAndTests.bin"
+
 IGPS_DIR = "${STAGING_DIR_NATIVE}/${datadir}/npcm7xx-igps"
 
 # Prepare the Bootblock and U-Boot images using npcm7xx-bingo
@@ -18,6 +25,25 @@ do_prepare_bootloaders() {
 
     bingo ${IGPS_DIR}/mergedBootBlockAndUboot.xml \
             -o ${DEPLOY_DIR_IMAGE}/${UBOOT_BINARY}.${MERGED_SUFFIX}
+
+    bingo ${IGPS_DIR}/MEMTest.xml \
+            -o ${DEPLOY_DIR_IMAGE}/${TEST1_BINARY}
+
+    bingo ${IGPS_DIR}/DDRSITest.xml \
+            -o ${DEPLOY_DIR_IMAGE}/${TEST2_BINARY}
+
+    bingo ${IGPS_DIR}/GFXTest.xml \
+            -o ${DEPLOY_DIR_IMAGE}/${TEST3_BINARY}
+
+    bingo ${IGPS_DIR}/mergedTests12.xml \
+            -o ${DEPLOY_DIR_IMAGE}/${TEST12_BINARY}
+
+    bingo ${IGPS_DIR}/mergedTests123.xml \
+            -o ${DEPLOY_DIR_IMAGE}/${TEST123_BINARY}
+
+    bingo ${IGPS_DIR}/mergedBootBlockAndUbootAndTests.xml \
+            -o ${DEPLOY_DIR_IMAGE}/${MERGED_BB_UBOOT_TEST_BINARY}
+
     cd "$olddir"
 }
 
@@ -25,6 +51,8 @@ do_prepare_bootloaders[depends] += " \
     npcm7xx-bootblock:do_deploy \
     npcm7xx-bingo-native:do_populate_sysroot \
     npcm7xx-igps-native:do_populate_sysroot \
+    npcm7xx-ddr4si-test:do_deploy \
+    npcm7xx-gfx-test:do_deploy \
     "
 
 addtask do_prepare_bootloaders before do_generate_static after do_generate_rwfs_static


### PR DESCRIPTION
	Note: 1. concatenate BB and uboot image and Test images
		 as mergedBootBlockAndUbootAndTests.bin
              2. MTest only has header for recording test result
              3. each header is 0x100 in bytes

Signed-off-by: Medad CChien <ctcchien@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
