### PR TITLE
meta-evb: meta-buv-runbmc: update buv-runbmc configuration

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/machine/buv-runbmc.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/machine/buv-runbmc.conf
@@ -5,10 +5,11 @@ KMACHINE = "nuvoton"
 KERNEL_DEVICETREE = "${KMACHINE}-npcm750-buv-runbmc.dtb"
 
 FLASH_SIZE = "65536"
-FLASH_UBOOT_OFFSET = "0"
-FLASH_KERNEL_OFFSET = "2048"
-FLASH_ROFS_OFFSET = "8192"
-FLASH_RWFS_OFFSET = "62464"
+# avoid image_types_phosphor.bbclass override
+FLASH_KERNEL_OFFSET:flash-65536 = "2048"
+FLASH_ROFS_OFFSET:flash-65536 = "8192"
+FLASH_RWFS_OFFSET:flash-65536 = "62464"
+
 
 UBOOT_MACHINE = "PolegRunBMC_defconfig"
 UBOOT_DEVICETREE = "nuvoton-npcm750-buv"


### PR DESCRIPTION
update buv-runbmc machine configuration to avoid override by image_types_phosphor.bbclass

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
