### PR TITLE
meta-quanta: olympus-nuvoton: smbios: fix present and functional prop…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-x86/smbios/smbios-mdrv2.bb
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-x86/smbios/smbios-mdrv2.bb
@@ -5,7 +5,7 @@ DESCRIPTION = "SMBIOS MDR version 2 service for Intel based platfrom"
 SRC_URI = "git://github.com/openbmc/smbios-mdr"
 SRCREV = "d23b84a7eb2be944b12e6539cf627f595b299fda"
 
-SRC_URI_append = " ${@entity_enabled(d, '', 'file://0001-Notify-inventory-manager-that-a-interface-needs-adde.patch')}"
+SRC_URI_append = " ${@entity_enabled(d, '', 'file://0003-smbios-fix-present-and-functional-property-to-true.patch')}"
 SRC_URI += "file://smbios2"
 SRC_URI += "file://smbios-mdrv2.service"
 

--- a/meta-quanta/meta-olympus-nuvoton/recipes-x86/smbios/smbios-mdrv2/0003-smbios-fix-present-and-functional-property-to-true.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-x86/smbios/smbios-mdrv2/0003-smbios-fix-present-and-functional-property-to-true.patch
@@ -1,0 +1,88 @@
+From 900cce8c015455b6331ac670b845276070f5794c Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Fri, 16 Jul 2021 17:38:34 +0800
+Subject: [PATCH 3/3] smbios: fix present and functional property to true
+
+Signed-off-by: Tim Lee <timlee660101@gmail.com>
+---
+ include/dimm.hpp | 9 ++++++++-
+ src/dimm.cpp     | 9 +++++++--
+ 2 files changed, 15 insertions(+), 3 deletions(-)
+
+diff --git a/include/dimm.hpp b/include/dimm.hpp
+index 4230ae4..c3bd9c7 100644
+--- a/include/dimm.hpp
++++ b/include/dimm.hpp
+@@ -20,6 +20,7 @@
+ #include <xyz/openbmc_project/Inventory/Decorator/Asset/server.hpp>
+ #include <xyz/openbmc_project/Inventory/Item/Dimm/server.hpp>
+ #include <xyz/openbmc_project/Inventory/Item/server.hpp>
++#include <xyz/openbmc_project/State/Decorator/OperationalStatus/server.hpp>
+ 
+ namespace phosphor
+ {
+@@ -36,7 +37,9 @@ class Dimm :
+     sdbusplus::server::object::object<
+         sdbusplus::xyz::openbmc_project::Inventory::Decorator::server::Asset>,
+     sdbusplus::server::object::object<
+-        sdbusplus::xyz::openbmc_project::Inventory::server::Item>
++        sdbusplus::xyz::openbmc_project::Inventory::server::Item>,
++    sdbusplus::server::object::object<
++        sdbusplus::xyz::openbmc_project::State::Decorator::server::OperationalStatus>
+ {
+   public:
+     Dimm() = delete;
+@@ -58,6 +61,9 @@ class Dimm :
+         sdbusplus::server::object::object<
+             sdbusplus::xyz::openbmc_project::Inventory::server::Item>(
+             bus, objPath.c_str()),
++        sdbusplus::server::object::object<
++            sdbusplus::xyz::openbmc_project::State::Decorator::server::OperationalStatus>(
++            bus, objPath.c_str()),
+         dimmNum(dimmId), storage(smbiosTableStorage)
+     {
+         memoryInfoUpdate();
+@@ -77,6 +83,7 @@ class Dimm :
+     std::string partNumber(std::string value) override;
+     uint8_t memoryAttributes(uint8_t value) override;
+     uint16_t memoryConfiguredSpeedInMhz(uint16_t value) override;
++    bool functional(bool value) override;
+ 
+   private:
+     uint8_t dimmNum;
+diff --git a/src/dimm.cpp b/src/dimm.cpp
+index e2cfbc6..b29b245 100644
+--- a/src/dimm.cpp
++++ b/src/dimm.cpp
+@@ -174,8 +174,6 @@ void Dimm::dimmManufacturer(const uint8_t positionNum, const uint8_t structLen,
+     bool val = true;
+     if (result == "NO DIMM")
+     {
+-        val = false;
+-
+         // No dimm presence so making manufacturer value as "" (instead of
+         // NO DIMM - as there won't be any manufacturer for DIMM which is not
+         // present).
+@@ -183,6 +181,7 @@ void Dimm::dimmManufacturer(const uint8_t positionNum, const uint8_t structLen,
+     }
+     manufacturer(result);
+     present(val);
++    functional(val);
+ }
+ 
+ std::string Dimm::manufacturer(std::string value)
+@@ -237,5 +236,11 @@ uint16_t Dimm::memoryConfiguredSpeedInMhz(uint16_t value)
+         memoryConfiguredSpeedInMhz(value);
+ }
+ 
++bool Dimm::functional(bool value)
++{
++    return sdbusplus::xyz::openbmc_project::State::Decorator::server::OperationalStatus::functional(
++        value);
++}
++
+ } // namespace smbios
+ } // namespace phosphor
+-- 
+2.17.1
+


### PR DESCRIPTION
…erty to true

Symptom:
Read "Present" property from "Verify SDR" keyword and got unexpected result.
Then cause test item "Test DIMM SDR Info At Power On" and
"Test DIMM SDR Info At Power Off" got failed.

Root cause:
Present property got false value from
/xyz/openbmc_project/inventory/system/chassis/motherboard/dimmX path
sometimes then cause ${presence_rest} got false that
didn't match expectation of auto test item.

Due to our previous patch try to notify inventory manager
to add present property and smbios also try to do the same thing recently.

Thus, we found that the present property be changed by smbios
and inventory manager simultaneously that cause present property
got inconsistent value.

Another "Functional" property didn't be added correctly according
current openbmc design.
Thus, we need to add functional property with default true value.

Solution:
Fix present property to true and add functional property with true by default.

Tested:
Run robot test -v Test_DIMM_SDR_Info_At_Power_Off ipmi/test_ipmi_sdr.robot
Test DIMM SDR Info At Power Off | PASS |
Test DIMM SDR Info At Power On  | PASS |

Signed-off-by: Tim Lee <timlee660101@gmail.com>