### PR TITLE
meta-quanta: olympus-nuvoton: logging: fix meson build python command…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/logging/files/0001-build-meson-fix-python-command-parameter.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/logging/files/0001-build-meson-fix-python-command-parameter.patch
@@ -1,0 +1,35 @@
+From 46ac668b4fb56aaa4c3ce0392db7d098efeeca38 Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Thu, 8 Jul 2021 08:22:15 +0800
+Subject: [PATCH] build: meson fix python command parameter
+
+Signed-off-by: Tim Lee <timlee660101@gmail.com>
+---
+ meson.build | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index b2fe71e0..36c78e39 100644
+--- a/meson.build
++++ b/meson.build
+@@ -96,7 +96,7 @@ elog_lookup_gen = custom_target('elog-lookup.cpp'.underscorify(),
+         '-t', '',
+         '-m', '@INPUT1@',
+         '-y', yamldir,
+-        '-u', meson.current_source_dir() / '../tools/',
++        '-u', meson.current_source_dir() / 'tools/',
+         '-o', '@OUTPUT0@',
+     ],
+ )
+@@ -112,7 +112,7 @@ elog_process_gen = custom_target('elog-process-metadata.cpp'.underscorify(),
+         '-t', '',
+         '-m', '@INPUT1@',
+         '-y', yamldir,
+-        '-u', meson.current_source_dir() / '../tools/',
++        '-u', meson.current_source_dir() / 'tools/',
+         '-o', '@OUTPUT0@',
+     ],
+ )
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/logging/phosphor-logging_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/logging/phosphor-logging_%.bbappend
@@ -1,4 +1,7 @@
+FILESEXTRAPATHS_prepend_olympus-nuvoton := "${THISDIR}/files:"
+
+SRC_URI_append_olympus-nuvoton = " file://0001-build-meson-fix-python-command-parameter.patch"
+
 OBMC_YAML_PROVIDER_RECIPES_append_olympus-nuvoton = " \
     olympus-nuvoton-debug-collector-yaml-provider.bb \
     "
-


### PR DESCRIPTION
… parameter

Symptom:
Callout related test items got failed when running test test_association.robot

Root cause:
According content get from /xyz/openbmc_project/logging/entry/1.
We found that "Associations" data content doesn't include "callout" property.
And "AdditionalData" data content doesn't add "CALLOUT_DEVICE_PATH_TEST"
association correctly. Then cause test_association.robot got failed.

https://10.103.152.249/xyz/openbmc_project/logging/entry/1
"data": {
	"AdditionalData": [
		"_PID=1858",
	],
	"Associations": [],
	"Id": 1,
	"Message": "example.xyz.openbmc_project.Example.Elog.TestCallout",
	"Path": "/var/lib/phosphor-logging/errors/1",
	"Purpose": "xyz.openbmc_project.Software.Version.VersionPurpose.BMC",
	"Resolved": false,
	"Severity": "xyz.openbmc_project.Logging.Entry.Level.Error",
	"Timestamp": 1625702968092,
	"UpdateTimestamp": 1625702968092,
	"Version": "2.10.0-rc1-1752-g77569257e"
},

Before using meson build for phosphor-logging, we didn't meet this issue.
We found g_errMetaMap didn't include below mapping in build\elog-lookup.cpp
{"example.xyz.openbmc_project.Example.Device.Callout",
{"CALLOUT_ERRNO_TEST","CALLOUT_DEVICE_PATH_TEST"}},

Also found meta didn't include below mapping in build\elog-process-metadata.cpp
{"CALLOUT_DEVICE_PATH_TEST", metadata::associations::build
<example::xyz::openbmc_project::Example::Device::
Callout::CALLOUT_DEVICE_PATH_TEST>},

The problem is cause by meson.build python wrong parameter
Then cause python cannot find example yaml file location
to generate correct mapping in elog-lookup.cpp and elog-process-metadata.cpp

Solution:
Fix python command parameter '-u' with 'tools/' instead of '../tools/'
command: [
        python_prog, '@INPUT0@',
        '-t', '',
        '-m', '@INPUT1@',
        '-y', yamldir,
        '-u', meson.current_source_dir() / 'tools/',
        '-o', '@OUTPUT0@',
    ],

Tested:
Verified content of https://10.103.152.249/xyz/openbmc_project/logging/entry/1
"AdditionalData": [
"_PID=1070",
"CALLOUT_DEVICE_PATH_TEST=/sys/devices/platform/ahb/ahb:apb/f0082000.i2c/..",
"CALLOUT_ERRNO_TEST=0",
"DEV_ADDR=0x0DEADEAD"
],
"Associations": [
"callout",
"fault",
"/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0"
]

And run robot test PASS at below related test items
robot -t Create Test Error Callout And Verify
robot -t Create Test Error Callout And Verify AdditionalData
robot -t Create Test Error Callout And Verify Associations
robot -t Create Test Error Callout And Delete

Signed-off-by: Tim Lee <timlee660101@gmail.com>