### PR TITLE
[WA]meta-quanta: olympus-nuvoton: bmcweb: revert task for tftp change

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0001-Revert-Tasks-for-TFTP-upload.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0001-Revert-Tasks-for-TFTP-upload.patch
@@ -1,0 +1,26 @@
+From 298a2dfcac1c32a9ea0350e04cc4ca06a1ee6a8d Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Fri, 14 May 2021 09:24:12 +0800
+Subject: [PATCH] Revert "Tasks for TFTP upload"
+
+This reverts commit d7a596bd7e449cdbfb92e961cc7049f80775e61f.
+---
+ redfish-core/lib/update_service.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/redfish-core/lib/update_service.hpp b/redfish-core/lib/update_service.hpp
+index ca1234f..7790575 100644
+--- a/redfish-core/lib/update_service.hpp
++++ b/redfish-core/lib/update_service.hpp
+@@ -480,7 +480,7 @@ class UpdateServiceActionsSimpleUpdate : public Node
+         // Setup callback for when new software detected
+         // Give TFTP 10 minutes to complete
+         monitorForSoftwareAvailable(
+-            asyncResp, req,
++            nullptr, req,
+             "/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate",
+             600);
+ 
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -4,6 +4,7 @@ SRC_URI_append_olympus-nuvoton = " file://0003-Redfish-Add-power-metrics-support
 SRC_URI_append_olympus-nuvoton = " file://0005-bmcweb-chassis-add-indicatorLED-support.patch"
 SRC_URI_append_olympus-nuvoton = " file://0014-add-config-to-config-virtual-media-buffer-size.patch"
 SRC_URI_append_olympus-nuvoton = " file://0015-redfish-log-service-corrects-odata-id-of-bmc-journal.patch"
+SRC_URI_append_olympus-nuvoton = " file://0001-Revert-Tasks-for-TFTP-upload.patch"
 
 # Enable CPU Log and Raw PECI support
 EXTRA_OEMESON_append = " -Dredfish-cpu-log=enabled"


### PR DESCRIPTION
Disalbe dynamic sensors feature in ipmid to avoid getting FRU data via
entity manager.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
