### PR TITLE
meta-quanta: olympus-nuvoton: enable Crashdump functionality

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-olympus-nuvoton/packagegroups/packagegroup-olympus-nuvoton-apps.bb
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-olympus-nuvoton/packagegroups/packagegroup-olympus-nuvoton-apps.bb
@@ -67,6 +67,7 @@ RDEPENDS_${PN}-system = " \
         nuvoton-ipmi-oem \
         olympus-nuvoton-iptable-restore \
         srvcfg-manager \
+        crashdump \
         "
 RDEPENDS_${PN}-system_append = " \
         ${@entity_enabled(d, '', 'first-boot-set-psu')} \

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -8,9 +8,8 @@ SRC_URI_append_olympus-nuvoton = " file://0014-add-config-to-config-virtual-medi
 SRC_URI_append_olympus-nuvoton = " file://0016-manager-do-not-update-value-if-string-is-empty.patch"
 SRC_URI_append_olympus-nuvoton = " file://0018-redfish-log_services-fix-createDump-functionality.patch"
 
-# Enable CPU Log and Raw PECI support
-#EXTRA_OEMESON_append = " -Dredfish-cpu-log=enabled"
-#EXTRA_OEMESON_append = " -Dredfish-raw-peci=enabled"
+# Enable CPU Log support
+EXTRA_OEMESON_append = " -Dredfish-cpu-log=enabled"
 
 # Enable Redfish BMC Journal support
 EXTRA_OEMESON_append = " -Dredfish-bmc-journal=enabled"


### PR DESCRIPTION
Summary:
1. Intel Crashdump v1.0.6
2. Crashdump Redfish new curl:
   /redfish/v1/Systems/system/LogServices/Crashdump/Actions/LogService.CollectDiagnosticData
3. Crashdump Redfish new parameters:
   DiagnosticDataType:"OEM" and "OEMDiagnosticDataType":"OnDemand" or "Telemetry"
4. New object path OnDemand:
   /com/intel/crashdump/OnDemand and /com/intel/crashdump/Telemetry
5. SendRawPeci Redfish API didn't support anymore

Verify by DBus:
busctl call com.intel.crashdump /com/intel/crashdump/OnDemand
org.freedesktop.DBus.Properties Get ss "com.intel.crashdump" "Log"

Verify by Redfish:
curl -k -H "X-Auth-Token: $token" -X POST
https://${bmc}/redfish/v1/Systems/system/LogServices/Crashdump/Actions/
LogService.CollectDiagnosticData -d
'{"DiagnosticDataType":"OEM", "OEMDiagnosticDataType": "OnDemand"}'

Signed-off-by: Tim Lee <timlee660101@gmail.com>