### PR TITLE
meta-nuvoton: nuvoton: add Nuvoton IPMI OEM command library

### DIFF
--- a/meta-nuvoton/recipes-nuvoton/ipmi/nuvoton-ipmi-oem_git.bb
+++ b/meta-nuvoton/recipes-nuvoton/ipmi/nuvoton-ipmi-oem_git.bb
@@ -1,0 +1,28 @@
+SUMMARY = "Nuvoton IPMI OEM command library"
+DESCRIPTION = "Nuvoton IPMI OEM command library"
+HOMEPAGE = "https://github.com/nuvoton-ipmi-oem"
+PR = "r1"
+PV = "0.1+git${SRCPV}"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ce3556061e8d4b01638d497053a82dfd"
+
+inherit autotools pkgconfig
+inherit systemd
+inherit obmc-phosphor-ipmiprovider-symlink
+
+DEPENDS += "autoconf-archive-native"
+DEPENDS += "sdbusplus"
+DEPENDS += "phosphor-logging"
+DEPENDS += "phosphor-ipmi-host"
+DEPENDS += "nlohmann-json"
+
+S = "${WORKDIR}/git"
+SRC_URI = "git://github.com/Nuvoton-Israel/nuvoton-ipmi-oem"
+SRCREV = "83bfc660282f3f8ee2b8acc068f5afc9e9e0d102"
+
+FILES_${PN}_append = " ${libdir}/ipmid-providers/lib*${SOLIBS}"
+FILES_${PN}_append = " ${libdir}/host-ipmid/lib*${SOLIBS}"
+FILES_${PN}_append = " ${libdir}/net-ipmid/lib*${SOLIBS}"
+FILES_${PN}-dev_append = " ${libdir}/ipmid-providers/lib*${SOLIBSDEV} ${libdir}/ipmid-providers/*.la"
+
+HOSTIPMI_PROVIDER_LIBRARY += "libnuvoemcmds.so"


### PR DESCRIPTION
1. Add the recipe for Nuvoton IPMI OEM command library

Signed-off-by: kfting <kfting@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
