### PR TITLE
meta-evb: meta-buv-runbmc: fix services down after merge code

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/configuration/entity-manager/F0B_BMC_BMC.json
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/configuration/entity-manager/F0B_BMC_BMC.json
@@ -876,6 +876,12 @@
         "EntityId": 7,
         "EntityInstance": 1
     },
+    "xyz.openbmc_project.Inventory.Decorator.Asset": {
+        "Manufacturer": "$BOARD_MANUFACTURER",
+        "Model": "$PRODUCT_PRODUCT_NAME",
+        "PartNumber": "$BOARD_PART_NUMBER",
+        "SerialNumber": "$BOARD_SERIAL_NUMBER"
+    },
     "xyz.openbmc_project.Inventory.Item.Bmc": {},
     "xyz.openbmc_project.Common.UUID": {
         "UUID": "$BOARD_INFO_AM1"

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/configuration/entity-manager_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/configuration/entity-manager_%.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS:prepend:buv-runbmc := "${THISDIR}/${PN}:"
 
 SRC_URI:append:buv-runbmc = " file://F0B_BMC_BMC.json"
 
-FILES_${PN}:append:buv-runbmc = " \
+FILES:${PN}:append:buv-runbmc = " \
     ${datadir}/entity-manager/F0B_BMC_BMC.json"
 
 do_install:append:buv-runbmc() {

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -19,3 +19,6 @@ EXTRA_OEMESON:append:buv-runbmc = " -Dhttp-body-limit=35"
 
 # enable debug
 # EXTRA_OEMESON_append_buv-runbmc = " -Dbmcweb-logging=enabled"
+
+# Enable dbus rest API /xyz/
+EXTRA_OEMESON:append:buv-runbmc = " -Drest=enabled"

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/inventory/buv-runbmc-inventory-cleanup.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/inventory/buv-runbmc-inventory-cleanup.bb
@@ -1,0 +1,17 @@
+SUMMARY = "Copy the inventory cleanup yaml for inventory manager"
+PR = "r1"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit allarch
+inherit phosphor-inventory-manager
+
+S = "${WORKDIR}"
+
+SRC_URI = "file://inventory-cleanup.yaml"
+
+do_install() {
+        install -D inventory-cleanup.yaml ${D}${base_datadir}/events.d/inventory-cleanup.yaml
+}
+
+FILES:${PN} = "${base_datadir}/events.d/inventory-cleanup.yaml"

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/inventory/buv-runbmc-inventory-cleanup/inventory-cleanup.yaml
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/inventory/buv-runbmc-inventory-cleanup/inventory-cleanup.yaml
@@ -1,0 +1,16 @@
+description: >
+    RunBMC inventory fixups
+
+events:
+    - name: Add Chassis interface
+      description: >
+          Add the chassis interface on the chassis inventory path
+      type: startup
+      actions:
+          - name: createObjects
+            objs:
+                /system/chassis:
+                  xyz.openbmc_project.Inventory.Item.Chassis:
+                      Type:
+                          value: "xyz.openbmc_project.Inventory.Item.Chassis.ChassisType.RackMount"
+                          type: string

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/inventory/phosphor-inventory-manager/associations.json
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/inventory/phosphor-inventory-manager/associations.json
@@ -1,0 +1,117 @@
+[
+    {
+        "path": "system/chassis/motherboard/fan",
+        "endpoints":
+        [
+            {
+                "types":
+                {
+                    "rType": "inventory",
+                    "fType": "sensors"
+                },
+                "paths":
+                [
+                    "/xyz/openbmc_project/sensors/fan_tach/fan1",
+                    "/xyz/openbmc_project/sensors/fan_tach/fan2",
+                    "/xyz/openbmc_project/sensors/fan_tach/fan3",
+                    "/xyz/openbmc_project/sensors/fan_tach/fan4"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "system/chassis/motherboard/management_card/bmc",
+        "endpoints":
+        [
+            {
+                "types":
+                {
+                    "rType": "inventory",
+                    "fType": "sensors"
+                },
+                "paths":
+                [
+                    "/xyz/openbmc_project/sensors/temperature/BMC_Temp"
+                ]
+            },
+            {
+                "types":
+                {
+                    "rType": "inventory",
+                    "fType": "leds"
+                },
+                "paths":
+                [
+                    "/xyz/openbmc_project/led/physical/heartbeat"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "system/chassis/motherboard",
+        "endpoints":
+        [
+            {
+                "types":
+                {
+                    "rType": "inventory",
+                    "fType": "sensors"
+                },
+                "paths":
+                [
+                    "/xyz/openbmc_project/sensors/temperature/BUV_Temp",
+                    "/xyz/openbmc_project/sensors/voltage/ADC1",
+                    "/xyz/openbmc_project/sensors/voltage/ADC2",
+                    "/xyz/openbmc_project/sensors/voltage/ADC3",
+                    "/xyz/openbmc_project/sensors/voltage/ADC4",
+                    "/xyz/openbmc_project/sensors/voltage/ADC5",
+                    "/xyz/openbmc_project/sensors/voltage/ADC6",
+                    "/xyz/openbmc_project/sensors/voltage/ADC7",
+                    "/xyz/openbmc_project/sensors/voltage/ADC8",
+                    "/xyz/openbmc_project/sensors/voltage/MB_P12V_INA219_Output_Voltage",
+                    "/xyz/openbmc_project/sensors/voltage/MB_P3V3_INA219_Output_Voltage",
+                    "/xyz/openbmc_project/sensors/power/MB_P12V_INA219_Output_Power",
+                    "/xyz/openbmc_project/sensors/power/MB_P3V3_INA219_Output_Power",
+                    "/xyz/openbmc_project/sensors/current/MB_P12V_INA219_Output_Current",
+                    "/xyz/openbmc_project/sensors/current/MB_P3V3_INA219_Output_Current"
+                ]
+            }
+        ]
+    },
+    {
+        "path": "system/chassis",
+        "endpoints":
+        [
+            {
+                "types":
+                {
+                    "rType": "chassis",
+                    "fType": "all_sensors"
+                },
+                "paths":
+                [
+                    "/xyz/openbmc_project/sensors/fan_tach/fan1",
+                    "/xyz/openbmc_project/sensors/fan_tach/fan2",
+                    "/xyz/openbmc_project/sensors/fan_tach/fan3",
+                    "/xyz/openbmc_project/sensors/fan_tach/fan4",
+                    "/xyz/openbmc_project/sensors/temperature/BMC_Temp",
+                    "/xyz/openbmc_project/sensors/temperature/BUV_Temp",
+                    "/xyz/openbmc_project/sensors/voltage/ADC1",
+                    "/xyz/openbmc_project/sensors/voltage/ADC2",
+                    "/xyz/openbmc_project/sensors/voltage/ADC3",
+                    "/xyz/openbmc_project/sensors/voltage/ADC4",
+                    "/xyz/openbmc_project/sensors/voltage/ADC5",
+                    "/xyz/openbmc_project/sensors/voltage/ADC6",
+                    "/xyz/openbmc_project/sensors/voltage/ADC7",
+                    "/xyz/openbmc_project/sensors/voltage/ADC8",
+                    "/xyz/openbmc_project/sensors/voltage/MB_P12V_INA219_Output_Voltage",
+                    "/xyz/openbmc_project/sensors/voltage/MB_P3V3_INA219_Output_Voltage",
+                    "/xyz/openbmc_project/sensors/power/MB_P12V_INA219_Output_Power",
+                    "/xyz/openbmc_project/sensors/power/MB_P3V3_INA219_Output_Power",
+                    "/xyz/openbmc_project/sensors/current/MB_P12V_INA219_Output_Current",
+                    "/xyz/openbmc_project/sensors/current/MB_P3V3_INA219_Output_Current"
+                ]
+            }
+        ]
+    }
+]

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/inventory/phosphor-inventory-manager_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/inventory/phosphor-inventory-manager_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend:buv-runbmc := "${THISDIR}/${PN}:"
+PACKAGECONFIG:append:buv-runbmc = " associations"
+
+SRC_URI:append:buv-runbmc = " file://associations.json"
+DEPENDS:append:buv-runbmc = " buv-runbmc-inventory-cleanup"
+
+do_install:append:buv-runbmc() {
+    install -d ${D}${base_datadir}
+    install -m 0755 ${WORKDIR}/associations.json ${D}${base_datadir}/associations.json
+}

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/sensors/phosphor-hwmon_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/sensors/phosphor-hwmon_%.bbappend
@@ -13,13 +13,13 @@ ITEMSFMT = "ahb/apb/{0}.conf"
 ITEMS += "${@compose_list(d, 'ITEMSFMT', 'NAMES')}"
 
 ENVS = "obmc/hwmon/{0}"
-SYSTEMD_ENVIRONMENT_FILE_${PN} += "${@compose_list(d, 'ENVS', 'ITEMS')}"
+SYSTEMD_ENVIRONMENT_FILE:${PN}:buv-runbmc += "${@compose_list(d, 'ENVS', 'ITEMS')}"
 
 # Fan sensors
 FITEMS = "pwm-fan-controller@103000.conf"
 FENVS = "obmc/hwmon/ahb/apb/{0}"
-SYSTEMD_ENVIRONMENT_FILE_${PN} += "${@compose_list(d, 'FENVS', 'FITEMS')}"
+SYSTEMD_ENVIRONMENT_FILE:${PN}:buv-runbmc += "${@compose_list(d, 'FENVS', 'FITEMS')}"
 
 # ADC
 ADC_ITEMS = "adc@c000.conf"
-SYSTEMD_ENVIRONMENT_FILE_${PN} += "${@compose_list(d, 'FENVS', 'ADC_ITEMS')}"
+SYSTEMD_ENVIRONMENT_FILE:${PN}:buv-runbmc += "${@compose_list(d, 'FENVS', 'ADC_ITEMS')}"

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-x86/chassis/x86-power-control/power-config-host0.json
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-x86/chassis/x86-power-control/power-config-host0.json
@@ -1,12 +1,42 @@
 {
-    "gpio_configs":{
-        "PostComplete": "POST_COMPLETE",
-        "PwrButton": "POWER_BUTTON",
-        "PwrOK": "PS_PWROK",
-        "PwrOut": "POWER_OUT",
-        "RstButton": "RESET_BUTTON",
-        "RstOut": "RESET_OUT"
+  "gpio_configs":[
+    {
+        "Name" : "PostComplete",
+        "LineName" : "POST_COMPLETE",
+        "Type" : "GPIO",
+        "Polarity" : "ActiveHigh"
     },
+    {
+        "Name" : "PowerButton",
+        "LineName" : "POWER_BUTTON",
+        "Type" : "GPIO",
+        "Polarity" : "ActiveLow"
+    },
+    {
+        "Name" : "PowerOk",
+        "LineName" : "PS_PWROK",
+        "Type" : "GPIO",
+        "Polarity" : "ActiveHigh"
+    },
+    {
+        "Name" : "PowerOut",
+        "LineName" : "POWER_OUT",
+        "Type" : "GPIO",
+        "Polarity" : "ActiveLow"
+    },
+    {
+        "Name" : "ResetButton",
+        "LineName" : "RESET_BUTTON",
+        "Type" : "GPIO",
+        "Polarity" : "ActiveLow"
+    },
+    {
+        "Name" : "ResetOut",
+        "LineName" : "RESET_OUT",
+        "Type" : "GPIO",
+        "Polarity" : "ActiveLow"
+    }
+  ],
     "timing_configs":{
         "PowerPulseMs": 200,
         "ForceOffPulseMs": 15000,


### PR DESCRIPTION
1. update entity manager recipe and configuration file
2. enable bmcweb old style xyz rest API
3. fix web UI cannot show any HW sensors by update inventory recipe
4. update hwmon recipe typo
5. update x86 power control configuration file to match new format

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
