### PR TITLE
meta-quanta: meta-olympus-nuvoton: fix service startup errors

### DIFF
--- a/meta-nuvoton/recipes-nuvoton/loadmcu/files/mcu-version.sh
+++ b/meta-nuvoton/recipes-nuvoton/loadmcu/files/mcu-version.sh
@@ -16,7 +16,7 @@ minor=`echo $version | awk '{print$1}'`
 version="V`echo $((major))`.`echo $((minor))`"
 
 if [ $version != "V0.0" ]; then
-   echo "VERSION_ID=$version" > /usr/share/phosphor-bmc-code-mgmt/mcu-release
+   echo "VERSION_ID=$version" > /var/lib/phosphor-bmc-code-mgmt/mcu-release
 else
-   echo "VERSION_ID=N/A" > /usr/share/phosphor-bmc-code-mgmt/mcu-release
+   echo "VERSION_ID=N/A" > /var/lib/phosphor-bmc-code-mgmt/mcu-release
 fi

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/fans/phosphor-pid-control/fan-boot-control.service
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/fans/phosphor-pid-control/fan-boot-control.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Set Fan to Default Duty as Booting Up
 DefaultDependencies=no
-ConditionPathExists=/sys/class/hwmon/hwmon6/pwm1
+ConditionPathExists=/sys/class/hwmon/hwmon5/pwm1
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
1. mcu version service: move version path to writable space
2. fan-boot-control: correct hwmon device

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
