### PR TITLE
meta-nuvoton: linux-nuvoton: bump srcrev 30714f6...317aef8

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_git.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_git.bb
@@ -1,7 +1,7 @@
 KBRANCH ?= "Poleg-5.4-OpenBMC"
 LINUX_VERSION ?= "5.4.16"
 
-SRCREV="30714f6673c730be742f6b2d4d54cb9a8a40e349"
+SRCREV="317aef891ad9d3d054e8f8999be2897bf4b23505"
 
 require linux-nuvoton.inc
 


### PR DESCRIPTION
Fix image update fail via bmcweb cause by Uboot partition size
is not enough.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
