### PR TITLE
meta-quanta: olympus-nuvoton: dump: change return type to dump entry …

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dbus/phosphor-dbus-interfaces/0030-remove-parameters-of-CreateDump.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dbus/phosphor-dbus-interfaces/0030-remove-parameters-of-CreateDump.patch
@@ -1,18 +1,18 @@
-From 2056ef3100a97e822decfb11d587c2dd6a762257 Mon Sep 17 00:00:00 2001
+From 23177567c7b3abdc44d1b52e46d79b1932e2bee3 Mon Sep 17 00:00:00 2001
 From: Tim Lee <timlee660101@gmail.com>
-Date: Tue, 11 May 2021 15:44:06 +0800
+Date: Thu, 13 May 2021 17:02:17 +0800
 Subject: [PATCH 30/30] remove parameters of CreateDump
 
 Signed-off-by: Tim Lee <timlee660101@gmail.com>
 ---
- .../Dump/Create.interface.yaml                | 19 -------------------
- 1 file changed, 19 deletions(-)
+ .../Dump/Create.interface.yaml                | 27 +++----------------
+ 1 file changed, 3 insertions(+), 24 deletions(-)
 
 diff --git a/xyz/openbmc_project/Dump/Create.interface.yaml b/xyz/openbmc_project/Dump/Create.interface.yaml
-index b83798a9..965ab118 100644
+index b83798a9..8a244183 100644
 --- a/xyz/openbmc_project/Dump/Create.interface.yaml
 +++ b/xyz/openbmc_project/Dump/Create.interface.yaml
-@@ -14,25 +14,6 @@ methods:
+@@ -14,32 +14,11 @@ methods:
      - name: CreateDump
        description: >
            Method to create a manual Dump.
@@ -36,8 +36,18 @@ index b83798a9..965ab118 100644
 -            ends up in AdditionaData like:
 -              ["KEY1=value1", "KEY2=value2"]
        returns:
-         - name: Path
-           type: object_path
+-        - name: Path
+-          type: object_path
++        - name: Id
++          type: uint32
+           description: >
+-            The object path of the object that implements
+-            xyz.openbmc_project.Common.Progress to track the progress
+-            of the dump
++            The Dump entry id number.
+       errors:
+         - xyz.openbmc_project.Common.File.Error.Write
+         - xyz.openbmc_project.Dump.Create.Error.Disabled
 -- 
 2.17.1
 

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dump/phosphor-debug-collector/0002-return-dump-entry-id-number-instead-of-object-path.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dump/phosphor-debug-collector/0002-return-dump-entry-id-number-instead-of-object-path.patch
@@ -1,0 +1,72 @@
+From 643cd26b3aad29107a3e91420b8aeab4362d0a43 Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Thu, 13 May 2021 16:20:43 +0800
+Subject: [PATCH 2/2] return dump entry id number instead of object path
+
+Signed-off-by: Tim Lee <timlee660101@gmail.com>
+---
+ dump_manager_bmc.cpp | 26 ++------------------------
+ dump_manager_bmc.hpp |  6 +++---
+ 2 files changed, 5 insertions(+), 27 deletions(-)
+
+diff --git a/dump_manager_bmc.cpp b/dump_manager_bmc.cpp
+index 0236e46..a7c0e57 100644
+--- a/dump_manager_bmc.cpp
++++ b/dump_manager_bmc.cpp
+@@ -35,32 +35,10 @@ void Manager::create(Type type, std::vector<std::string> fullPaths)
+ 
+ } // namespace internal
+ 
+-sdbusplus::message::object_path Manager::createDump()
++uint32_t Manager::createDump()
+ {
+     std::vector<std::string> paths;
+-    auto id = captureDump(Type::UserRequested, paths);
+-
+-    // Entry Object path.
+-    auto objPath = fs::path(baseEntryPath) / std::to_string(id);
+-
+-    try
+-    {
+-        std::time_t timeStamp = std::time(nullptr);
+-        entries.insert(std::make_pair(
+-            id, std::make_unique<bmc::Entry>(
+-                    bus, objPath.c_str(), id, timeStamp, 0, std::string(),
+-                    phosphor::dump::OperationStatus::InProgress, *this)));
+-    }
+-    catch (const std::invalid_argument& e)
+-    {
+-        log<level::ERR>(e.what());
+-        log<level::ERR>("Error in creating dump entry",
+-                        entry("OBJECTPATH=%s", objPath.c_str()),
+-                        entry("ID=%d", id));
+-        elog<InternalFailure>();
+-    }
+-
+-    return objPath.string();
++    return captureDump(Type::UserRequested, paths);
+ }
+ 
+ uint32_t Manager::captureDump(Type type,
+diff --git a/dump_manager_bmc.hpp b/dump_manager_bmc.hpp
+index 79a7bc7..49ba573 100644
+--- a/dump_manager_bmc.hpp
++++ b/dump_manager_bmc.hpp
+@@ -90,11 +90,11 @@ class Manager : virtual public CreateIface,
+     void restore() override;
+ 
+     /** @brief Implementation for CreateDump
+-     *  Method to create a BMC dump entry when user requests for a new BMC dump
++     *  Method to create Dump.
+      *
+-     *  @return object_path - The object path of the new dump entry.
++     *  @return id - The Dump entry id number.
+      */
+-    sdbusplus::message::object_path createDump() override;
++    uint32_t createDump() override;
+ 
+   private:
+     /** @brief Create Dump entry d-bus object
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dump/phosphor-debug-collector_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dump/phosphor-debug-collector_%.bbappend
@@ -2,3 +2,4 @@ FILESEXTRAPATHS_prepend_olympus-nuvoton := "${THISDIR}/${PN}:"
 
 EXTRA_OECONF += "BMC_DUMP_TOTAL_SIZE=500 "
 SRC_URI += "file://0001-fix-bmc-dump-cannot-accept-no-additional-parameters.patch"
+SRC_URI += "file://0002-return-dump-entry-id-number-instead-of-object-path.patch"


### PR DESCRIPTION
…id for CreateDump

Symptom:
Evaluating expression '/xyz/openbmc_project/dump/bmc/entry/1 == None' failed: SyntaxError: invalid syntax.
The cause auto test bmc dump item failed.

Root cause:
Due to CreateDump change return type from uint32_t to string for return full object path.
But, auto test bmc dump item need to check dump entry id not full object path. That's cause invalid syntax fail.

Solution:
Change return type from object path to uint32_t for createDump()

Tested:
robot redfish/extended/test_bmc_dump.robot

Signed-off-by: Tim Lee <timlee660101@gmail.com>