### PR TITLE
meta-evb-npcm845: phosphor-ecc: reload service file

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ecc/phosphor-ecc/phosphor-ecc.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ecc/phosphor-ecc/phosphor-ecc.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=phosphor ECC dbus
+Wants=phosphor-dbus-monitor.service
+After=phosphor-dbus-monitor.service
+ConditionPathExists=|/sys/devices/system/edac/mc
+
+[Service]
+ExecStart=/usr/bin/ecc_main
+Restart=always
+SyslogIdentifier=phosphor-ecc
+Type=dbus
+BusName=xyz.openbmc_project.memory.ECC
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ecc/phosphor-ecc_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ecc/phosphor-ecc_%.bbappend
@@ -1,0 +1,16 @@
+FILESEXTRAPATHS_prepend_evb-npcm845 := "${THISDIR}/${PN}:"
+
+# reload service files
+SRC_URI_append_evb-npcm845 = " \
+    file://phosphor-ecc.service \
+    "
+
+SYSTEMD_SERVICE_${PN}_append_evb-npcm845 = " \
+    phosphor-ecc.service \
+    "
+
+do_install_append_evb-npcm845() {
+    install -d ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/phosphor-ecc.service \
+        ${D}${systemd_unitdir}/system
+}


### PR DESCRIPTION
	Note: execute ecc_main only when ecc is enabled
	      service file will check below edac path
	      /sys/devices/system/edac/mc

Signed-off-by: Medad CChien <ctcchien@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
