### PR TITLE
meta-quanta: meta-olympus-nuvoton: phosphor-logging: add redfish even…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/logging/files/0001-logging-test-report-a-redfish-event-success-when-add.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/logging/files/0001-logging-test-report-a-redfish-event-success-when-add.patch
@@ -1,0 +1,40 @@
+From 9d0f415d7e2590440bcba828b158674e6f351ad4 Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Thu, 19 Aug 2021 16:53:33 +0800
+Subject: [PATCH] logging test: report a redfish event success when add event
+ log
+
+Signed-off-by: Brian Ma <chma0@nuvoton.com>
+---
+ logging_test.cpp | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/logging_test.cpp b/logging_test.cpp
+index d7d82cee..7d4a0b98 100644
+--- a/logging_test.cpp
++++ b/logging_test.cpp
+@@ -201,6 +201,13 @@ int elog_test()
+     return 0;
+ }
+ 
++void redfish_event_log(){
++    sd_journal_send(
++        "MESSAGE=Create redfish base event log test",
++        "PRIORITY=%i", LOG_INFO, "REDFISH_MESSAGE_ID=%s",
++        "Base.1.10.Success", NULL);
++}
++
+ void commitError(const char* text)
+ {
+     if (std::strcmp(text, "AutoTestSimple") == 0)
+@@ -216,6 +223,7 @@ void commitError(const char* text)
+             std::cout << "elog exception caught: " << e.what() << std::endl;
+             commit(e.name());
+         }
++        redfish_event_log();
+     }
+     else if (std::strcmp(text, "AutoTestCreateAndCommit") == 0)
+     {
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/logging/phosphor-logging_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/logging/phosphor-logging_%.bbappend
@@ -1,4 +1,5 @@
 FILESEXTRAPATHS_prepend_olympus-nuvoton := "${THISDIR}/files:"
 
 SRC_URI_append_olympus-nuvoton = " file://0001-build-meson-fix-python-command-parameter.patch"
+SRC_URI_append_olympus-nuvoton = " file://0001-logging-test-report-a-redfish-event-success-when-add.patch"
 


### PR DESCRIPTION
…t log

Add redfish event log success when send dbus event log test.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
