### PR TITLE
meta-quanta: meta-olympus-nuvoton: dbus: allow the mapper to discover…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dbus/phosphor-dbus-interfaces-mapper-config-native.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dbus/phosphor-dbus-interfaces-mapper-config-native.bbappend
@@ -1,0 +1,2 @@
+PHOSPHOR_MAPPER_SERVICE_append = " com.intel.crashdump"
+PHOSPHOR_MAPPER_INTERFACE_append = " com.intel.crashdump"


### PR DESCRIPTION
… crashdump

Symptom:
Crashdump log cannot be generated correctly.

Root cause:
ObjectMapper cannot discover crashdump service and interfaces.

Solution:
Add phosphor-dbus-interfaces-mapper-config-native.bbappend
allow the maper to discover crashdump interfaces and services.

Tested:
curl -k -H "X-Auth-Token: $token" -X POST
https://${bmc}/redfish/v1/Systems/system/LogServices/Crashdump/Actions/LogService.CollectDiagnosticData

Signed-off-by: Tim Lee <timlee660101@gmail.com>