### PR TITLE
meta-quanta: meta-olympus-nuvoton: phosphor-ipmi-host: add sensor type

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-add-watchdog-sensor-type.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-add-watchdog-sensor-type.patch
@@ -1,44 +1,24 @@
-From 572be161f796c535774cc43762d85e33051fa287 Mon Sep 17 00:00:00 2001
-From: Brian Ma <chma0@nuvoton.com>
-Date: Thu, 2 Jan 2020 16:37:26 +0800
-Subject: [PATCH] add watchdog sensor type
-
----
- sdrutils.hpp      | 3 ++-
- sensorhandler.hpp | 1 +
- 2 files changed, 3 insertions(+), 1 deletion(-)
-
-diff --git a/sdrutils.hpp b/sdrutils.hpp
-index 7297467..9773837 100644
---- a/sdrutils.hpp
-+++ b/sdrutils.hpp
-@@ -91,6 +91,7 @@ const static boost::container::flat_map<
-          {"fan_tach", std::make_pair(IPMI_SENSOR_FAN, THRESHOLD)},
-          {"fan_pwm", std::make_pair(IPMI_SENSOR_FAN, THRESHOLD)},
-          {"power", std::make_pair(IPMI_SENSOR_OTHER, THRESHOLD)},
-+         {"watchdog", std::make_pair(IPMI_SENSOR_WATCHDOG, SENSOR_SPECIFIC)},
-          {"memory", std::make_pair(IPMI_SENSOR_MEMORY, SENSOR_SPECIFIC)}}};
- 
- inline static std::string getSensorTypeStringFromPath(const std::string& path)
-@@ -180,4 +181,4 @@ inline static std::string getPathFromSensorNumber(uint8_t sensorNum)
- 
-     return path;
- }
--#endif // JOURNAL_SEL
-\ No newline at end of file
-+#endif // JOURNAL_SEL
-diff --git a/sensorhandler.hpp b/sensorhandler.hpp
-index bb49195..27c16b5 100644
---- a/sensorhandler.hpp
-+++ b/sensorhandler.hpp
-@@ -39,6 +39,7 @@ enum ipmi_sensor_types
-     IPMI_SENSOR_OTHER = 0x0B,
-     IPMI_SENSOR_TPM = 0xCC,
-     IPMI_SENSOR_MEMORY = 0x0C,
-+    IPMI_SENSOR_WATCHDOG = 0x23,
+diff --git a/include/dbus-sdr/sdrutils.hpp b/include/dbus-sdr/sdrutils.hpp
+index e700af6..c65d253 100644
+--- a/include/dbus-sdr/sdrutils.hpp
++++ b/include/dbus-sdr/sdrutils.hpp
+@@ -235,6 +235,8 @@ enum class SensorTypeCodes : uint8_t
+     current = 0x3,
+     fan = 0x4,
+     other = 0xB,
++    memory = 0xC,
++    watchdog = 0x23,
  };
  
- enum ipmi_event_types
--- 
-2.17.1
-
+ const static boost::container::flat_map<const char*, SensorTypeCodes, CmpStr>
+@@ -243,7 +245,9 @@ const static boost::container::flat_map<const char*, SensorTypeCodes, CmpStr>
+                  {"current", SensorTypeCodes::current},
+                  {"fan_tach", SensorTypeCodes::fan},
+                  {"fan_pwm", SensorTypeCodes::fan},
+-                 {"power", SensorTypeCodes::other}}};
++                 {"power", SensorTypeCodes::other},
++                 {"memory", SensorTypeCodes::memory},
++                 {"watchdog", SensorTypeCodes::watchdog}}};
+ 
+ std::string getSensorTypeStringFromPath(const std::string& path);
+ 

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -18,6 +18,7 @@ EXTRA_OECONF_olympus-nuvoton = " \
 PACKAGECONFIG_append_olympus-entity = " dynamic-sensors"
 
 SRC_URI_append_olympus-nuvoton = " file://phosphor-ipmi-host.service"
+SRC_URI_append_olympus-nuvoton = " file://0001-add-watchdog-sensor-type.patch"
 
 SYSTEMD_SERVICE_${PN}_append_olympus-nuvoton = " phosphor-ipmi-host.service"
 SYSTEMD_LINK_${PN}_remove_olympus-nuvoton += "${@compose_list_zip(d, 'SOFT_FMT', 'OBMC_HOST_INSTANCES')}"


### PR DESCRIPTION
Add sensor type watchdog for dbus-sdr SEL.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Note. the new version ipmid already update new sensor type, this patch should remove if update ipmid.
