### PR TITLE
meta-quanta: olympus-nuvoton: dump: return error response when bad db…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0017-dbus-rest-return-error-response-when-bad-dbus-reques.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0017-dbus-rest-return-error-response-when-bad-dbus-reques.patch
@@ -1,0 +1,28 @@
+From a92496c98c29a48f382f91157fa8c7e3142d0c66 Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Thu, 20 May 2021 13:30:02 +0800
+Subject: [PATCH 17/17] dbus rest return error response when bad dbus request
+
+Signed-off-by: Tim Lee <timlee660101@gmail.com>
+---
+ include/openbmc_dbus_rest.hpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/include/openbmc_dbus_rest.hpp b/include/openbmc_dbus_rest.hpp
+index 581e40b31..4cc740693 100644
+--- a/include/openbmc_dbus_rest.hpp
++++ b/include/openbmc_dbus_rest.hpp
+@@ -1695,6 +1695,10 @@ inline void handleGet(crow::Response& res, std::string& objectPath,
+                             {
+                                 BMCWEB_LOG_ERROR << "Bad dbus request error: "
+                                                  << ec2;
++                                setErrorResponse(res, boost::beast::http::status::not_found,
++                                                    notFoundDesc, notFoundMsg);
++                                res.end();
++                                return;
+                             }
+                             else
+                             {
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -5,6 +5,7 @@ SRC_URI_append_olympus-nuvoton = " file://0005-bmcweb-chassis-add-indicatorLED-s
 SRC_URI_append_olympus-nuvoton = " file://0014-add-config-to-config-virtual-media-buffer-size.patch"
 SRC_URI_append_olympus-nuvoton = " file://0015-redfish-log-service-corrects-odata-id-of-bmc-journal.patch"
 SRC_URI_append_olympus-nuvoton = " file://0016-manager-do-not-update-value-if-string-is-empty.patch"
+SRC_URI_append_olympus-nuvoton = " file://0017-dbus-rest-return-error-response-when-bad-dbus-reques.patch"
 
 # Enable CPU Log and Raw PECI support
 EXTRA_OEMESON_append = " -Dredfish-cpu-log=enabled"


### PR DESCRIPTION
…us-request in dbus rest

Symptom:
"Create Two User Initiated Dump And Delete One" of "Test Bmc Dump" test failed.

Root cause:
handleGet() function in bmcweb should be return setErrorResponse() when doing get request for deleted bmc dump before.
But code into else section to print "message 200 OK", not "message 404 Not Found". Response should be [404] not [200].

Due to /xyz/openbmc_project/dump/bmc/entry/1 object path already be deleted when bmc dump log be deleted.
Thus when doing get request again then we will found that async_send() call return "Bad dbus request error".
After that get request will go to else condition and print "message 200 OK" with "data" is empty.

Solution:
Add setErrorResponse with not found error message return when async_send return "Bad dbus request error:"

Tested:
robot -t Create_Two_User_Initiated_Dump_And_Delete_One redfish/extended/test_bmc_dump.robot

Create Two User Initiated Dump And Delete One :: Create two dumps ... | PASS |
Test Bmc Dump :: Test dump functionality of OpenBMC.                          | PASS |
1 critical test, 1 passed, 0 failed
1 test total, 1 passed, 0 failed

Signed-off-by: Tim Lee <timlee660101@gmail.com>