### PR TITLE
meta-buv-runbmc: fix build break

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -1,7 +1,8 @@
 SRC_URI_remove_buv-runbmc = "git://github.com/openbmc/phosphor-host-ipmid"
 SRC_URI_prepend_buv-runbmc = "git://github.com/Nuvoton-Israel/phosphor-host-ipmid"
 
-SRCREV := "18ef684602df1a24ace76f16c24d143ec347c237"
+inherit buv-entity-utils
+SRCREV_buv-runbmc = "3f553e155500938a51a06173633c51be87ec463a"
 
 DEPENDS_append_buv-runbmc = " buv-runbmc-yaml-config"
 
@@ -10,6 +11,8 @@ EXTRA_OECONF_buv-runbmc = " \
     SENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/buv-runbmc-yaml-config/ipmi-sensors.yaml \
     FRU_YAML_GEN=${STAGING_DIR_HOST}${datadir}/buv-runbmc-yaml-config/ipmi-fru-read.yaml \
     "
+EXTRA_OECONF_append_buv-runbmc = " \
+    ${@entity_enabled(d, '', ' --disable-dynamic_sensors')}"
 
 do_install_append_buv-runbmc(){
   install -d ${D}${includedir}/phosphor-ipmi-host

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/sensors/dbus-sensors_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/sensors/dbus-sensors_%.bbappend
@@ -1,8 +1,6 @@
 FILESEXTRAPATHS_prepend_buv-runbmc := "${THISDIR}/${PN}:"
 
 SRC_URI_append_buv-runbmc = " \
-    file://0001-add-Unit-property-in-Value-interface.patch \
-    file://0002-add-Scale-d-bus-interface-property.patch \
     file://0003-Avoid-power-state-always-ADC-cannot-trigger-alarm.patch \
     file://0004-wait-mapper-for-avoid-failed-to-find-log.patch \
     "


### PR DESCRIPTION
Update phosphor-ipmi-host version and remove dbus sensor patches
to fix BUV board build break

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Note!!
Only fix build break, distro buv-entity a lot of functions may not work now...
