### PR TITLE
meta-quanta: meta-olympus-nuvoton: fix pakage missing build break

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/conf/bblayers.conf.sample
+++ b/meta-quanta/meta-olympus-nuvoton/conf/bblayers.conf.sample
@@ -13,6 +13,7 @@ BBLAYERS ?= " \
   ##OEROOT##/meta-openembedded/meta-python \
   ##OEROOT##/meta-security \
   ##OEROOT##/meta-phosphor \
+  ##OEROOT##/meta-intel-openbmc \
   ##OEROOT##/meta-nuvoton \
   ##OEROOT##/meta-google \
   ##OEROOT##/meta-quanta \
@@ -26,6 +27,7 @@ BBLAYERS_NON_REMOVABLE ?= " \
   ##OEROOT##/meta-openembedded/meta-python \
   ##OEROOT##/meta-security \
   ##OEROOT##/meta-phosphor \
+  ##OEROOT##/meta-intel-openbmc \
   ##OEROOT##/meta-nuvoton \
   ##OEROOT##/meta-google \
   ##OEROOT##/meta-quanta \

--- a/meta-quanta/meta-olympus-nuvoton/recipes-olympus-nuvoton/packagegroups/packagegroup-olympus-nuvoton-apps.bb
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-olympus-nuvoton/packagegroups/packagegroup-olympus-nuvoton-apps.bb
@@ -61,7 +61,7 @@ RDEPENDS:${PN}-system = " \
         adm1278-hotswap-power-cycle \
         google-ipmi-sys \
         mac-address \
-        smbios-mdrv2 \
+        smbios-mdr \
         loadmcu \
         usb-network \
         nuvoton-ipmi-oem \


### PR DESCRIPTION
Missing change for commit 93ca686f6854d3e4e
1. package smbios-mdrv2 -> smbios-mdr
2. use the upstream intel oem ipmi need add intel layer back

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
