### PR TITLE
meta-quanta: olympus-nuvoton: bmcweb: fix segmentation fault in updat…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0010-bmcweb-fix-segmentation-fault-in-update-service.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0010-bmcweb-fix-segmentation-fault-in-update-service.patch
@@ -1,0 +1,26 @@
+From 606d6e4eecdef4ab6746e61135c926c3cdd20afc Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Tue, 22 Sep 2020 10:04:26 +0800
+Subject: [PATCH 10/10] bmcweb: fix segmentation fault in update service
+
+Signed-off-by: Tim Lee <timlee660101@gmail.com>
+---
+ redfish-core/lib/update_service.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/redfish-core/lib/update_service.hpp b/redfish-core/lib/update_service.hpp
+index 0b151d94..3c3cc478 100644
+--- a/redfish-core/lib/update_service.hpp
++++ b/redfish-core/lib/update_service.hpp
+@@ -81,7 +81,7 @@ static void softwareInterfaceAdded(std::shared_ptr<AsyncResp> asyncResp,
+         if (interface.first == "xyz.openbmc_project.Software.Activation")
+         {
+             // Found our interface, disable callbacks
+-            fwUpdateMatcher = nullptr;
++            //fwUpdateMatcher = nullptr;
+ 
+             // Retrieve service and activate
+             crow::connections::systemBus->async_method_call(
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -6,6 +6,7 @@ SRC_URI_append_olympus-nuvoton = " file://0005-bmcweb-chassis-add-indicatorLED-s
 #SRC_URI_append_olympus-nuvoton = " file://0006-bmcweb-get-cpu-and-dimm-info-from-prettyname.patch"
 
 SRC_URI_append_olympus-nuvoton = " file://0001-redfish-cpudimm-fix-cannot-prsent-totalcores.patch"
+SRC_URI_append_olympus-nuvoton = " file://0010-bmcweb-fix-segmentation-fault-in-update-service.patch"
 
 # Enable CPU Log and Raw PECI support
 EXTRA_OECMAKE += "-DBMCWEB_ENABLE_REDFISH_CPU_LOG=ON"


### PR DESCRIPTION
…e service

Issue Symptom:
Bmcweb.service was terminated abnormal after updating images via Redfish curl command.
The debug log about bmcweb.service exited as below:
Sep 18 07:50:25 olympus-nuvoton systemd[1]: bmcweb.service: Main process exited, code=dumped, status=11/SEGV
Sep 18 07:50:25 olympus-nuvoton systemd[1]: bmcweb.service: Failed with result 'core-dump'.

Root cause:
The callback function pointer fwUpdateMatcher be set as nullptr that cause callback function softwareInterfaceAdded() be disabled.
Then when the next dbus signal relate to member is InterfacesAdded in object path /xyz/operbmc_project/software
will call to a NULL callback function and that cause bmcweb got 11/SEGV fail and be terminated abnormal.

Solution:
Set fwUpdateMatcher as nullptr should remove it from softwareInterfaceAdded()
and that already be set as nullptr in monitorForSoftwareAvailable() after got response.

Verification via redish curl command:
Update BMC image using UpdateService.SimpleUpdate POST action.
curl -k -H "X-Auth-Token: $token" -X POST https://${bmc}/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate -d \
'{"ImageURI":"tftp://10.103.61.175/obmc-phosphor-image-olympus-nuvoton-20200921031720.static.mtd.tar"}'

Update BMC image using UpdateService POST action.
curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/octet-stream" -X POST -T \
tim/obmc-phosphor-image-olympus-nuvoton-20200921031720.static.mtd.tar https://${bmc}/redfish/v1/UpdateService

Signed-off-by: Tim Lee <timlee660101@gmail.com>
