### PR TITLE
meta-quanta: meta-olympus-nuvoton: entity-manager: porting reload sensor

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/configuration/entity-manager/olympus-reload-sensor-off.service
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/configuration/entity-manager/olympus-reload-sensor-off.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Reload Sensor off Configuration
+
+[Service]
+ExecStart=/bin/sh -c "olympus-reload-sensor.sh 0"
+SyslogIdentifier=obmc-power-stop

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/configuration/entity-manager/olympus-reload-sensor-on.service
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/configuration/entity-manager/olympus-reload-sensor-on.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Reload Sensor On Configuration
+
+[Service]
+ExecStart=/bin/sh -c "olympus-reload-sensor.sh 1"
+SyslogIdentifier=obmc-power-start

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/configuration/entity-manager/olympus-reload-sensor.sh
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/configuration/entity-manager/olympus-reload-sensor.sh
@@ -1,0 +1,16 @@
+echo "reload sensor config $1"
+
+systemctl stop xyz.openbmc_project.Logging.IPMI.service
+if [ $1 = "1" ]; then
+    if [ ! -d "/sys/bus/platform/drivers/nuvoton-i2c/f0086000.i2c" ]; then
+        echo -n "f0086000.i2c" > /sys/bus/platform/drivers/nuvoton-i2c/bind
+    fi
+    sleep 10
+else
+    if [ -d "/sys/bus/platform/drivers/nuvoton-i2c/f0086000.i2c" ]; then
+        echo -n "f0086000.i2c" > /sys/bus/platform/drivers/nuvoton-i2c/unbind
+    fi
+    sleep 10
+fi
+systemctl restart xyz.openbmc_project.psusensor.service
+systemctl start xyz.openbmc_project.Logging.IPMI.service

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/configuration/entity-manager/xyz.openbmc_project.EntityManager.service
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/configuration/entity-manager/xyz.openbmc_project.EntityManager.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Entity Manager
-After=dbus.service
 Wants=xyz.openbmc_project.FruDevice.service
 After=xyz.openbmc_project.FruDevice.service
 
@@ -9,7 +8,9 @@ ExecStartPre=/bin/mkdir -p /var/configuration
 ExecStartPre=/bin/mkdir -p /tmp/overlays
 ExecStart=/usr/bin/entity-manager
 Restart=always
-Type=simple
+Type=dbus
+BusName=xyz.openbmc_project.EntityManager
 
 [Install]
 WantedBy=basic.target
+Alias=dbus-xyz.openbmc_project.EntityManager.service

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/configuration/entity-manager_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/configuration/entity-manager_%.bbappend
@@ -1,15 +1,36 @@
 FILESEXTRAPATHS_prepend_olympus-nuvoton := "${THISDIR}/${PN}:"
+inherit obmc-phosphor-systemd
 
 SRC_URI_append_olympus-nuvoton = " file://F0B_BMC_MB.json"
 SRC_URI_append_olympus-nuvoton = " file://xyz.openbmc_project.EntityManager.service"
 SRC_URI_append_olympus-nuvoton = " file://xyz.openbmc_project.FruDevice.service"
 
