### PR TITLE
meta-buv-runbmc: Enable USB host function

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton/arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton/arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts
@@ -493,7 +493,7 @@
 };
 
 &udc9 {
-	status = "okay";
+	status = "disabled";
 };
 
 &aes {


### PR DESCRIPTION
disalbe udc9 in DTS for enable USB host

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
