### PR TITLE
meta-olympus-nuvoton: phosphor-software-manager: remove mmc only upda…

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager/avoid_update_bios_fail_remove_mmc
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager/avoid_update_bios_fail_remove_mmc
@@ -1,0 +1,16 @@
+diff --git a/item_updater.cpp b/item_updater.cpp
+index 35ffb39..cb1b5b7 100644
+--- a/item_updater.cpp
++++ b/item_updater.cpp
+@@ -371,7 +371,10 @@ void ItemUpdater::erase(std::string entryId)
+     if (it != versions.end())
+     {
+         // Delete ReadOnly partitions if it's not active
+-        removeReadOnlyPartition(entryId);
++        if (it->second->purpose == VersionPurpose::BMC)
++        {
++            removeReadOnlyPartition(entryId);
++        }
+         removePersistDataDirectory(entryId);
+ 
+         // Removing entry in versions map

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS:prepend:olympus-nuvoton := "${THISDIR}/${PN}:"
 SRC_URI:append:olympus-nuvoton = " file://support_update_uboot_with_emmc_image.patch"
 SRC_URI:append:olympus-nuvoton = " file://restore_verify_bios.patch"
 SRC_URI:append:olympus-nuvoton = " file://report_same_version.patch"
+SRC_URI:append:olympus-nuvoton = " file://avoid_update_bios_fail_remove_mmc"
 
 PACKAGECONFIG:append:olympus-nuvoton = " verify_signature flash_bios"
 EXTRA_OEMESON:append:olympus-nuvoton = " -Doptional-images=image-bios"


### PR DESCRIPTION
…te BMC

Avoid remove mmc read only parition when update BIOS image.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