-FILES_${PN} += " ${datadir}/entity-manager/F0B_BMC_MB.json \
-               "
+FILES_${PN} += "${datadir}/entity-manager/F0B_BMC_MB.json"
+
+# reload sensor service files
+SRC_URI_append_olympus-nuvoton = " \
+    file://olympus-reload-sensor-on.service \
+    file://olympus-reload-sensor-off.service \
+    file://olympus-reload-sensor.sh"
+
+SYSTEMD_SERVICE_${PN}_append_olympus-nuvoton = " \
+    olympus-reload-sensor-on.service \
+    olympus-reload-sensor-off.service"
+
+SENSOR_ON_TMPL = "olympus-reload-sensor-on.service"
+CHASSIS_POWERON_TGTFMT = "obmc-chassis-poweron.target"
+ENABLE_POWER_FMT = "../${SENSOR_ON_TMPL}:${CHASSIS_POWERON_TGTFMT}.wants/${SENSOR_ON_TMPL}"
+SYSTEMD_LINK_${PN} += "${@compose_list(d, 'ENABLE_POWER_FMT', 'OBMC_CHASSIS_INSTANCES')}"
+
+SENSOR_OFF_TMPL = "olympus-reload-sensor-off.service"
+CHASSIS_POWEROFF_TGTFMT = "obmc-chassis-poweroff.target"
+DISABLE_POWER_FMT = "../${SENSOR_OFF_TMPL}:${CHASSIS_POWEROFF_TGTFMT}.wants/${SENSOR_OFF_TMPL}"
+SYSTEMD_LINK_${PN} += "${@compose_list(d, 'DISABLE_POWER_FMT', 'OBMC_CHASSIS_INSTANCES')}"
+
 do_install_append_olympus-nuvoton() {
     install -d ${D}${datadir}/entity-manager
     install -m 0644 -D ${WORKDIR}/F0B_BMC_MB.json \
         ${D}${datadir}/entity-manager/configurations/F0B_BMC_MB.json
-    install -m 644 ${WORKDIR}/xyz.openbmc_project.EntityManager.service ${D}${systemd_system_unitdir}/
-    install -m 644 ${WORKDIR}/xyz.openbmc_project.FruDevice.service ${D}${systemd_system_unitdir}/
+    install -d ${D}/${bindir}
+    install -m 0755 ${WORKDIR}/olympus-reload-sensor.sh ${D}${bindir}
 }

--- a/meta-quanta/meta-olympus-nuvoton/recipes-x86/chassis/x86-power-control_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-x86/chassis/x86-power-control_%.bbappend
@@ -1,23 +1,15 @@
 FILESEXTRAPATHS_prepend_olympus-nuvoton := "${THISDIR}/${PN}:"
-inherit entity-utils
 
-OLYMPUS_FILES = " \
-    file://0001-support-host-boot-progress.patch \
-    file://0002-add-support-chassis-on-off-target-files.patch \
-    file://obmc-mapper.target \
-    file://obmc-chassis-poweroff.target \
-    file://obmc-chassis-poweron.target \
-    "
 SRC_URI_append_olympus-nuvoton = " file://power-config-host0.json"
-SRC_URI_append_olympus-nuvoton = " ${@entity_enabled(d, '', '${OLYMPUS_FILES}')}"
+SRC_URI_append_olympus-nuvoton = " file://0001-support-host-boot-progress.patch"
+SRC_URI_append_olympus-nuvoton = " file://0002-add-support-chassis-on-off-target-files.patch"
+SRC_URI_append_olympus-nuvoton = " file://obmc-mapper.target"
+SRC_URI_append_olympus-nuvoton = " file://obmc-chassis-poweroff.target"
+SRC_URI_append_olympus-nuvoton = " file://obmc-chassis-poweron.target"
 
-OLYMPUS_TARGETS = " \
-    obmc-mapper.target \
-    obmc-chassis-poweroff.target \
-    obmc-chassis-poweron.target \
-    "
-SYSTEMD_SERVICE_${PN}_append_olympus-nuvoton = " ${@entity_enabled(d, '', '${OLYMPUS_TARGETS}')}"
-
+SYSTEMD_SERVICE_${PN} += "obmc-mapper.target"
+SYSTEMD_SERVICE_${PN} += "obmc-chassis-poweroff.target"
+SYSTEMD_SERVICE_${PN} += "obmc-chassis-poweron.target"
 
 inherit obmc-phosphor-systemd
 


### PR DESCRIPTION
Porting reload sensor process from hwmon
1. sync entity manager service from upstream
2. revert x86 power control change for enable process for entity manager
3. add reload-sensor service files

Issue:
  ipmi sdr list command execute fail if BMC boot before host PC

Root Cause:
  pmbus driver may not update attribute rated_max after probe, and
  ipmid will access this attribute by PSU sensor dbus property Max_Value
  for calculate sensor value to match ipmi sensor data format.
  see IPMI v2 spec 36.1 Linear and Linearized Sensors

Solution:
  remove sensors on bus 6 which monitor host power while host power off,
  and add it back when host power on.

Test:
  run ipmitool sdr list, host power on/off, BMC reset

Signed-off-by: Brian_Ma <chma0@nuvoton.com>


