### PR TITLE
meta-quanta: meta-olympus-nuvoton: recipes-phosphor: interfaces: bmcw…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0014-add-config-to-config-virtual-media-buffer-size.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0014-add-config-to-config-virtual-media-buffer-size.patch
@@ -1,0 +1,38 @@
+diff --git a/include/vm_websocket.hpp b/include/vm_websocket.hpp
+index a175f0a8..ab8121d7 100644
+--- a/include/vm_websocket.hpp
++++ b/include/vm_websocket.hpp
+@@ -17,7 +17,7 @@ static crow::websocket::Connection* session = nullptr;
+ // The max network block device buffer size is 128kb plus 16bytes
+ // for the message header:
+ // https://github.com/NetworkBlockDevice/nbd/blob/master/doc/proto.md#simple-reply-message
+-static constexpr auto nbdBufferSize = 131088;
++static constexpr auto nbdBufferSize = 131088 * BMCWEB_VM_BUFFER_SIZE;
+ 
+ class Handler : public std::enable_shared_from_this<Handler>
+ {
+ 
+diff --git a/meson.build b/meson.build
+index 529b9cbf..fc62c2e8 100644
+--- a/meson.build
++++ b/meson.build
+@@ -340,6 +340,7 @@ srcfiles_unittest = ['include/ut/dbus_utility_test.cpp',
+ 
+ conf_data = configuration_data()
+ conf_data.set('BMCWEB_HTTP_REQ_BODY_LIMIT_MB',get_option('http-body-limit'))
++conf_data.set('BMCWEB_VM_BUFFER_SIZE',get_option('vm-buffer-size'))
+ conf_data.set('MESON_INSTALL_PREFIX',get_option('prefix'))
+ configure_file(output: 'config.h',
+                configuration: conf_data)
+diff --git a/meson_options.txt b/meson_options.txt
+index 1298b968..ef8619aa 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -22,6 +22,7 @@ option('cookie-auth', type : 'feature', value : 'enabled', description : '''Enab
+ option('mutual-tls-auth', type : 'feature', value : 'enabled', description : '''Enables authenticating users through TLS client certificates. The insecure-disable-ssl must be disabled for this option to take effect.''')
+ option('ibm-management-console', type : 'feature', value : 'disabled', description : 'Enable the IBM management console specific functionality. Paths are under \'/ibm/v1/\'')
+ option('http-body-limit', type: 'integer', min : 0, max : 512, value : 30, description : 'Specifies the http request body length limit')
++option('vm-buffer-size', type: 'integer', min : 1, max : 10, value : 1, description : 'Specifies the buffer size for virtual media')
+ 
+ # Insecure options. Every option that starts with a `insecure` flag should
+ # not be enabled by default for any platform, unless the author fully comprehends

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -4,6 +4,7 @@ SRCREV := "f16f62633a64f386fd0382703ff0949ea177f457"
 
 SRC_URI_append_olympus-nuvoton = " file://0003-Redfish-Add-power-metrics-support.patch"
 SRC_URI_append_olympus-nuvoton = " file://0005-bmcweb-chassis-add-indicatorLED-support.patch"
+SRC_URI_append_olympus-nuvoton = " file://0014-add-config-to-config-virtual-media-buffer-size.patch"
 
 # Enable CPU Log and Raw PECI support
 EXTRA_OEMESON_append = " -Dredfish-cpu-log=enabled"
@@ -23,3 +24,6 @@ EXTRA_OEMESON_append = " -Dhttp-body-limit=35"
 
 # Enable Redfish DUMP log service
 EXTRA_OEMESON_append = " -Dredfish-dump-log=enabled"
+
+# Buffer size for virtual media
+EXTRA_OEMESON_append = " -Dvm-buffer-size=2"


### PR DESCRIPTION
…eb: Add a config to set vm buffer size

	Note: if nbd-proxy doesn't read all the data in buffer and bmcweb gets one more msg from nbd-server,
              then buffer will overflow

Signed-off-by: Medad CChien <ctcchien@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
