### PR TITLE
meta-quanta: olympus-nuvoton: packagegroup-obmc-apps

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
@@ -8,4 +8,6 @@ RDEPENDS_${PN}-inventory_remove = " \
        "
 RDEPENDS_${PN}-host-state-mgmt_append_olympus-nuvoton = " olympus-nuvoton-debug-collector"
 
-IMAGE_FEATURES_remove = "${@entity_enabled(d, '', 'obmc-fru-ipmi')}"
+RDEPENDS_${PN}-fru-ipmi_remove = " \
+       ${@entity_enabled(d, '','fru-device')} \
+       "


### PR DESCRIPTION
Fix fru-device package cannot remove in normal distro.
The IMAGE_FEATURES_remove not take effect in bbappend

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
