### PR TITLE
meta-quanta: olympus-nuvoton: smbios: add functional property for sdr…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-x86/smbios/smbios-mdrv2.bb
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-x86/smbios/smbios-mdrv2.bb
@@ -5,7 +5,7 @@ DESCRIPTION = "SMBIOS MDR version 2 service for Intel based platfrom"
 SRC_URI = "git://github.com/openbmc/smbios-mdr"
 SRCREV = "d23b84a7eb2be944b12e6539cf627f595b299fda"
 
-SRC_URI_append = " ${@entity_enabled(d, '', 'file://0003-smbios-fix-present-and-functional-property-to-true.patch')}"
+SRC_URI_append = " ${@entity_enabled(d, '', 'file://0004-smbios-add-functional-property-for-sdr-dimm-test.patch')}"
 SRC_URI += "file://smbios2"
 SRC_URI += "file://smbios-mdrv2.service"
 

--- a/meta-quanta/meta-olympus-nuvoton/recipes-x86/smbios/smbios-mdrv2/0004-smbios-add-functional-property-for-sdr-dimm-test.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-x86/smbios/smbios-mdrv2/0004-smbios-add-functional-property-for-sdr-dimm-test.patch
@@ -1,0 +1,79 @@
+From 6859194a80a5f5556ac7f0fc96828e5165b7b1c3 Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Wed, 25 Aug 2021 16:00:22 +0800
+Subject: [PATCH 4/4] smbios: add functional property for sdr dimm test
+
+Signed-off-by: Tim Lee <timlee660101@gmail.com>
+---
+ include/dimm.hpp | 9 ++++++++-
+ src/dimm.cpp     | 7 +++++++
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/include/dimm.hpp b/include/dimm.hpp
+index 4230ae4..c3bd9c7 100644
+--- a/include/dimm.hpp
++++ b/include/dimm.hpp
+@@ -20,6 +20,7 @@
+ #include <xyz/openbmc_project/Inventory/Decorator/Asset/server.hpp>
+ #include <xyz/openbmc_project/Inventory/Item/Dimm/server.hpp>
+ #include <xyz/openbmc_project/Inventory/Item/server.hpp>
++#include <xyz/openbmc_project/State/Decorator/OperationalStatus/server.hpp>
+ 
+ namespace phosphor
+ {
+@@ -36,7 +37,9 @@ class Dimm :
+     sdbusplus::server::object::object<
+         sdbusplus::xyz::openbmc_project::Inventory::Decorator::server::Asset>,
+     sdbusplus::server::object::object<
+-        sdbusplus::xyz::openbmc_project::Inventory::server::Item>
++        sdbusplus::xyz::openbmc_project::Inventory::server::Item>,
++    sdbusplus::server::object::object<
++        sdbusplus::xyz::openbmc_project::State::Decorator::server::OperationalStatus>
+ {
+   public:
+     Dimm() = delete;
+@@ -58,6 +61,9 @@ class Dimm :
+         sdbusplus::server::object::object<
+             sdbusplus::xyz::openbmc_project::Inventory::server::Item>(
+             bus, objPath.c_str()),
++        sdbusplus::server::object::object<
++            sdbusplus::xyz::openbmc_project::State::Decorator::server::OperationalStatus>(
++            bus, objPath.c_str()),
+         dimmNum(dimmId), storage(smbiosTableStorage)
+     {
+         memoryInfoUpdate();
+@@ -77,6 +83,7 @@ class Dimm :
+     std::string partNumber(std::string value) override;
+     uint8_t memoryAttributes(uint8_t value) override;
+     uint16_t memoryConfiguredSpeedInMhz(uint16_t value) override;
++    bool functional(bool value) override;
+ 
+   private:
+     uint8_t dimmNum;
+diff --git a/src/dimm.cpp b/src/dimm.cpp
+index e2cfbc6..93bbf8e 100644
+--- a/src/dimm.cpp
++++ b/src/dimm.cpp
+@@ -183,6 +183,7 @@ void Dimm::dimmManufacturer(const uint8_t positionNum, const uint8_t structLen,
+     }
+     manufacturer(result);
+     present(val);
++    functional(val);
+ }
+ 
+ std::string Dimm::manufacturer(std::string value)
+@@ -237,5 +238,11 @@ uint16_t Dimm::memoryConfiguredSpeedInMhz(uint16_t value)
+         memoryConfiguredSpeedInMhz(value);
+ }
+ 
++bool Dimm::functional(bool value)
++{
++    return sdbusplus::xyz::openbmc_project::State::Decorator::server::OperationalStatus::functional(
++        value);
++}
++
+ } // namespace smbios
+ } // namespace phosphor
+-- 
+2.17.1
+


### PR DESCRIPTION
… dimm test

Symptom:
Test automation ipmi sdr test item got failed.

Root cause:
According auto test item test_ipmi_sdr.robot in keyword "Verify SDR" that
will check two properties. One is present property, another is functional property.
But, smbios didn't provide functional proerty then cause test item got failed.

Solution:
Add functional property for sdr dimm test.

Tested:
Run robot test -v Test_DIMM_SDR_Info_At_Power_Off/On ipmi/test_ipmi_sdr.robot

Signed-off-by: Tim Lee <timlee660101@gmail.com>