### PR TITLE
meta-quanta: olympus-nuvoton: smbios: fix crash issue due to non-prin…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-x86/smbios/smbios-mdrv2.bb
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-x86/smbios/smbios-mdrv2.bb
@@ -2,10 +2,9 @@ SUMMARY = "SMBIOS MDR version 2 service for Intel based platform"
 DESCRIPTION = "SMBIOS MDR version 2 service for Intel based platfrom"
 
 SRC_URI = "git://github.com/openbmc/smbios-mdr"
-SRCREV = "9c362668c24153066f746393f12f3869e095d523"
+SRCREV = "26de0d73700eef983af4733d258314b7c39bd7ac"
 
 SRC_URI += "file://0001-Notify-inventory-manager-that-a-interface-needs-adde.patch"
-SRC_URI += "file://0002-remove-fno-rtti-cxx-flags.patch"
 SRC_URI += "file://smbios2"
 SRC_URI += "file://smbios-mdrv2.service"
 
@@ -36,6 +35,8 @@ DEPENDS += " \
 do_install_append() {
     install -d ${D}${localstatedir_nativesdk}/${base_libdir_nativesdk}/smbios
     install -m 0644 ${WORKDIR}/smbios2 ${D}${localstatedir_nativesdk}/${base_libdir_nativesdk}/smbios
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/smbios-mdrv2.service ${D}${systemd_system_unitdir}
 }
 
 EXTRA_OECMAKE = "-DYOCTO=1"

--- a/meta-quanta/meta-olympus-nuvoton/recipes-x86/smbios/smbios-mdrv2/smbios-mdrv2.service
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-x86/smbios/smbios-mdrv2/smbios-mdrv2.service
@@ -7,8 +7,8 @@ After=mapper-wait@-xyz-openbmc_project-inventory.service
 Restart=always
 RestartSec=5
 StartLimitBurst=10
+ExecStartPre=/bin/mkdir -p /var/lib/smbios
 ExecStart=/usr/bin/env smbiosmdrv2app
-SyslogIdentifier=smbiosmdrv2app
 
 [Install]
 WantedBy={SYSTEMD_DEFAULT_TARGET}


### PR DESCRIPTION
…t char

Symptom:
localhost phosphor-mapper[283]: Introspect call failed with error: generic:113, No route to host on process: xyz.openbmc_project.Smbios.MDR_V2 path: /
smbiosmdrv2app[336]: terminate called after throwing an instance of 'sdbusplus::exception::SdBusError'

Root cause:
When smbios table file is broken, the parsed string type propery like version may contain non-print char,
which causes smbios service crash.

Solution:
Update new commit from community and adjust our service file for our usage.

Verified:
Check journal log to make sure no more crash from smbios.

Signed-off-by: Tim Lee <timlee660101@gmail.com>