### PR TITLE
meta-nuvoton: correct uboot env size

### DIFF
--- a/meta-nuvoton/recipes-bsp/u-boot/u-boot-emmc.inc
+++ b/meta-nuvoton/recipes-bsp/u-boot/u-boot-emmc.inc
@@ -1,7 +1,7 @@
 SRC_URI:append:df-phosphor-mmc = " file://u-boot-emmc.cfg"
 SRC_URI:append:df-phosphor-mmc = " file://u-boot-env-emmc.txt"
 
-UBOOT_ENV_SIZE:df-phosphor-mmc = "0x10000"
+UBOOT_ENV_SIZE:df-phosphor-mmc = "0x40000"
 UBOOT_ENV:df-phosphor-mmc = "u-boot-env"
 UBOOT_ENV_SUFFIX:df-phosphor-mmc = "bin"
 UBOOT_ENV_TXT:df-phosphor-mmc = "u-boot-env-emmc.txt"


### PR DESCRIPTION
The wrong size setting will cause getting bad CRC32 when uboot load
environment settings from SPI flash.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
