### PR TITLE
meta-quanta: olympus-nuvoton: dump: fix bmc dump auto test fail

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dbus/phosphor-dbus-interfaces/0030-remove-parameters-of-CreateDump.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dbus/phosphor-dbus-interfaces/0030-remove-parameters-of-CreateDump.patch
@@ -1,0 +1,43 @@
+From 2056ef3100a97e822decfb11d587c2dd6a762257 Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Tue, 11 May 2021 15:44:06 +0800
+Subject: [PATCH 30/30] remove parameters of CreateDump
+
+Signed-off-by: Tim Lee <timlee660101@gmail.com>
+---
+ .../Dump/Create.interface.yaml                | 19 -------------------
+ 1 file changed, 19 deletions(-)
+
+diff --git a/xyz/openbmc_project/Dump/Create.interface.yaml b/xyz/openbmc_project/Dump/Create.interface.yaml
+index b83798a9..965ab118 100644
+--- a/xyz/openbmc_project/Dump/Create.interface.yaml
++++ b/xyz/openbmc_project/Dump/Create.interface.yaml
+@@ -14,25 +14,6 @@ methods:
+     - name: CreateDump
+       description: >
+           Method to create a manual Dump.
+-      parameters:
+-        - name: AdditionalData
+-          type: dict[string, string]
+-          description: >
+-            The additional data, if any, for initiating the dump.
+-            The key in this case should be an implementation
+-            specific enum defined for the specific type of dump
+-            either in xyz or in a domain.
+-            The enum-format string is required to come from a
+-            parallel class with this specific Enum name.
+-            All of the Enum strings should be in the format
+-            'domain.Dump.Create.CreateParameters.ParamName'.
+-            e.g.:
+-              {
+-                "key1": "value1",
+-                "key2": "value2"
+-              }
+-            ends up in AdditionaData like:
+-              ["KEY1=value1", "KEY2=value2"]
+       returns:
+         - name: Path
+           type: object_path
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dbus/phosphor-dbus-interfaces_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dbus/phosphor-dbus-interfaces_%.bbappend
@@ -10,3 +10,4 @@ SRC_URI_append_olympus-nuvoton = " file://0028-MCTP-Daemon-D-Bus-interface-defin
 SRC_URI_append_olympus-nuvoton = " file://0024-Add-the-pre-timeout-interrupt-defined-in-IPMI-spec.patch"
 SRC_URI_append_olympus-nuvoton = " file://0025-Add-PreInterruptFlag-properity-in-DBUS.patch"
 SRC_URI_append_olympus-nuvoton = " file://0029-Add-LastRebootCause-property-in-BMC-interface.patch"
+SRC_URI_append_olympus-nuvoton = " file://0030-remove-parameters-of-CreateDump.patch"

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dump/phosphor-debug-collector/0001-fix-bmc-dump-cannot-accept-no-additional-parameters.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dump/phosphor-debug-collector/0001-fix-bmc-dump-cannot-accept-no-additional-parameters.patch
@@ -1,0 +1,47 @@
+From 92600f820bebb8db5d4eaea46452d025da9b0be5 Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Tue, 11 May 2021 15:33:30 +0800
+Subject: [PATCH] fix bmc dump cannot accept no additional parameters
+
+Signed-off-by: Tim Lee <timlee660101@gmail.com>
+---
+ dump_manager_bmc.cpp | 7 +------
+ dump_manager_bmc.hpp | 3 +--
+ 2 files changed, 2 insertions(+), 8 deletions(-)
+
+diff --git a/dump_manager_bmc.cpp b/dump_manager_bmc.cpp
+index aef7a3e..0236e46 100644
+--- a/dump_manager_bmc.cpp
++++ b/dump_manager_bmc.cpp
+@@ -35,13 +35,8 @@ void Manager::create(Type type, std::vector<std::string> fullPaths)
+ 
+ } // namespace internal
+ 
+-sdbusplus::message::object_path
+-    Manager::createDump(std::map<std::string, std::string> params)
++sdbusplus::message::object_path Manager::createDump()
+ {
+-    if (!params.empty())
+-    {
+-        log<level::WARNING>("BMC dump accepts no additional parameters");
+-    }
+     std::vector<std::string> paths;
+     auto id = captureDump(Type::UserRequested, paths);
+ 
+diff --git a/dump_manager_bmc.hpp b/dump_manager_bmc.hpp
+index 24cfd0c..79a7bc7 100644
+--- a/dump_manager_bmc.hpp
++++ b/dump_manager_bmc.hpp
+@@ -94,8 +94,7 @@ class Manager : virtual public CreateIface,
+      *
+      *  @return object_path - The object path of the new dump entry.
+      */
+-    sdbusplus::message::object_path
+-        createDump(std::map<std::string, std::string> params) override;
++    sdbusplus::message::object_path createDump() override;
+ 
+   private:
+     /** @brief Create Dump entry d-bus object
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dump/phosphor-debug-collector_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dump/phosphor-debug-collector_%.bbappend
@@ -1,4 +1,4 @@
 FILESEXTRAPATHS_prepend_olympus-nuvoton := "${THISDIR}/${PN}:"
 
 EXTRA_OECONF += "BMC_DUMP_TOTAL_SIZE=500 "
-SRC_URI += "file://0001-block-sigchld-signal.patch"
+SRC_URI += "file://0001-fix-bmc-dump-cannot-accept-no-additional-parameters.patch"


### PR DESCRIPTION
Symptom:
"Create User Initiated Dump" this keyword will issue a REST POST request to create BMC dump, but response got fail message "message": "400 Bad Request" then cause dump test items were all failed.
POST Request using : uri=/xyz/openbmc_project/dump/bmc/action/CreateDump <Response [400]>

Root cause:
The existing method CreateDump in xyz.openbmc_project.Dump.Create doesn't accept any parameters. But, IBM add a type of IBM host-specific dump requires additional parameters to create user-initiated dumps.
This feature of IBM is disabled by default in meson.build/phosphor-debug-collector in OpenBMC.

However, createDump method should keep original design no need any parameters, but createDump be changed to accept two params createDump(std::map<std::string, std::string> params) override, even this IBM feature is disabled. And Test Bmc Dump item always request POST without any parameters, thus cause this fail symptom.

Solution:
1. phosphor-debug-collector: patch for fixing bmc dump cannot accept no additional parameters.
2. phosphor-dbus-interface: patch for removing parameters of CreateDump method.

Tested:
Create BMC Dump
1. curl -k -H "X-Auth-Token: $token" -X POST https://${bmc}/xyz/openbmc_project/dump/bmc/action/CreateDump -d '{"data": []}'
2. busctl --verbose call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/bmc xyz.openbmc_project.Dump.Create CreateDump
3. https://${bmc}/xyz/openbmc_project/dump/bmc/entry/1

Signed-off-by: Tim Lee <timlee660101@gmail.com>