### PR TITLE
meta-quanta: olympus-nuvoton: bmcweb: fix Members@odata.count is inco…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0013-systems-fix-Members-odata.count-is-incorrect-even-Me.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0013-systems-fix-Members-odata.count-is-incorrect-even-Me.patch
@@ -1,0 +1,26 @@
+From 332b07c0776c25f475058bbcf700570cc875ea16 Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Thu, 19 Nov 2020 14:08:35 +0800
+Subject: [PATCH 13/13] systems: fix Members@odata.count is incorrect even
+ Members have contents
+
+Signed-off-by: Tim Lee <timlee660101@gmail.com>
+---
+ redfish-core/lib/systems.hpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/redfish-core/lib/systems.hpp b/redfish-core/lib/systems.hpp
+index 944f730f..5103736a 100644
+--- a/redfish-core/lib/systems.hpp
++++ b/redfish-core/lib/systems.hpp
+@@ -1695,6 +1695,7 @@ class SystemsCollection : public Node
+                 count = 0;
+                 ifaceArray.push_back(
+                     {{"@odata.id", "/redfish/v1/Systems/system"}});
++                    count = ifaceArray.size();
+                 if (!ec)
+                 {
+                     BMCWEB_LOG_DEBUG << "Hypervisor is available";
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -6,6 +6,7 @@ SRC_URI_append_olympus-nuvoton = " file://0003-Redfish-Add-power-metrics-support
 SRC_URI_append_olympus-nuvoton = " file://0005-bmcweb-chassis-add-indicatorLED-support.patch"
 SRC_URI_append_olympus-nuvoton = " file://0010-bmcweb-fix-segmentation-fault-in-update-service.patch"
 SRC_URI_append_olympus-nuvoton = " file://0001-redifsh-logservice-fix-duplicate-res-end.patch"
+SRC_URI_append_olympus-nuvoton = " file://0013-systems-fix-Members-odata.count-is-incorrect-even-Me.patch"
 
 # Enable CPU Log and Raw PECI support
 EXTRA_OEMESON_append = " -Dredfish-cpu-log=enabled"


### PR DESCRIPTION
…rrect even Members have contents in Systems

Issue symptom:
Run automation test "Verify_Systems_Defaults" then we got ERROR as below.
Verify Systems Defaults :: Verify systems defaults.                   | FAIL |
**ERROR** Invalid variable value: systems['Members@odata.count']:     0 <int>

Root cause:
In Systems, doGet() didn't calculate count after ifaceArray.push_back({{"@odata.id", "/redfish/v1/Systems/system"}})

Solution:
Increase count by ifaceArray.size() after ifaceArray.push_back() in Systems

Tested:
1. Verified
   robot -t Verify_Systems_Defaults redfish/service_root/test_sessions_management.robot
   Verify Systems Defaults :: Verify systems defaults.                | PASS |

2. Verified system detail from Redfish.
   Get https://<BMC-IP>/redfish/v1/Systems
   Response:
   {
      "@odata.id": "/redfish/v1/Systems",
      "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
      "Members": [
         {
            "@odata.id": "/redfish/v1/Systems/system"
         }
      ],
      "Members@odata.count": 1,
      "Name": "Computer System Collection"
   }

Signed-off-by: Tim Lee <timlee660101@gmail.com>