### PR TITLE
meta-quanta: meta-olympus-nuvoton: fix systemd services error

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-core/systemd/systemd_%.bbappend
@@ -1,5 +1,7 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend:olympus-nuvoton := "${THISDIR}/files:"
 
-SRC_URI += " \
+SRCREV:olympus-nuvoton = "4fa9d8f14523982482386d398d2b2669902f2098"
+
+SRC_URI:append:olympus-nuvoton = " \
     file://0001-networkd-create-new-socket.patch \
 "


### PR DESCRIPTION
We got serveral systemd services error after merge systemd code, like:
[FAILED] Failed to mount Huge Pages File System.
[FAILED] Failed to mount POSIX Message Queue File System.
[FAILED] Failed to start Rebuild Hardware Database.
[FAILED] Failed to start Commit a transient machine-id on disk.
[FAILED] Failed to start Platform Persistent Storage Archival.

All these failed get similar situation
 Active: failed (Result: start-limit-hit)
Condition: start condition failed at ...
=> 1. get start-limit-hit, 2. condition failed

These error cause by systemd change: ed8fbbf1745c6a
Bug: https://github.com/systemd/systemd/issues/21025

So, bump the systemd srcrev to 4fa9d8f1452

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
