### PR TITLE
meta-quanta: meta-olympus-nuvoton: bmcweb: fix update service error

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0001-redfish-update_service-fix-fwUpdateErrorMatcher-cann.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0001-redfish-update_service-fix-fwUpdateErrorMatcher-cann.patch
@@ -1,0 +1,173 @@
+From 6f9d660c881931dbb5f62aa99454bede15d031bf Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Thu, 14 Oct 2021 17:50:12 +0800
+Subject: [PATCH] redfish: update_service: fix fwUpdateErrorMatcher cannot
+ working
+
+Because the phosphor logging commit ef952af2 disable the propChanged
+before ifacesAdded, the fwUpdateErrorMatcher cannot get any software
+error after image update. In this case we can only get internal error
+by fwAvailableTimer.
+Update fwUpdateErrorMatcher to get ifacesAdded dbus signal to handle
+software error correctly.
+---
+ redfish-core/lib/update_service.hpp | 138 ++++++++++++++++------------
+ 1 file changed, 81 insertions(+), 57 deletions(-)
+
+diff --git a/redfish-core/lib/update_service.hpp b/redfish-core/lib/update_service.hpp
+index 663d48bec..098f9c180 100644
+--- a/redfish-core/lib/update_service.hpp
++++ b/redfish-core/lib/update_service.hpp
+@@ -316,68 +316,92 @@ static void monitorForSoftwareAvailable(
+ 
+     fwUpdateErrorMatcher = std::make_unique<sdbusplus::bus::match::match>(
+         *crow::connections::systemBus,
+-        "type='signal',member='PropertiesChanged',path_namespace='/xyz/"
+-        "openbmc_project/logging/entry',"
+-        "arg0='xyz.openbmc_project.Logging.Entry'",
++        "interface='org.freedesktop.DBus.ObjectManager',type='signal',"
++        "member='InterfacesAdded',"
++        "path='/xyz/openbmc_project/logging'",
+         [asyncResp, url](sdbusplus::message::message& m) {
+-            BMCWEB_LOG_DEBUG << "Error Match fired";
+-            boost::container::flat_map<std::string, std::variant<std::string>>
+-                values;
+-            std::string objName;
+-            m.read(objName, values);
+-            auto find = values.find("Message");
+-            if (find == values.end())
+-            {
+-                return;
+-            }
+-            std::string* type = std::get_if<std::string>(&(find->second));
+-            if (type == nullptr)
+-            {
+-                return; // if this was our message, timeout will cover it
+-            }
+-            if (!boost::starts_with(*type, "xyz.openbmc_project.Software"))
+-            {
+-                return;
+-            }
+-            if (*type ==
+-                "xyz.openbmc_project.Software.Image.Error.UnTarFailure")
+-            {
+-                redfish::messages::invalidUpload(asyncResp->res, url,
+-                                                 "Invalid archive");
+-            }
+-            else if (*type == "xyz.openbmc_project.Software.Image.Error."
+-                              "ManifestFileFailure")
+-            {
+-                redfish::messages::invalidUpload(asyncResp->res, url,
+-                                                 "Invalid manifest");
+-            }
+-            else if (*type ==
+-                     "xyz.openbmc_project.Software.Image.Error.ImageFailure")
+-            {
+-                redfish::messages::invalidUpload(asyncResp->res, url,
+-                                                 "Invalid image format");
+-            }
+-            else if (*type == "xyz.openbmc_project.Software.Version.Error."
+-                              "AlreadyExists")
++            std::vector<std::pair<
++                std::string,
++                std::vector<std::pair<std::string, std::variant<std::string>>>>>
++                interfacesProperties;
++
++            sdbusplus::message::object_path objPath;
++            m.read(objPath, interfacesProperties);
++            BMCWEB_LOG_DEBUG << "obj path = " << objPath.str;
++            for (auto& interface : interfacesProperties)
+             {
++                if (interface.first == "xyz.openbmc_project.Logging.Entry")
++                {
++                    BMCWEB_LOG_DEBUG << "Error Match fired";
++                    auto values = interface.second; // vector<std::pair>
++                    auto find = std::find_if(
++                        values.begin(), values.end(),
++                        [](const std::pair<
++                            std::string, std::variant<std::string>>& val_pair) {
++                            return val_pair.first == "Message";
++                        });
++                    if (find == values.end())
++                    {
++                        return;
++                    }
++                    std::string* type =
++                        std::get_if<std::string>(&(find->second));
++                    if (type == nullptr)
++                    {
++                        return; // if this was our message, timeout will cover
++                                // it
++                    }
++                    if (!boost::starts_with(*type,
++                                            "xyz.openbmc_project.Software"))
++                    {
++                        return;
++                    }
++                    if (*type ==
++                        "xyz.openbmc_project.Software.Image.Error.UnTarFailure")
++                    {
++                        redfish::messages::invalidUpload(asyncResp->res, url,
++                                                         "Invalid archive");
++                    }
++                    else if (*type ==
++                             "xyz.openbmc_project.Software.Image.Error."
++                             "ManifestFileFailure")
++                    {
++                        redfish::messages::invalidUpload(asyncResp->res, url,
++                                                         "Invalid manifest");
++                    }
++                    else if (*type == "xyz.openbmc_project.Software.Image."
++                                      "Error.ImageFailure")
++                    {
++                        redfish::messages::invalidUpload(
++                            asyncResp->res, url, "Invalid image format");
++                    }
++                    else if (*type ==
++                             "xyz.openbmc_project.Software.Version.Error."
++                             "AlreadyExists")
++                    {
+ 
+-                redfish::messages::invalidUpload(
+-                    asyncResp->res, url, "Image version already exists");
++                        redfish::messages::invalidUpload(
++                            asyncResp->res, url,
++                            "Image version already exists");
+ 
+-                redfish::messages::resourceAlreadyExists(
+-                    asyncResp->res, "UpdateService.v1_5_0.UpdateService",
+-                    "Version", "uploaded version");
+-            }
+-            else if (*type ==
+-                     "xyz.openbmc_project.Software.Image.Error.BusyFailure")
+-            {
+-                redfish::messages::resourceExhaustion(asyncResp->res, url);
+-            }
+-            else
+-            {
+-                redfish::messages::internalError(asyncResp->res);
++                        redfish::messages::resourceAlreadyExists(
++                            asyncResp->res,
++                            "UpdateService.v1_5_0.UpdateService", "Version",
++                            "uploaded version");
++                    }
++                    else if (*type == "xyz.openbmc_project.Software.Image."
++                                      "Error.BusyFailure")
++                    {
++                        redfish::messages::resourceExhaustion(asyncResp->res,
++                                                              url);
++                    }
++                    else
++                    {
++                        redfish::messages::internalError(asyncResp->res);
++                    }
++                    fwAvailableTimer = nullptr;
++                }
+             }
+-            fwAvailableTimer = nullptr;
+         });
+ }
+ 
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -5,6 +5,7 @@ FILESEXTRAPATHS:prepend:olympus-nuvoton := "${THISDIR}/${PN}:"
 #SRC_URI:append:olympus-nuvoton = " file://0014-add-config-to-config-virtual-media-buffer-size.patch"
 #SRC_URI:append:olympus-nuvoton = " file://0016-manager-do-not-update-value-if-string-is-empty.patch"
 SRC_URI:append:olympus-nuvoton = " file://0018-redfish-log_services-fix-createDump-functionality.patch"
+SRC_URI:append:olympus-nuvoton = " file://0001-redfish-update_service-fix-fwUpdateErrorMatcher-cann.patch"
 
 # Enable CPU Log support
 EXTRA_OEMESON:append:olympus-nuvoton = " -Dredfish-cpu-log=enabled"
@@ -29,3 +30,6 @@ EXTRA_OEMESON:append:olympus-nuvoton = " -Dredfish-dump-log=enabled"
 
 # Enable dbus rest API /xyz/
 EXTRA_OEMESON:append:olympus-nuvoton = " -Drest=enabled"
+
+# Enable debug message
+#EXTRA_OEMESON:append:olympus-nuvoton = " -Dbmcweb-logging=enabled"


### PR DESCRIPTION
hander not working

Because the phosphor logging commit ef952af2 disable the propChanged
before ifacesAdded, the fwUpdateErrorMatcher cannot get any software
error after image update. In this case we can only get internal error
by fwAvailableTimer.(expect bad request)
Update fwUpdateErrorMatcher to get ifacesAdded dbus signal to handle
software error correctly.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
