### PR TITLE
meta-quanta: meta-olympus-nuvoton: move PACKAGE_CLASSES to rpm

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/conf/local.conf.sample
+++ b/meta-quanta/meta-olympus-nuvoton/conf/local.conf.sample
@@ -1,6 +1,6 @@
 MACHINE ??= "olympus-nuvoton"
 DISTRO ?= "openbmc-phosphor"
-PACKAGE_CLASSES ?= "package_ipk"
+PACKAGE_CLASSES ?= "package_rpm"
 SANITY_TESTED_DISTROS:append ?= " *"
 EXTRA_IMAGE_FEATURES = "debug-tweaks"
 USER_CLASSES ?= "buildstats image-prelink"


### PR DESCRIPTION
Due to we cannot build pass with package_ipk, use package_rpm first.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
