### PR TITLE
meta-quanta: meta-olympus-nuvoton: phosphor-ipmi-fru: fix syntax error

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-fru_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-fru_%.bbappend
@@ -6,7 +6,7 @@ FILESEXTRAPATHS:prepend:olympus-nuvoton := "${THISDIR}/${PN}:"
 DEPENDS:append:olympus-nuvoton = " \
     ${@entity_enabled(d, '', 'olympus-nuvoton-yaml-config')}"
 
-EXTRA_OECONF_olympus-nuvoton = " \
+EXTRA_OECONF:olympus-nuvoton = " \
     ${@entity_enabled(d, '', 'YAML_GEN=${STAGING_DIR_HOST}${datadir}/olympus-nuvoton-yaml-config/ipmi-fru-read.yaml')} \
     ${@entity_enabled(d, '', 'PROP_YAML=${STAGING_DIR_HOST}${datadir}/olympus-nuvoton-yaml-config/ipmi-extra-properties.yaml')} \
     "


### PR DESCRIPTION
Fix phosphor-ipmi-fru recipe syntax error.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
