### PR TITLE
meta-quanta: meta-olympus-nuvoton: software-manager: enable reboot guard

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager/obmc-flash-host-bios@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager/obmc-flash-host-bios@.service
@@ -5,4 +5,6 @@ Description=Flash Host Bios image %I to Host
 Type=oneshot
 RemainAfterExit=no
 ExecStartPre=/bin/mv /tmp/images/%i/image-bios /tmp/image-bios
+ExecStartPre=/usr/bin/obmc-flash-bmc rebootguardenable
 ExecStart=/usr/bin/bios-update.sh
+ExecStopPost=/usr/bin/obmc-flash-bmc rebootguarddisable

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager/obmc-flash-host-bios@.service
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager/obmc-flash-host-bios@.service
@@ -5,4 +5,6 @@ Description=Flash Host Bios image %I to Host
 Type=oneshot
 RemainAfterExit=no
 ExecStartPre=/bin/mv /tmp/images/%i/image-bios /tmp/image-bios
+ExecStartPre=/usr/bin/obmc-flash-bmc rebootguardenable
 ExecStart=/usr/bin/bios-update.sh
+ExecStopPost=/usr/bin/obmc-flash-bmc rebootguarddisable


### PR DESCRIPTION
The BIOS update progress is not trigger reboot guard in software
manager, enable it before bios update and disable it after update
finished.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
