### PR TITLE
meta-evb: meta-evb-nuvoton: meta-buv-runbmc: phosphor-software-manager

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/dbus/phosphor-dbus-interfaces/0001-Software-Add-MCU-VersionPurpose.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/dbus/phosphor-dbus-interfaces/0001-Software-Add-MCU-VersionPurpose.patch
@@ -1,0 +1,24 @@
+From 09d9ab58263f3bd34e2a7d45f0a4de4ad1860753 Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Thu, 3 Sep 2020 17:09:43 +0800
+Subject: [PATCH] Software: Add MCU VersionPurpose
+
+Signed-off-by: Tim Lee <timlee660101@gmail.com>
+---
+ xyz/openbmc_project/Software/Version.interface.yaml | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/xyz/openbmc_project/Software/Version.interface.yaml b/xyz/openbmc_project/Software/Version.interface.yaml
+index 345e5b5..2f5c5b8 100644
+--- a/xyz/openbmc_project/Software/Version.interface.yaml
++++ b/xyz/openbmc_project/Software/Version.interface.yaml
+@@ -38,3 +38,6 @@ enumerations:
+         - name: PSU
+           description: >
+             The version is a version for a PSU.
++        - name: MCU
++          description: >
++            The version is a version for a MCU.
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/dbus/phosphor-dbus-interfaces_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/dbus/phosphor-dbus-interfaces_%.bbappend
@@ -1,3 +1,4 @@
 FILESEXTRAPATHS_prepend_buv-runbmc := "${THISDIR}/${PN}:"
 
 SRC_URI_append_buv-runbmc = " file://0028-MCTP-Daemon-D-Bus-interface-definition.patch"
+SRC_URI_append_buv-runbmc = " file://0001-Software-Add-MCU-VersionPurpose.patch"

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager/obmc-flash-host-bios@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager/obmc-flash-host-bios@.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Flash Host Bios image %I to Host
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart="mv /tmp/image/%i/image-bios /tmp/image-bios; /usr/bin/bios-update.sh"

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -1,0 +1,7 @@
+SRC_URI = "git://github.com/Nuvoton-Israel/phosphor-bmc-code-mgmt.git"
+SRCREV = "3bdf22dde6ea11bbcc797c9f9ed62776fcebbd79"
+
+FILES_${PN}-updater_append_buv-runbmc = " \
+    ${datadir}/phosphor-bmc-code-mgmt/bios-release"
+
+PACKAGECONFIG_buv-runbmc += "verify_signature"


### PR DESCRIPTION
move software manager to Nuvoton customized for BUV

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
