### PR TITLE
meta-quanta: meta-olympus-nuvoton: recipes-phosphor: fix start hardreset

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/watchdog/phosphor-watchdog/0001-Customize-phosphor-watchdog-for-Intel-platforms.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/watchdog/phosphor-watchdog/0001-Customize-phosphor-watchdog-for-Intel-platforms.patch
@@ -1,4 +1,4 @@
-From a66278fbb97c3bae2814bdafad05acc168837d7a Mon Sep 17 00:00:00 2001
+From 5760937ef1ae9a4610b47ba64fdebe594fc2c9df Mon Sep 17 00:00:00 2001
 From: James Feist <james.feist@linux.intel.com>
 Date: Mon, 17 Jun 2019 12:00:58 -0700
 Subject: [PATCH] Customize phosphor-watchdog for Intel platforms
@@ -10,18 +10,24 @@ required for compatibility with Intel platforms.
    2. Use dbus properties for power control insted of service files
    3. Use host status to enable/disable watchdog
    4. Set preTimeoutInterruptOccurFlag
+   5. Assign watchdog cause for correct reset cause reporting
+   6. Add NMI Pre-Interrupt support for IPMI watchdog timer.
 
 Signed-off-by: James Feist <james.feist@linux.intel.com>
 Signed-off-by: Ren Yu <yux.ren@intel.com>
 Signed-off-by: Yong Li <yong.b.li@linux.intel.com>
 Signed-off-by: Jason M. Bills <jason.m.bills@linux.intel.com>
+Signed-off-by: Johnathan Mantey <johnathanx.mantey@intel.com>
+Signed-off-by: Sunita Kumari <sunitax.kumari@intel.com>
+
+%% original patch: 0001-Customize-phosphor-watchdog-for-Intel-platforms.patch
 ---
- src/watchdog.cpp | 193 ++++++++++++++++++++++++++++++++++++++++++++---
- src/watchdog.hpp |  23 +++++-
- 2 files changed, 206 insertions(+), 10 deletions(-)
+ src/watchdog.cpp | 230 ++++++++++++++++++++++++++++++++++++++++++++---
+ src/watchdog.hpp |  23 ++++-
+ 2 files changed, 242 insertions(+), 11 deletions(-)
 
 diff --git a/src/watchdog.cpp b/src/watchdog.cpp
-index 57e9050..3b5356f 100644
+index 57e905059153..1204db4cab0f 100644
 --- a/src/watchdog.cpp
 +++ b/src/watchdog.cpp
 @@ -1,11 +1,14 @@
@@ -39,7 +45,7 @@ index 57e9050..3b5356f 100644
  
  namespace phosphor
  {
-@@ -18,10 +21,69 @@ using namespace phosphor::logging;
+@@ -18,10 +21,86 @@ using namespace phosphor::logging;
  using sdbusplus::exception::SdBusError;
  using sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
  
@@ -94,6 +100,23 @@ index 57e9050..3b5356f 100644
 +static constexpr const char* request = "RequestedPowerTransition";
 +} // namespace chassis
 +
