### PR TITLE
meta-quanta: olympus-nuvoton: bmcweb: update patch

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0018-redfish-log_services-fix-createDump-functionality.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0018-redfish-log_services-fix-createDump-functionality.patch
@@ -1,23 +1,23 @@
-From 659c0c5b7a72e62728fb336d3970881d05a6c557 Mon Sep 17 00:00:00 2001
+From 4025c7e3c3bca702b523074eb40524b36930834a Mon Sep 17 00:00:00 2001
 From: Tim Lee <timlee660101@gmail.com>
-Date: Mon, 7 Jun 2021 16:44:05 +0800
+Date: Fri, 7 Jan 2022 13:36:07 +0800
 Subject: [PATCH 18/18] redfish: log_services: fix createDump functionality
 
 Signed-off-by: Tim Lee <timlee660101@gmail.com>
 ---
- redfish-core/lib/log_services.hpp | 43 ++++++++++++++++++++++++++++---
- 1 file changed, 40 insertions(+), 3 deletions(-)
+ redfish-core/lib/log_services.hpp | 46 ++++++++++++++++++++++++++++---
+ 1 file changed, 42 insertions(+), 4 deletions(-)
 
 diff --git a/redfish-core/lib/log_services.hpp b/redfish-core/lib/log_services.hpp
-index 92caac9c1..62744f497 100644
+index 074c927d4..b728e8f75 100644
 --- a/redfish-core/lib/log_services.hpp
 +++ b/redfish-core/lib/log_services.hpp
-@@ -849,21 +849,58 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
- 
+@@ -846,22 +846,60 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
      crow::connections::systemBus->async_method_call(
-         [asyncResp, req, dumpPath, dumpType](const boost::system::error_code ec,
--                                             const uint32_t& dumpId) {
-+                                             const sdbusplus::message::object_path& objPath) {
+         [asyncResp, payload(task::Payload(req)), dumpPath,
+          dumpType](const boost::system::error_code ec,
+-                   const uint32_t& dumpId) mutable {
++                   const sdbusplus::message::object_path& objPath) mutable {
              if (ec)
              {
                  BMCWEB_LOG_ERROR << "CreateDump resp_handler got error " << ec;
@@ -36,7 +36,10 @@ index 92caac9c1..62744f497 100644
 +            auto dumpId = std::stoul(idString);
              BMCWEB_LOG_DEBUG << "Dump Created. Id: " << dumpId;
  
--            createDumpTaskCallback(req, asyncResp, dumpId, dumpPath, dumpType);
+-            createDumpTaskCallback(std::move(payload), asyncResp, dumpId,
+-                                   dumpPath, dumpType);
++            //createDumpTaskCallback(std::move(payload), asyncResp, dumpId,
++            //                       dumpPath, dumpType);
 +            std::shared_ptr<task::TaskData> task = task::TaskData::createTask(
 +                [dumpPath, dumpId](boost::system::error_code err, sdbusplus::message::message&,
 +                    const std::shared_ptr<task::TaskData>& taskData) {
@@ -64,7 +67,7 @@ index 92caac9c1..62744f497 100644
 +                objPath.str + "'");
 +            task->startTimer(std::chrono::minutes(5));
 +            task->populateResp(asyncResp->res);
-+            task->payload.emplace(req);
++            task->payload.emplace(std::move(payload));
          },
          "xyz.openbmc_project.Dump.Manager",
          "/xyz/openbmc_project/dump/" +

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -2,8 +2,7 @@ FILESEXTRAPATHS:prepend:olympus-nuvoton := "${THISDIR}/${PN}:"
 
 SRC_URI:append:olympus-nuvoton = " file://0003-Redfish-Add-power-metrics-support.patch"
 SRC_URI:append:olympus-nuvoton = " file://0005-bmcweb-chassis-add-indicatorLED-support.patch"
-# TODO:remove for build pass, need to fix
-#SRC_URI:append:olympus-nuvoton = " file://0018-redfish-log_services-fix-createDump-functionality.patch"
+SRC_URI:append:olympus-nuvoton = " file://0018-redfish-log_services-fix-createDump-functionality.patch"
 SRC_URI:append:olympus-nuvoton = " file://0001-redfish-update_service-fix-fwUpdateErrorMatcher-cann.patch"
 
 # Enable CPU Log support


### PR DESCRIPTION
Correct our previous patch for this functionality with the latest upstream
0018-redfish-log_services-fix-createDump-functionality.patch

Signed-off-by: Tim Lee <timlee660101@gmail.com>
