### PR TITLE
phosphor-software-manager: report version alreay exist error

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager/report_same_version.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager/report_same_version.patch
@@ -1,0 +1,45 @@
+diff --git a/image_manager.cpp b/image_manager.cpp
+index a9a5a69..f4dadee 100644
+--- a/image_manager.cpp
++++ b/image_manager.cpp
+@@ -11,10 +11,11 @@
+ #include <sys/wait.h>
+ #include <unistd.h>
+ 
+-#include <elog-errors.hpp>
++#include <phosphor-logging/elog-errors.hpp>
+ #include <phosphor-logging/elog.hpp>
+ #include <phosphor-logging/lg2.hpp>
+ #include <xyz/openbmc_project/Software/Image/error.hpp>
++#include <xyz/openbmc_project/Software/Version/error.hpp>
+ 
+ #include <algorithm>
+ #include <cstring>
+@@ -31,11 +32,14 @@ namespace manager
+ PHOSPHOR_LOG2_USING;
+ using namespace phosphor::logging;
+ using namespace sdbusplus::xyz::openbmc_project::Software::Image::Error;
++using namespace sdbusplus::xyz::openbmc_project::Software::Version::Error;
++using ExitFail = xyz::openbmc_project::Software::Version::AlreadyExists;
+ namespace Software = phosphor::logging::xyz::openbmc_project::Software;
+ using ManifestFail = Software::Image::ManifestFileFailure;
+ using UnTarFail = Software::Image::UnTarFailure;
+ using InternalFail = Software::Image::InternalFailure;
+ using ImageFail = Software::Image::ImageFailure;
++using ExitFail = Software::Version::AlreadyExists;
+ namespace fs = std::filesystem;
+ 
+ struct RemovablePath
+@@ -219,8 +223,10 @@ int Manager::processImage(const std::string& tarFilePath)
+     }
+     else
+     {
+-        info("Software Object with the same version ({VERSION}) already exists",
+-             "VERSION", id);
++        error("Software Object with the same version ({VERSION}) already exists",
++              "VERSION", id);
++        report<AlreadyExists>(
++               ExitFail::IMAGE_VERSION(version.c_str()));
+     }
+     return 0;
+ }

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS:prepend:buv-runbmc := "${THISDIR}/${PN}:"
 SRC_URI:append:buv-runbmc = " \
     file://support_update_uboot_with_emmc_image.patch \
     file://restore_verify_bios.patch \
+    file://report_same_version.patch \
     "
 
 PACKAGECONFIG:buv-runbmc += "verify_signature flash_bios"

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager/report_same_version.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager/report_same_version.patch
@@ -1,0 +1,45 @@
+diff --git a/image_manager.cpp b/image_manager.cpp
+index a9a5a69..f4dadee 100644
+--- a/image_manager.cpp
++++ b/image_manager.cpp
+@@ -11,10 +11,11 @@
+ #include <sys/wait.h>
+ #include <unistd.h>
+ 
+-#include <elog-errors.hpp>
++#include <phosphor-logging/elog-errors.hpp>
+ #include <phosphor-logging/elog.hpp>
+ #include <phosphor-logging/lg2.hpp>
+ #include <xyz/openbmc_project/Software/Image/error.hpp>
++#include <xyz/openbmc_project/Software/Version/error.hpp>
+ 
+ #include <algorithm>
+ #include <cstring>
+@@ -31,11 +32,14 @@ namespace manager
+ PHOSPHOR_LOG2_USING;
+ using namespace phosphor::logging;
+ using namespace sdbusplus::xyz::openbmc_project::Software::Image::Error;
++using namespace sdbusplus::xyz::openbmc_project::Software::Version::Error;
++using ExitFail = xyz::openbmc_project::Software::Version::AlreadyExists;
+ namespace Software = phosphor::logging::xyz::openbmc_project::Software;
+ using ManifestFail = Software::Image::ManifestFileFailure;
+ using UnTarFail = Software::Image::UnTarFailure;
+ using InternalFail = Software::Image::InternalFailure;
+ using ImageFail = Software::Image::ImageFailure;
++using ExitFail = Software::Version::AlreadyExists;
+ namespace fs = std::filesystem;
+ 
+ struct RemovablePath
+@@ -219,8 +223,10 @@ int Manager::processImage(const std::string& tarFilePath)
+     }
+     else
+     {
+-        info("Software Object with the same version ({VERSION}) already exists",
+-             "VERSION", id);
++        error("Software Object with the same version ({VERSION}) already exists",
++              "VERSION", id);
++        report<AlreadyExists>(
++               ExitFail::IMAGE_VERSION(version.c_str()));
+     }
+     return 0;
+ }

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS:prepend:olympus-nuvoton := "${THISDIR}/${PN}:"
 
 SRC_URI:append:olympus-nuvoton = " file://support_update_uboot_with_emmc_image.patch"
 SRC_URI:append:olympus-nuvoton = " file://restore_verify_bios.patch"
+SRC_URI:append:olympus-nuvoton = " file://report_same_version.patch"
 
 PACKAGECONFIG:olympus-nuvoton += "verify_signature flash_bios"
 EXTRA_OEMESON:append:olympus-nuvoton = " -Doptional-images=image-bios"


### PR DESCRIPTION
We should report version already exist error instead of do nothing,
and just wait for bmcweb timeout (600 seconds).
If we can report the exist error, the bmcweb will return http 400
when recive error report. No need to wait for firmware update timer
timeout.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