++namespace host
++{
++static constexpr const char* busName = "xyz.openbmc_project.State.Host";
++static constexpr const char* path = "/xyz/openbmc_project/state/host0";
++static constexpr const char* interface = "xyz.openbmc_project.State.Host";
++static constexpr const char* request = "RequestedHostTransition";
++} // namespace host
++
++namespace nmi
++{
++static constexpr const char* busName = "xyz.openbmc_project.Control.Host.NMI";
++static constexpr const char* path = "/xyz/openbmc_project/control/host0/nmi";
++static constexpr const char* interface = "xyz.openbmc_project.Control.Host.NMI";
++static constexpr const char* request = "NMI";
++
++} // namespace nmi
++
 +void Watchdog::powerStateChangedHandler(
 +    const std::map<std::string, std::variant<std::string>>& props)
 +{
@@ -113,7 +136,7 @@ index 57e9050..3b5356f 100644
  
  void Watchdog::resetTimeRemaining(bool enableWatchdog)
  {
-@@ -107,13 +169,102 @@ uint64_t Watchdog::interval(uint64_t value)
+@@ -107,13 +186,111 @@ uint64_t Watchdog::interval(uint64_t value)
  // Optional callback function on timer expiration
  void Watchdog::timeOutHandler()
  {
@@ -213,11 +236,20 @@ index 57e9050..3b5356f 100644
 +                        "Watchdog timeout. timer use: %s",
 +                        preInterruptActionMessageArgs.c_str(),
 +                        timeUserMessage.c_str(), NULL);
++
++        if (preTimeoutInterruptAction ==
++            Watchdog::PreTimeoutInterruptAction::NMI)
++        {
++            sdbusplus::message::message preTimeoutInterruptHandler;
++            preTimeoutInterruptHandler = bus.new_method_call(
++                nmi::busName, nmi::path, nmi::interface, nmi::request);
++            bus.call_noreply(preTimeoutInterruptHandler);
++        }
 +    }
  
      auto target = actionTargetMap.find(action);
      if (target == actionTargetMap.end())
-@@ -133,10 +284,11 @@ void Watchdog::timeOutHandler()
+@@ -133,12 +310,45 @@ void Watchdog::timeOutHandler()
  
          try
          {
@@ -225,24 +257,8 @@ index 57e9050..3b5356f 100644
 -                                              SYSTEMD_INTERFACE, "StartUnit");
 -            method.append(target->second);
 -            method.append("replace");
-+            auto method =
-+                bus.new_method_call(chassis::busName, chassis::path,
-+                                    "org.freedesktop.DBus.Properties", "Set");
-+            method.append(chassis::interface, chassis::request,
-+                          std::variant<std::string>(target->second));
- 
-             bus.call_noreply(method);
-         }
-@@ -147,6 +299,29 @@ void Watchdog::timeOutHandler()
-                             entry("ERROR=%s", e.what()));
-             commit<InternalFailure>();
-         }
-+
-+        // set restart cause for watchdog HardReset & PowerCycle actions
-+        if ((action == Watchdog::Action::HardReset) ||
-+            (action == Watchdog::Action::PowerCycle))
-+        {
-+            try
++            sdbusplus::message::message method;
++            if (action == Watchdog::Action::HardReset)
 +            {
 +                auto method = bus.new_method_call(
 +                    restart::busName, restart::path,
@@ -251,20 +267,41 @@ index 57e9050..3b5356f 100644
 +                    restart::interface, restart::property,
 +                    std::variant<std::string>("xyz.openbmc_project.State.Host."
 +                                              "RestartCause.WatchdogTimer"));
-+                bus.call(method);
-+            }
-+            catch (sdbusplus::exception_t& e)
-+            {
-+                log<level::ERR>("Failed to set HostRestartCause property",
-+                                entry("ERROR=%s", e.what()));
-+                commit<InternalFailure>();
-+            }
-+        }
-     }
++                bus.call_noreply(method);
  
-     tryFallbackOrDisable();
+-            bus.call_noreply(method);
++                method = bus.new_method_call(host::busName, host::path,
++                                             "org.freedesktop.DBus.Properties",
++                                             "Set");
++                method.append(host::interface, host::request,
++                              std::variant<std::string>(target->second));
++                bus.call_noreply(method);
++            }
++            else
++            {
++                if (action == Watchdog::Action::PowerCycle)
++                {
++                    auto method = bus.new_method_call(
++                        restart::busName, restart::path,
++                        "org.freedesktop.DBus.Properties", "Set");
++                    method.append(restart::interface, restart::property,
++                                  std::variant<std::string>(
++                                      "xyz.openbmc_project.State.Host."
++                                      "RestartCause.WatchdogTimer"));
++                    bus.call_noreply(method);
++                }
++                method = bus.new_method_call(chassis::busName, chassis::path,
++                                             "org.freedesktop.DBus.Properties",
++                                             "Set");
++                method.append(chassis::interface, chassis::request,
++                              std::variant<std::string>(target->second));
++                bus.call_noreply(method);
++            }
+         }
+         catch (const SdBusError& e)
+         {
 diff --git a/src/watchdog.hpp b/src/watchdog.hpp
-index 7de9bb3..b004b7a 100644
+index 7de9bb38419c..b004b7ab4e3f 100644
 --- a/src/watchdog.hpp
 +++ b/src/watchdog.hpp
 @@ -68,7 +68,18 @@ class Watchdog : public WatchdogInherits

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/watchdog/phosphor-watchdog/phosphor-watchdog.service
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/watchdog/phosphor-watchdog/phosphor-watchdog.service
@@ -4,7 +4,7 @@ Description=Phosphor Watchdog
 [Service]
 ExecStart=/usr/bin/env phosphor-watchdog --continue --service=xyz.openbmc_project.Watchdog \
          --path=/xyz/openbmc_project/watchdog/host0 \
-         --action_target=xyz.openbmc_project.State.Watchdog.Action.HardReset=xyz.openbmc_project.State.Chassis.Transition.Reset \
+         --action_target=xyz.openbmc_project.State.Watchdog.Action.HardReset=xyz.openbmc_project.State.Host.Transition.ForceWarmReboot \
          --action_target=xyz.openbmc_project.State.Watchdog.Action.PowerOff=xyz.openbmc_project.State.Chassis.Transition.Off \
          --action_target=xyz.openbmc_project.State.Watchdog.Action.PowerCycle=xyz.openbmc_project.State.Chassis.Transition.PowerCycle
 


### PR DESCRIPTION
target error
1. update Intel patch to internal 0.57
   ref: https://github.com/Intel-BMC/openbmc/tree/intel/meta-openbmc-mods/meta-common/recipes-phosphor/watchdog/phosphor-watchdog
2. change hardreset target to
   xyz.openbmc_project.State.Host.Transition.ForceWarmReboot.
   the x86-power-control does not support xyz.openbmc_project.State.Chassis.Transition.Reset

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
