### PR TITLE
meta-quanta: olympus-nuvoton: smbios: fix smbios-mdrv2 service crash …

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-x86/smbios/smbios-mdrv2.bb
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-x86/smbios/smbios-mdrv2.bb
@@ -7,6 +7,7 @@ SRCREV = "9c362668c24153066f746393f12f3869e095d523"
 SRC_URI += "file://0001-Notify-inventory-manager-that-a-interface-needs-adde.patch"
 SRC_URI += "file://0002-remove-fno-rtti-cxx-flags.patch"
 SRC_URI += "file://smbios2"
+SRC_URI += "file://smbios-mdrv2.service"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
…at the first time when boot up

Symptom:
Check_For_Application_Failures test item fail and fail log as below.
smbiosmdrv2app[336]: terminate called after throwing an instance of 'sdbusplus::exception::SdBusError'
smbiosmdrv2app[336]:   what():  sd_bus_call: org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable
systemd[1]: smbios-mdrv2.service: Main process exited, code=dumped, status=6/ABRT
systemd[1]: smbios-mdrv2.service: Failed with result 'core-dump'.

Root cause:
Due to inventory-manager service not be executed before smbios-mdrv2 service.
That will cause dbus report error about unknown service when using notify method of inventory manager.

Solution:
Add service denpendancy to make sure smbios-mdrv2 service will run after inventory-manager service.

Verified:
robot -t Check_For_Application_Failures redfish/extended/test_basic_ci.robot
Test Basic Ci :: Test for HW CI...| PASS |

Signed-off-by: Tim Lee <timlee660101@gmail.com>