### PR TITLE
meta-quanta: meta-olympus-nuvoton: phosphor-ipmi-host: porting SOL co…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host/0059-Move-Set-SOL-config-parameter-to-host-ipmid.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host/0059-Move-Set-SOL-config-parameter-to-host-ipmid.patch
@@ -1,0 +1,356 @@
+From 9f4fb8a6aa076261b19c187aeef840d818158ec7 Mon Sep 17 00:00:00 2001
+From: Cheng C Yang <cheng.c.yang@intel.com>
+Date: Wed, 16 Oct 2019 14:24:20 +0800
+Subject: [PATCH] Move Set SOL config parameter to host-ipmid
+
+Move Set SOL config parameter command from net-ipmid to host-ipmid,
+so that BIOS in Intel platform can enable or disable SOL through KCS.
+Get SOL config parameter command will be moved later.
+
+Tested by:
+With the related change in phospher-ipmi-net and phospher-dbus-interface,
+Run commands:
+ipmitool raw 0x0c 0x21 0x0e 0x00 0x01
+ipmitool raw 0x0c 0x21 0x0e 0x01 0x00
+ipmitool raw 0x0c 0x21 0x0e 0x02 0x03
+ipmitool raw 0x0c 0x21 0x0e 0x03 0x5 0x03
+ipmitool raw 0x0c 0x21 0x0e 0x04 0x5 0x03
+All these commands have correct response and all dbus interface for
+sol command change to same value in above commands.
+After reboot BMC, "Progress" property in dbus interface change back
+to 0 and other properties will not reset to default value.
+
+Signed-off-by: Cheng C Yang <cheng.c.yang@intel.com>
+Signed-off-by: James Feist <james.feist@linux.intel.com>
+---
+ host-ipmid-whitelist.conf |   1 +
+ transporthandler.cpp      | 294 ++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 295 insertions(+)
+
+diff --git a/host-ipmid-whitelist.conf b/host-ipmid-whitelist.conf
+index 5397115..c93f3b1 100644
+--- a/host-ipmid-whitelist.conf
++++ b/host-ipmid-whitelist.conf
+@@ -41,6 +41,7 @@
+ 0x0A:0x48    //<Storage>:<Get SEL Time>
+ 0x0A:0x49    //<Storage>:<Set SEL Time>
+ 0x0C:0x02    //<Transport>:<Get LAN Configuration Parameters>
++0x0C:0x21    //<Transport>:<Set SOL Configuration Parameters>
+ 0x2C:0x00    //<Group Extension>:<Group Extension Command>
+ 0x2C:0x01    //<Group Extension>:<Get DCMI Capabilities>
+ 0x2C:0x02    //<Group Extension>:<Get Power Reading>
+diff --git a/transporthandler.cpp b/transporthandler.cpp
+index 0012746..0de76c4 100644
+--- a/transporthandler.cpp
++++ b/transporthandler.cpp
+@@ -2030,8 +2030,298 @@ RspType<message::Payload> getLan(Context::ptr ctx, uint4_t channelBits,
+ } // namespace transport
+ } // namespace ipmi
+ 
++constexpr const char* solInterface = "xyz.openbmc_project.Ipmi.SOL";
++constexpr const char* solPath = "/xyz/openbmc_project/ipmi/sol/";
++
+ void register_netfn_transport_functions() __attribute__((constructor));
+ 
++static std::string
++    getSOLService(std::shared_ptr<sdbusplus::asio::connection> dbus,
++                  const std::string& solPathWitheEthName)
++{
++    static std::string solService{};
++    if (solService.empty())
++    {
++        try
++        {
++            solService =
++                ipmi::getService(*dbus, solInterface, solPathWitheEthName);
++        }
++        catch (const sdbusplus::exception::SdBusError& e)
++        {
++            solService.clear();
++            phosphor::logging::log<phosphor::logging::level::ERR>(
++                "Error: get SOL service failed");
++            return solService;
++        }
++    }
++    return solService;
++}
++
++static int setSOLParameter(const std::string& property,
++                           const ipmi::Value& value, const uint8_t& channelNum)
++{
++    auto dbus = getSdBus();
++
++    std::string ethdevice = ipmi::getChannelName(channelNum);
++
++    std::string solPathWitheEthName = std::string(solPath) + ethdevice;
++
++    std::string service = getSOLService(dbus, solPathWitheEthName);
++    if (service.empty())
++    {
++        phosphor::logging::log<phosphor::logging::level::ERR>(
++            "Unable to get SOL service failed");
++        return -1;
++    }
++    try
++    {
++        ipmi::setDbusProperty(*dbus, service, solPathWitheEthName, solInterface,
++                              property, value);
++    }
++    catch (sdbusplus::exception_t&)
++    {
++        phosphor::logging::log<phosphor::logging::level::ERR>(
++            "Error setting sol parameter");
++        return -1;
++    }
++
++    return 0;
++}
++
++static int getSOLParameter(const std::string& property, ipmi::Value& value,
++                           const uint8_t& channelNum)
++{
++    auto dbus = getSdBus();
++
++    std::string ethdevice = ipmi::getChannelName(channelNum);
++
++    std::string solPathWitheEthName = std::string(solPath) + ethdevice;
++
++    std::string service = getSOLService(dbus, solPathWitheEthName);
++    if (service.empty())
++    {
++        phosphor::logging::log<phosphor::logging::level::ERR>(
++            "Unable to get SOL service failed");
++        return -1;
++    }
++    try
++    {
++        value = ipmi::getDbusProperty(*dbus, service, solPathWitheEthName,
++                                      solInterface, property);
++    }
++    catch (sdbusplus::exception_t&)
++    {
++        phosphor::logging::log<phosphor::logging::level::ERR>(
++            "Error getting sol parameter");
++        return -1;
++    }
++
++    return 0;
++}
++
++static const constexpr uint8_t encryptMask = 0x80;
++static const constexpr uint8_t encryptShift = 7;
++static const constexpr uint8_t authMask = 0x40;
++static const constexpr uint8_t authShift = 6;
++static const constexpr uint8_t privilegeMask = 0xf;
++
++namespace ipmi
++{
++constexpr Cc ccParmNotSupported = 0x80;
++constexpr Cc ccSetInProgressActive = 0x81;
++constexpr Cc ccSystemInfoParameterSetReadOnly = 0x82;
++
++static inline auto responseParmNotSupported()
++{
++    return response(ccParmNotSupported);
++}
++static inline auto responseSetInProgressActive()
++{
++    return response(ccSetInProgressActive);
++}
++static inline auto responseSystemInfoParameterSetReadOnly()
++{
++    return response(ccSystemInfoParameterSetReadOnly);
++}
++
++} // namespace ipmi
++
++namespace sol
++{
++enum class Parameter
++{
++    progress,       //!< Set In Progress.
++    enable,         //!< SOL Enable.
++    authentication, //!< SOL Authentication.
++    accumulate,     //!< Character Accumulate Interval & Send Threshold.
++    retry,          //!< SOL Retry.
++    nvbitrate,      //!< SOL non-volatile bit rate.
++    vbitrate,       //!< SOL volatile bit rate.
++    channel,        //!< SOL payload channel.
++    port,           //!< SOL payload port.
++};
++
++enum class Privilege : uint8_t
++{
++    highestPriv,
++    callbackPriv,
++    userPriv,
++    operatorPriv,
++    adminPriv,
++    oemPriv,
++};
++
++} // namespace sol
++
++constexpr uint8_t progressMask = 0x03;
++constexpr uint8_t enableMask = 0x01;
++constexpr uint8_t retryMask = 0x07;
++
++ipmi::RspType<> setSOLConfParams(ipmi::Context::ptr ctx, uint4_t chNum,
++                                 uint4_t reserved, uint8_t paramSelector,
++                                 uint8_t configParamData1,
++                                 std::optional<uint8_t> configParamData2)
++{
++    ipmi::ChannelInfo chInfo;
++    uint8_t channelNum = ipmi::convertCurrentChannelNum(
++        static_cast<uint8_t>(chNum), ctx->channel);
++    if (reserved != 0 ||
++        (!ipmi::isValidChannel(static_cast<uint8_t>(channelNum))))
++    {
++        return ipmi::responseInvalidFieldRequest();
++    }
++
++    ipmi_ret_t compCode =
++        ipmi::getChannelInfo(static_cast<uint8_t>(channelNum), chInfo);
++    if (compCode != IPMI_CC_OK ||
++        chInfo.mediumType !=
++            static_cast<uint8_t>(ipmi::EChannelMediumType::lan8032))
++    {
++        return ipmi::responseInvalidFieldRequest();
++    }
++
++    switch (static_cast<sol::Parameter>(paramSelector))
++    {
++        case sol::Parameter::progress:
++        {
++            if (configParamData2)
++            {
++                return ipmi::responseReqDataLenInvalid();
++            }
++            uint8_t progress = configParamData1 & progressMask;
++            ipmi::Value currentProgress = 0;
++            if (getSOLParameter("Progress", currentProgress, channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++
++            if ((std::get<uint8_t>(currentProgress) == 1) && (progress == 1))
++            {
++                return ipmi::responseSetInProgressActive();
++            }
++
++            if (setSOLParameter("Progress", progress, channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++            break;
++        }
++        case sol::Parameter::enable:
++        {
++            if (configParamData2)
++            {
++                return ipmi::responseReqDataLenInvalid();
++            }
++            bool enable = configParamData1 & enableMask;
++            if (setSOLParameter("Enable", enable, channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++            break;
++        }
++        case sol::Parameter::authentication:
++        {
++            if (configParamData2)
++            {
++                return ipmi::responseReqDataLenInvalid();
++            }
++            uint8_t encrypt = (configParamData1 & encryptMask) >> encryptShift;
++            uint8_t auth = (configParamData1 & authMask) >> authShift;
++            uint8_t privilege = configParamData1 & privilegeMask;
++            // For security considering encryption and authentication must be
++            // true.
++            if (!encrypt || !auth)
++            {
++                return ipmi::responseSystemInfoParameterSetReadOnly();
++            }
++            else if (privilege <
++                         static_cast<uint8_t>(sol::Privilege::userPriv) ||
++                     privilege > static_cast<uint8_t>(sol::Privilege::oemPriv))
++            {
++                return ipmi::responseInvalidFieldRequest();
++            }
++
++            if (setSOLParameter("Privilege", privilege, channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++
++            break;
++        }
++        case sol::Parameter::accumulate:
++        {
++            if (!configParamData2)
++            {
++                return ipmi::responseReqDataLenInvalid();
++            }
++            if (*configParamData2 == 0)
++            {
++                return ipmi::responseInvalidFieldRequest();
++            }
++            if (setSOLParameter("AccumulateIntervalMS", configParamData1,
++                                channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++            if (setSOLParameter("Threshold", *configParamData2, channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++            break;
++        }
++        case sol::Parameter::retry:
++        {
++            if (!configParamData2)
++            {
++                return ipmi::responseReqDataLenInvalid();
++            }
++            if ((setSOLParameter(
++                     "RetryCount",
++                     static_cast<uint8_t>(configParamData1 & retryMask),
++                     channelNum) < 0) ||
++                (setSOLParameter("RetryIntervalMS", *configParamData2,
++                                 channelNum) < 0))
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++
++            break;
++        }
++        case sol::Parameter::port:
++        {
++            return ipmi::responseSystemInfoParameterSetReadOnly();
++        }
++        case sol::Parameter::nvbitrate:
++        case sol::Parameter::vbitrate:
++        case sol::Parameter::channel:
++        default:
++            return ipmi::responseParmNotSupported();
++    }
++
++    return ipmi::responseSuccess();
++}
++
+ void register_netfn_transport_functions()
+ {
+     ipmi::registerHandler(ipmi::prioOpenBmcBase, ipmi::netFnTransport,
+@@ -2040,4 +2330,8 @@ void register_netfn_transport_functions()
+     ipmi::registerHandler(ipmi::prioOpenBmcBase, ipmi::netFnTransport,
+                           ipmi::transport::cmdGetLanConfigParameters,
+                           ipmi::Privilege::Operator, ipmi::transport::getLan);
++
++    ipmi::registerHandler(ipmi::prioOpenBmcBase, ipmi::netFnTransport,
++                          ipmi::transport::cmdSetSolConfigParameters,
++                          ipmi::Privilege::Admin, setSOLConfParams);
+ }
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host/0060-Move-Get-SOL-config-parameter-to-host-ipmid.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host/0060-Move-Get-SOL-config-parameter-to-host-ipmid.patch
@@ -1,0 +1,259 @@
+From ff1d4198e8ad8f824f34fb9d261ea0e25179f070 Mon Sep 17 00:00:00 2001
+From: Cheng C Yang <cheng.c.yang@intel.com>
+Date: Thu, 11 Jul 2019 00:32:58 +0800
+Subject: [PATCH] Move Get SOL config parameter to host-ipmid
+
+Move Get SOL config parameter command from net-ipmid to host-ipmid.
+
+Tested:
+Run command ipmitool sol info 1
+Set in progress                 : set-complete
+Enabled                         : true
+Force Encryption                : false
+Force Authentication            : false
+Privilege Level                 : ADMINISTRATOR
+Character Accumulate Level (ms) : 60
+Character Send Threshold        : 96
+Retry Count                     : 6
+Retry Interval (ms)             : 200
+Volatile Bit Rate (kbps)        : IPMI-Over-Serial-Setting
+Non-Volatile Bit Rate (kbps)    : 115.2
+Payload Channel                 : 1 (0x01)
+Payload Port                    : 623
+
+Signed-off-by: Cheng C Yang <cheng.c.yang@intel.com>
+Signed-off-by: James Feist <james.feist@linux.intel.com>
+---
+ host-ipmid-whitelist.conf |   1 +
+ transporthandler.cpp      | 191 ++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 192 insertions(+)
+
+diff --git a/host-ipmid-whitelist.conf b/host-ipmid-whitelist.conf
+index c93f3b1..730437d 100644
+--- a/host-ipmid-whitelist.conf
++++ b/host-ipmid-whitelist.conf
+@@ -42,6 +42,7 @@
+ 0x0A:0x49    //<Storage>:<Set SEL Time>
+ 0x0C:0x02    //<Transport>:<Get LAN Configuration Parameters>
+ 0x0C:0x21    //<Transport>:<Set SOL Configuration Parameters>
++0x0C:0x22    //<Transport>:<Get SOL Configuration Parameters>
+ 0x2C:0x00    //<Group Extension>:<Group Extension Command>
+ 0x2C:0x01    //<Group Extension>:<Get DCMI Capabilities>
+ 0x2C:0x02    //<Group Extension>:<Get Power Reading>
+diff --git a/transporthandler.cpp b/transporthandler.cpp
+index 0de76c4..b81e0d5 100644
+--- a/transporthandler.cpp
++++ b/transporthandler.cpp
+@@ -2120,6 +2120,28 @@ static int getSOLParameter(const std::string& property, ipmi::Value& value,
+     return 0;
+ }
+ 
++constexpr const char* consoleInterface = "xyz.openbmc_project.console";
++constexpr const char* consolePath = "/xyz/openbmc_project/console";
++static int getSOLBaudRate(ipmi::Value& value)
++{
++    auto dbus = getSdBus();
++
++    try
++    {
++        value =
++            ipmi::getDbusProperty(*dbus, "xyz.openbmc_project.console",
++                                  consolePath, consoleInterface, "baudrate");
++    }
++    catch (sdbusplus::exception_t&)
++    {
++        phosphor::logging::log<phosphor::logging::level::ERR>(
++            "Error getting sol baud rate");
++        return -1;
++    }
++
++    return 0;
++}
++
+ static const constexpr uint8_t encryptMask = 0x80;
+ static const constexpr uint8_t encryptShift = 7;
+ static const constexpr uint8_t authMask = 0x40;
+@@ -2322,6 +2344,171 @@ ipmi::RspType<> setSOLConfParams(ipmi::Context::ptr ctx, uint4_t chNum,
+     return ipmi::responseSuccess();
+ }
+ 
++static const constexpr uint8_t retryCountMask = 0x07;
++static constexpr uint16_t ipmiStdPort = 623;
++static constexpr uint8_t solParameterRevision = 0x11;
++ipmi::RspType<uint8_t, std::optional<uint8_t>, std::optional<uint8_t>>
++    getSOLConfParams(ipmi::Context::ptr ctx, uint4_t chNum, uint3_t reserved,
++                     bool getParamRev, uint8_t paramSelector,
++                     uint8_t setSelector, uint8_t blockSelector)
++{
++    ipmi::ChannelInfo chInfo;
++    uint8_t channelNum = ipmi::convertCurrentChannelNum(
++        static_cast<uint8_t>(chNum), ctx->channel);
++    if (reserved != 0 ||
++        (!ipmi::isValidChannel(static_cast<uint8_t>(channelNum))) ||
++        (ipmi::EChannelSessSupported::none ==
++         ipmi::getChannelSessionSupport(static_cast<uint8_t>(channelNum))))
++    {
++        return ipmi::responseInvalidFieldRequest();
++    }
++    ipmi_ret_t compCode =
++        ipmi::getChannelInfo(static_cast<uint8_t>(channelNum), chInfo);
++    if (compCode != IPMI_CC_OK ||
++        chInfo.mediumType !=
++            static_cast<uint8_t>(ipmi::EChannelMediumType::lan8032))
++    {
++        return ipmi::responseInvalidFieldRequest();
++    }
++
++    if (getParamRev)
++    {
++        return ipmi::responseSuccess(solParameterRevision, std::nullopt,
++                                     std::nullopt);
++    }
++
++    ipmi::Value value;
++    switch (static_cast<sol::Parameter>(paramSelector))
++    {
++        case sol::Parameter::progress:
++        {
++            if (getSOLParameter("Progress", value, channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++            return ipmi::responseSuccess(
++                solParameterRevision, std::get<uint8_t>(value), std::nullopt);
++        }
++        case sol::Parameter::enable:
++        {
++            if (getSOLParameter("Enable", value, channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++            return ipmi::responseSuccess(
++                solParameterRevision,
++                static_cast<uint8_t>(std::get<bool>(value)), std::nullopt);
++        }
++        case sol::Parameter::authentication:
++        {
++            uint8_t authentication = 0;
++            if (getSOLParameter("Privilege", value, channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++            authentication = (std::get<uint8_t>(value) & 0x0f);
++
++            if (getSOLParameter("ForceAuthentication", value, channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++            authentication |=
++                (static_cast<uint8_t>(std::get<bool>(value)) << 6);
++
++            if (getSOLParameter("ForceEncryption", value, channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++            authentication |=
++                (static_cast<uint8_t>(std::get<bool>(value)) << 7);
++            return ipmi::responseSuccess(solParameterRevision, authentication,
++                                         std::nullopt);
++        }
++        case sol::Parameter::accumulate:
++        {
++            if (getSOLParameter("AccumulateIntervalMS", value, channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++
++            ipmi::Value value1;
++            if (getSOLParameter("Threshold", value1, channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++            return ipmi::responseSuccess(solParameterRevision,
++                                         std::get<uint8_t>(value),
++                                         std::get<uint8_t>(value1));
++        }
++        case sol::Parameter::retry:
++        {
++            if (getSOLParameter("RetryCount", value, channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++
++            ipmi::Value value1;
++            if (getSOLParameter("RetryIntervalMS", value1, channelNum) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++            return ipmi::responseSuccess(
++                solParameterRevision, std::get<uint8_t>(value) & retryCountMask,
++                std::get<uint8_t>(value1));
++        }
++        case sol::Parameter::channel:
++        {
++            return ipmi::responseSuccess(solParameterRevision, channelNum,
++                                         std::nullopt);
++        }
++        case sol::Parameter::port:
++        {
++            uint16_t port = htole16(ipmiStdPort);
++            auto buffer = reinterpret_cast<const uint8_t*>(&port);
++            return ipmi::responseSuccess(solParameterRevision, buffer[0],
++                                         buffer[1]);
++        }
++        case sol::Parameter::nvbitrate:
++        {
++            if (getSOLBaudRate(value) < 0)
++            {
++                return ipmi::responseUnspecifiedError();
++            }
++            uint8_t bitRate = 0;
++            uint32_t* pBaudRate = std::get_if<uint32_t>(&value);
++            if (!pBaudRate)
++            {
++                phosphor::logging::log<phosphor::logging::level::ERR>(
++                    "Failed to get valid baud rate from D-Bus interface");
++            }
++            switch (*pBaudRate)
++            {
++                case 9600:
++                    bitRate = 0x06;
++                    break;
++                case 19200:
++                    bitRate = 0x07;
++                    break;
++                case 38400:
++                    bitRate = 0x08;
++                    break;
++                case 57600:
++                    bitRate = 0x09;
++                    break;
++                case 115200:
++                    bitRate = 0x0a;
++                    break;
++                default:
++                    break;
++            }
++            return ipmi::responseSuccess(solParameterRevision, bitRate,
++                                         std::nullopt);
++        }
++        default:
++            return ipmi::responseParmNotSupported();
++    }
++}
++
+ void register_netfn_transport_functions()
+ {
+     ipmi::registerHandler(ipmi::prioOpenBmcBase, ipmi::netFnTransport,
+@@ -2334,4 +2521,8 @@ void register_netfn_transport_functions()
+     ipmi::registerHandler(ipmi::prioOpenBmcBase, ipmi::netFnTransport,
+                           ipmi::transport::cmdSetSolConfigParameters,
+                           ipmi::Privilege::Admin, setSOLConfParams);
++
++    ipmi::registerHandler(ipmi::prioOpenBmcBase, ipmi::netFnTransport,
++                          ipmi::transport::cmdGetSolConfigParameters,
++                          ipmi::Privilege::User, getSOLConfParams);
+ }
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -1,10 +1,10 @@
 inherit entity-utils
-#SRC_URI:remove:olympus-nuvoton = "git://github.com/openbmc/phosphor-host-ipmid"
-#SRC_URI:prepend:olympus-nuvoton = "git://github.com/Nuvoton-Israel/phosphor-host-ipmid"
-
-#SRCREV := "3f553e155500938a51a06173633c51be87ec463a"
 
 FILESEXTRAPATHS:append:olympus-nuvoton := "${THISDIR}/${PN}:"
+SRC_URI:append:olympus-nuvoton = " \
+    file://0059-Move-Set-SOL-config-parameter-to-host-ipmid.patch \
+    file://0060-Move-Get-SOL-config-parameter-to-host-ipmid.patch \
+    "
 
 DEPENDS:append:olympus-nuvoton = " \
     ${@entity_enabled(d, '', 'olympus-nuvoton-yaml-config')}"

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/settings/phosphor-settings-manager/sol-default.override.yml
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/settings/phosphor-settings-manager/sol-default.override.yml
@@ -8,3 +8,7 @@
               Default: 'true'
           Progress:
               Default: 0
+          ForceAuthentication:
+              Default: 'true'
+          ForceEncryption:
+              Default: 'true'


### PR DESCRIPTION
…nfig functions

Porting SOL config parameter functions from Intel patches.
And also update SOL default property ForceAuthentication and
ForceEncryption for avoid SOL set privilege-level command
get "Attempt to write read-only parameter" error.

test:
  robot ipmi/test_ipmi_sol.robot
  ipmitool -I lanplus -C 17 -N 3 -p 623 -U root -P 0penBmc -H <BMC_IP> sol set privilege-level user
  ipmitool -I lanplus -C 17 -N 3 -p 623 -U root -P 0penBmc -H <BMC_IP> sol info
  ipmitool sol info 1

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
