### PR TITLE
meta-quanta: olympus-nuvoton: dump: adjust total dump files size in d…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dump/phosphor-debug-collector/0001-adjust-current-size-of-dump-directory-to-near-linux-.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dump/phosphor-debug-collector/0001-adjust-current-size-of-dump-directory-to-near-linux-.patch
@@ -1,0 +1,41 @@
+From ae07d5e055d795bad3cf3353c71f2097b88ebc51 Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Wed, 23 Jun 2021 13:53:43 +0800
+Subject: [PATCH] adjust current size of dump directory to near linux du
+ command
+
+Signed-off-by: Tim Lee <timlee660101@gmail.com>
+---
+ dump_manager_bmc.cpp | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/dump_manager_bmc.cpp b/dump_manager_bmc.cpp
+index 931c0eb..d5bff09 100644
+--- a/dump_manager_bmc.cpp
++++ b/dump_manager_bmc.cpp
+@@ -15,6 +15,7 @@
+ 
+ #include <ctime>
+ #include <regex>
++#include <cmath>
+ 
+ namespace phosphor
+ {
+@@ -249,13 +250,10 @@ size_t Manager::getAllowedSize()
+     {
+         if (!std::filesystem::is_directory(p))
+         {
+-            size += std::filesystem::file_size(p);
++            size += std::ceil((std::filesystem::file_size(p) / 1024.0));
+         }
+     }
+ 
+-    // Convert size into KB
+-    size = size / 1024;
+-
+     // Set the Dump size to Maximum  if the free space is greater than
+     // Dump max size otherwise return the available size.
+ 
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dump/phosphor-debug-collector_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dump/phosphor-debug-collector_%.bbappend
@@ -1,4 +1,4 @@
 FILESEXTRAPATHS_prepend_olympus-nuvoton := "${THISDIR}/${PN}:"
 
 EXTRA_OECONF += "BMC_DUMP_TOTAL_SIZE=500 "
-SRC_URI += "file://0001-block-sigchld-signal.patch"
+SRC_URI += "file://0001-adjust-current-size-of-dump-directory-to-near-linux-.patch"


### PR DESCRIPTION
…ump directory

Symptom:
"Verify Maximum BMC Dump Creation" test item got failed sometimes.

Root cause:
Phosphor-debug-collector is using std::filesystem::file_size to calculate total dump log files in dump directory. Then divide 1024 convert size to KB. However, auto test robot is using linux command "du -s" to calculate total size in dump directory. The calculate result is different between both then cause test got failed sometimes.

For example:
316	du -s /var/lib/phosphor-debug-collector/dumps

du -sh /var/lib/phosphor-debug-collector/dumps
315.5K  /var/lib/phosphor-debug-collector/dumps

du -sh /var/lib/phosphor-debug-collector/dumps/1
97.5K   /var/lib/phosphor-debug-collector/dumps/1
du -sh /var/lib/phosphor-debug-collector/dumps/2
105.5K  /var/lib/phosphor-debug-collector/dumps/2
du -sh /var/lib/phosphor-debug-collector/dumps/3
112.5K  /var/lib/phosphor-debug-collector/dumps/3

Solution:
In phosphor-debug-collector, calculate each dump file with std::ceil() and convert size to KB then calculate total dump files size in dump directory.

Tested:
Run 5 times above for robot -t Verify_Maximum_BMC_Dump_Creation redfish/managers/test_bmc_dumps.robot
Verify Maximum BMC Dump Creation :: Create maximum BMC dump and ve... | PASS |
1 critical test, 1 passed, 0 failed
1 test total, 1 passed, 0 failed

Signed-off-by: Tim Lee <timlee660101@gmail.com>