### PR TITLE
Revert "meta-quanta: olympus-nuvoton: x86-power-control: add obmc-map…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-x86/chassis/x86-power-control/obmc-mapper.target
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-x86/chassis/x86-power-control/obmc-mapper.target
@@ -1,4 +1,0 @@
-[Unit]
-Description=Phosphor Object Mapper
-RefuseManualStart=yes
-RefuseManualStop=yes

--- a/meta-quanta/meta-olympus-nuvoton/recipes-x86/chassis/x86-power-control_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-x86/chassis/x86-power-control_%.bbappend
@@ -3,11 +3,9 @@ FILESEXTRAPATHS:prepend:olympus-nuvoton := "${THISDIR}/${PN}:"
 SRC_URI:append:olympus-nuvoton = " file://power-config-host0.json"
 SRC_URI:append:olympus-nuvoton = " file://0001-support-host-boot-progress.patch"
 SRC_URI:append:olympus-nuvoton = " file://0002-add-support-chassis-on-off-target-files.patch"
-SRC_URI:append:olympus-nuvoton = " file://obmc-mapper.target"
 SRC_URI:append:olympus-nuvoton = " file://obmc-chassis-poweroff.target"
 SRC_URI:append:olympus-nuvoton = " file://obmc-chassis-poweron.target"
 
-SYSTEMD_SERVICE:${PN} += "obmc-mapper.target"
 SYSTEMD_SERVICE:${PN} += "obmc-chassis-poweroff.target"
 SYSTEMD_SERVICE:${PN} += "obmc-chassis-poweron.target"
 


### PR DESCRIPTION
…per.target"

This reverts commit 23317d1823bcd8e01b9f3ab715deb7045dc3d1a6.
The obmc-mapper.target already move to meta-phosphor/recipes-core/
by change 065ca47c7af, so we don't need porting again.

This change will fix the package ipk build fail issue.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
