### PR TITLE
meta-quanta: olympus-nuvoton: fix ipmid cannot read fru data

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -12,6 +12,7 @@ EXTRA_OECONF_olympus-nuvoton = " \
     --enable-boot-flag-safe-mode-support \
     SENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/olympus-nuvoton-yaml-config/ipmi-sensors.yaml \
     FRU_YAML_GEN=${STAGING_DIR_HOST}${datadir}/olympus-nuvoton-yaml-config/ipmi-fru-read.yaml \
+    --disable-dynamic_sensors \
     "
 
 SRC_URI_append_olympus-nuvoton = " file://phosphor-ipmi-host.service"


### PR DESCRIPTION
Disalbe dynamic sensors feature in ipmid to avoid getting FRU data via
entity manager.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
