### PR TITLE
meta-quanta: meta-olympus-nuvoton: recipes-phosphor: interfaces: bmcw…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -26,4 +26,4 @@ EXTRA_OEMESON_append = " -Dhttp-body-limit=35"
 EXTRA_OEMESON_append = " -Dredfish-dump-log=enabled"
 
 # Buffer size for virtual media
-EXTRA_OEMESON_append = " -Dvm-buffer-size=2"
+EXTRA_OEMESON_append = " -Dvm-buffer-size=3"


### PR DESCRIPTION
…eb: Set VM buffer size to three times

Signed-off-by: Medad CChien <ctcchien@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
