### PR TITLE
meta-quanta: olympus-nuvoton: bmcweb: fix createDump functionality of…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0018-redfish-log_services-fix-createDump-functionality.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0018-redfish-log_services-fix-createDump-functionality.patch
@@ -1,0 +1,79 @@
+From 994bdbb6a349b28fa8c0a6377e2218d2c0ed5d79 Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Mon, 7 Jun 2021 16:44:05 +0800
+Subject: [PATCH 18/18] redfish: log_services: fix createDump functionality
+
+Signed-off-by: Tim Lee <timlee660101@gmail.com>
+---
+ redfish-core/lib/log_services.hpp | 43 ++++++++++++++++++++++++++++---
+ 1 file changed, 40 insertions(+), 3 deletions(-)
+
+diff --git a/redfish-core/lib/log_services.hpp b/redfish-core/lib/log_services.hpp
+index efed76463..7c90ffbc1 100644
+--- a/redfish-core/lib/log_services.hpp
++++ b/redfish-core/lib/log_services.hpp
+@@ -812,21 +812,58 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+ 
+     crow::connections::systemBus->async_method_call(
+         [asyncResp, req, dumpPath, dumpType](const boost::system::error_code ec,
+-                                             const uint32_t& dumpId) {
++                                             const sdbusplus::message::object_path& objPath) {
+             if (ec)
+             {
+                 BMCWEB_LOG_ERROR << "CreateDump resp_handler got error " << ec;
+                 messages::internalError(asyncResp->res);
+                 return;
+             }
++
++            std::string path(objPath.str);
++            auto pos = path.rfind("/");
++            if (pos == std::string::npos)
++            {
++                return;
++            }
++
++            auto idString = path.substr(pos + 1);
++            auto dumpId = std::stoul(idString);
+             BMCWEB_LOG_DEBUG << "Dump Created. Id: " << dumpId;
+ 
+-            createDumpTaskCallback(req, asyncResp, dumpId, dumpPath, dumpType);
++            std::shared_ptr<task::TaskData> task = task::TaskData::createTask(
++                [dumpPath, dumpId](boost::system::error_code err, sdbusplus::message::message&,
++                    const std::shared_ptr<task::TaskData>& taskData) {
++                    if (err)
++                    {
++                        BMCWEB_LOG_ERROR << "CreateDump createTask got error" << err;
++                        taskData->state = "Cancelled";
++                        return task::completed;
++                    }
++
++                    nlohmann::json retMessage = messages::success();
++                    taskData->messages.emplace_back(retMessage);
++
++                    std::string headerLoc =
++                        "Location: " + dumpPath + std::to_string(dumpId);
++                    taskData->payload->httpHeaders.emplace_back(
++                        std::move(headerLoc));
++
++                    taskData->state = "Completed";
++                    return task::completed;
++                },
++                "type='signal',interface='org.freedesktop.DBus."
++                "Properties',"
++                "member='PropertiesChanged',path='" +
++                objPath.str + "'");
++            task->startTimer(std::chrono::minutes(5));
++            task->populateResp(asyncResp->res);
++            task->payload.emplace(req);
+         },
+         "xyz.openbmc_project.Dump.Manager",
+         "/xyz/openbmc_project/dump/" +
+             std::string(boost::algorithm::to_lower_copy(dumpType)),
+-        "xyz.openbmc_project.Dump.Create", "CreateDump");
++        "xyz.openbmc_project.Dump.Create", "CreateDump", std::array<std::pair<const char*, const char*>, 0>());
+ }
+ 
+ inline void clearDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -6,6 +6,7 @@ SRC_URI_append_olympus-nuvoton = " file://0003-Redfish-Add-power-metrics-support
 SRC_URI_append_olympus-nuvoton = " file://0005-bmcweb-chassis-add-indicatorLED-support.patch"
 SRC_URI_append_olympus-nuvoton = " file://0014-add-config-to-config-virtual-media-buffer-size.patch"
 SRC_URI_append_olympus-nuvoton = " file://0016-manager-do-not-update-value-if-string-is-empty.patch"
+SRC_URI_append_olympus-nuvoton = " file://0018-redfish-log_services-fix-createDump-functionality.patch"
 
 # Enable CPU Log and Raw PECI support
 #EXTRA_OEMESON_append = " -Dredfish-cpu-log=enabled"


### PR DESCRIPTION
… redfish

Symptom:
CreateDump resp_handler got error in bmcweb then report internal error.

Root cause:
1. createDump() function in bmcweb didn't support parameters as CreateDump() function
   in phosphor-debug-collector then cause create dump through redfish all test items are failed.
2. createTask() function called by createDumpTaskCallback() in bmcweb didn't handle well with
   member InterfacesAdded then cause match rule didn't match and return dbus error.

Solution:
1. Modify sync_method_call with object_path return type for CreateDump method call.
2. Modify match rule with member PropertiesChanged for bmc dump entry path.

Tested:
robot test for redfish/managers/test_bmc_dumps.robot

Signed-off-by: Tim Lee <timlee660101@gmail.com>