### PR TITLE
meta-nuvoton: webui-vue: Porting features from phosphor-webui

### DIFF
--- a/meta-nuvoton/recipes-phosphor/webui/webui-vue/0002-Add-Nuvoton-MCU-firmware-support.patch
+++ b/meta-nuvoton/recipes-phosphor/webui/webui-vue/0002-Add-Nuvoton-MCU-firmware-support.patch
@@ -1,0 +1,143 @@
+From 155799c9bd45e80fee3c260dcbba36fa84dabefd Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Tue, 29 Jun 2021 10:34:23 +0800
+Subject: [PATCH 1/2] Add Nuvoton MCU firmware support
+
+Signed-off-by: Brian Ma <chma0@nuvoton.com>
+---
+ src/locales/en-US.json                        |  1 +
+ .../modules/Configuration/FirmwareStore.js    |  9 +++++
+ src/views/Configuration/Firmware/Firmware.vue |  5 +++
+ .../Firmware/FirmwareCardsMcu.vue             | 37 +++++++++++++++++++
+ 4 files changed, 52 insertions(+)
+ create mode 100644 src/views/Configuration/Firmware/FirmwareCardsMcu.vue
+
+diff --git a/src/locales/en-US.json b/src/locales/en-US.json
+index 437ce03..c087f82 100644
+--- a/src/locales/en-US.json
++++ b/src/locales/en-US.json
+@@ -310,6 +310,7 @@
+     "sectionTitleBmcCards": "BMC",
+     "sectionTitleBmcCardsCombined": "BMC and server",
+     "sectionTitleHostCards": "Host",
++    "sectionTitleMcuCards": "MCU",
+     "sectionTitleUpdateFirmware": "Update firmware",
+     "alert": {
+       "operationInProgress": "Server power operation in progress.",
+diff --git a/src/store/modules/Configuration/FirmwareStore.js b/src/store/modules/Configuration/FirmwareStore.js
+index c6639ff..79f8638 100644
+--- a/src/store/modules/Configuration/FirmwareStore.js
++++ b/src/store/modules/Configuration/FirmwareStore.js
+@@ -6,6 +6,7 @@ const FirmwareStore = {
+   state: {
+     bmcFirmware: [],
+     hostFirmware: [],
++    mcuFirmware: null,
+     bmcActiveFirmwareId: null,
+     hostActiveFirmwareId: null,
+     applyTime: null,
+@@ -24,6 +25,7 @@ const FirmwareStore = {
+         (firmware) => firmware.id === state.hostActiveFirmwareId
+       );
+     },
++    mcuFirmware: (state) => state.mcuFirmware,
+     backupBmcFirmware: (state) => {
+       return state.bmcFirmware.find(
+         (firmware) => firmware.id !== state.bmcActiveFirmwareId
+@@ -40,6 +42,7 @@ const FirmwareStore = {
+     setActiveHostFirmwareId: (state, id) => (state.hostActiveFirmwareId = id),
+     setBmcFirmware: (state, firmware) => (state.bmcFirmware = firmware),
+     setHostFirmware: (state, firmware) => (state.hostFirmware = firmware),
++    setMcuFirmware: (state, firmware) => (state.mcuFirmware = firmware),
+     setApplyTime: (state, applyTime) => (state.applyTime = applyTime),
+     setTftpUploadAvailable: (state, tftpAvailable) =>
+       (state.tftpAvailable = tftpAvailable),
+@@ -81,6 +84,12 @@ const FirmwareStore = {
+           const bmcFirmware = [];
+           const hostFirmware = [];
+           response.forEach(({ data }) => {
++            const Description = data?.Description;
++            if (Description === 'MCU image') {
++              // there is only one MCU firmware, and we just care version
++              const mcuFirmware = data?.Version;
++              commit('setMcuFirmware', mcuFirmware);
++            }
+             const firmwareType = data?.RelatedItem?.[0]?.['@odata.id']
+               .split('/')
+               .pop();
+diff --git a/src/views/Configuration/Firmware/Firmware.vue b/src/views/Configuration/Firmware/Firmware.vue
+index a2acb9b..bfb9b78 100644
+--- a/src/views/Configuration/Firmware/Firmware.vue
++++ b/src/views/Configuration/Firmware/Firmware.vue
+@@ -14,6 +14,9 @@
+ 
+         <!-- Host Firmware -->
+         <host-cards v-if="!isSingleFileUploadEnabled" />
++
++        <!-- MCU Firmware -->
++        <mcu-cards />
+       </b-col>
+     </b-row>
+ 
+@@ -39,6 +42,7 @@ import AlertsServerPower from './FirmwareAlertServerPower';
+ import BmcCards from './FirmwareCardsBmc';
+ import FormUpdate from './FirmwareFormUpdate';
+ import HostCards from './FirmwareCardsHost';
++import McuCards from './FirmwareCardsMcu';
+ import PageSection from '@/components/Global/PageSection';
+ import PageTitle from '@/components/Global/PageTitle';
+ 
+@@ -51,6 +55,7 @@ export default {
+     BmcCards,
+     FormUpdate,
+     HostCards,
++    McuCards,
+     PageSection,
+     PageTitle,
+   },
+diff --git a/src/views/Configuration/Firmware/FirmwareCardsMcu.vue b/src/views/Configuration/Firmware/FirmwareCardsMcu.vue
+new file mode 100644
+index 0000000..3d5641e
+--- /dev/null
++++ b/src/views/Configuration/Firmware/FirmwareCardsMcu.vue
+@@ -0,0 +1,37 @@
++<template>
++  <page-section :section-title="$t('pageFirmware.sectionTitleMcuCards')">
++    <b-card-group deck>
++      <!-- Running image -->
++      <b-card>
++        <template #header>
++          <p class="font-weight-bold m-0">
++            {{ $t('pageFirmware.cardTitleRunning') }}
++          </p>
++        </template>
++        <dl class="mb-0">
++          <dt>{{ $t('pageFirmware.cardBodyVersion') }}</dt>
++          <dd class="mb-0">{{ runningVersion }}</dd>
++        </dl>
++      </b-card>
++    </b-card-group>
++  </page-section>
++</template>
++
++<script>
++import PageSection from '@/components/Global/PageSection';
++
++export default {
++  components: { PageSection },
++  computed: {
++    runningVersion() {
++      return this.$store.getters['firmware/mcuFirmware'] || '--';
++    },
++  },
++};
++</script>
++
++<style lang="scss" scoped>
++.page-section {
++  margin-top: -$spacer * 1.5;
++}
++</style>
+-- 
+2.17.1
+

--- a/meta-nuvoton/recipes-phosphor/webui/webui-vue/0003-DEMO-Add-reboot-cause-support.patch
+++ b/meta-nuvoton/recipes-phosphor/webui/webui-vue/0003-DEMO-Add-reboot-cause-support.patch
@@ -1,0 +1,105 @@
+From a9a54e019f0423d583794b71e47ff4248febe7c8 Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Tue, 29 Jun 2021 10:42:42 +0800
+Subject: [PATCH 2/2] [DEMO]Add reboot cause support
+
+---
+ src/locales/en-US.json                    |  1 +
+ src/store/modules/Control/ControlStore.js | 24 +++++++++++++++++++++++
+ src/views/Control/RebootBmc/RebootBmc.vue |  7 +++++++
+ 3 files changed, 32 insertions(+)
+
+diff --git a/src/locales/en-US.json b/src/locales/en-US.json
+index c087f82..1bc7704 100644
+--- a/src/locales/en-US.json
++++ b/src/locales/en-US.json
+@@ -635,6 +635,7 @@
+   "pageRebootBmc": {
+     "lastReboot": "Last BMC reboot",
+     "rebootBmc": "Reboot BMC",
++    "rebootCause": "Reboot cause:",
+     "rebootInformation": "When you reboot the BMC, your web browser loses contact with the BMC for several minutes. When the BMC is back online, you may need to log in again.",
+     "modal": {
+       "confirmMessage": "Are you sure you want to reboot the BMC?",
+diff --git a/src/store/modules/Control/ControlStore.js b/src/store/modules/Control/ControlStore.js
+index 9b8bf73..09e8b95 100644
+--- a/src/store/modules/Control/ControlStore.js
++++ b/src/store/modules/Control/ControlStore.js
+@@ -34,11 +34,13 @@ const ControlStore = {
+     isOperationInProgress: false,
+     lastPowerOperationTime: null,
+     lastBmcRebootTime: null,
++    lastBmcRebootCause: null,
+   },
+   getters: {
+     isOperationInProgress: (state) => state.isOperationInProgress,
+     lastPowerOperationTime: (state) => state.lastPowerOperationTime,
+     lastBmcRebootTime: (state) => state.lastBmcRebootTime,
++    lastBmcRebootCause: (state) => state.lastBmcRebootCause,
+   },
+   mutations: {
+     setOperationInProgress: (state, inProgress) =>
+@@ -47,6 +49,8 @@ const ControlStore = {
+       (state.lastPowerOperationTime = lastPowerOperationTime),
+     setLastBmcRebootTime: (state, lastBmcRebootTime) =>
+       (state.lastBmcRebootTime = lastBmcRebootTime),
++    setLastBmcRebootCause: (state, lastBmcRebootCause) =>
++      (state.lastBmcRebootCause = lastBmcRebootCause),
+   },
+   actions: {
+     async getLastPowerOperationTime({ commit }) {
+@@ -62,6 +66,26 @@ const ControlStore = {
+         .catch((error) => console.log(error));
+     },
+     getLastBmcRebootTime({ commit }) {
++      // get reboot cause first
++      api
++        .get('/xyz/openbmc_project/state/bmc0/attr/LastRebootCause')
++        .then((response) => {
++          const lastRebootCause = response.data.data;
++          console.log(lastRebootCause);
++          if (
++            lastRebootCause === 'xyz.openbmc_project.State.BMC.RebootCause.POR'
++          ) {
++            commit('setLastBmcRebootCause', 'Power-On-Reset');
++          } else if (
++            lastRebootCause ===
++            'xyz.openbmc_project.State.BMC.RebootCause.Watchdog'
++          ) {
++            commit('setLastBmcRebootCause', 'Watchdog');
++          } else {
++            commit('setLastBmcRebootCause', 'Unknown');
++          }
++        })
++        .catch((error) => console.log(error));
+       return api
+         .get('/redfish/v1/Managers/bmc')
+         .then((response) => {
+diff --git a/src/views/Control/RebootBmc/RebootBmc.vue b/src/views/Control/RebootBmc/RebootBmc.vue
+index 900619c..910188e 100644
+--- a/src/views/Control/RebootBmc/RebootBmc.vue
++++ b/src/views/Control/RebootBmc/RebootBmc.vue
+@@ -15,6 +15,10 @@
+                   {{ lastBmcRebootTime | formatTime }}
+                 </dd>
+                 <dd v-else>--</dd>
++                <dd>
++                  {{ $t('pageRebootBmc.rebootCause') }}
++                  {{ lastBmcRebootCause }}
++                </dd>
+               </dl>
+             </b-col>
+           </b-row>
+@@ -51,6 +55,9 @@ export default {
+     lastBmcRebootTime() {
+       return this.$store.getters['controls/lastBmcRebootTime'];
+     },
++    lastBmcRebootCause() {
++      return this.$store.getters['controls/lastBmcRebootCause'] || '--';
++    },
+   },
+   created() {
+     this.startLoader();
+-- 
+2.17.1
+

--- a/meta-nuvoton/recipes-phosphor/webui/webui-vue_%.bbappend
+++ b/meta-nuvoton/recipes-phosphor/webui/webui-vue_%.bbappend
@@ -2,4 +2,6 @@ FILESEXTRAPATHS_append_nuvoton := ":${THISDIR}/${PN}"
 
 SRC_URI_append_nuvoton = " \
     file://0001-novnc-add-16-bit-hextile-support-for-nuvoton-ece-eng.patch \
+    file://0002-Add-Nuvoton-MCU-firmware-support.patch \
+    file://0003-DEMO-Add-reboot-cause-support.patch \
 "


### PR DESCRIPTION
1. Add Nuvoton MCU firmware support
2. Add show reboot casue support for demo purpose,
   this feature only work on xyz API, not redfish

Signed-off-by: Brian_Ma <chma0@nuvoton.com>


