### PR TITLE
meta-quanta:meta-olympus-nuvoton:dbus-sensors: update patch

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/sensors/dbus-sensors/0001-Add-more-PSU-devices-support.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/sensors/dbus-sensors/0001-Add-more-PSU-devices-support.patch
@@ -1,25 +1,27 @@
-From d9c1e78f711032faeb2f43157f61147976d59ffb Mon Sep 17 00:00:00 2001
+From bae410c9b41cc838cd38f6c704980d957cf04c75 Mon Sep 17 00:00:00 2001
 From: Brian Ma <chma0@nuvoton.com>
 Date: Thu, 15 Jul 2021 14:54:27 +0800
 Subject: [PATCH] Add more PSU devices support
 
 ---
- src/PSUSensorMain.cpp | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
+ src/PSUSensorMain.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/src/PSUSensorMain.cpp b/src/PSUSensorMain.cpp
-index 6595db9..f926ddc 100644
+index ae7afc37..ebb49b4b 100644
 --- a/src/PSUSensorMain.cpp
 +++ b/src/PSUSensorMain.cpp
-@@ -72,7 +72,8 @@ static std::vector<std::string> pmbusNames = {
-     "ina230",   "ipsps1",    "isl68137",  "isl68220",  "isl68223",
-     "isl69243", "isl69260",  "lm25066",   "max16601",  "max20710",
-     "max20730", "max20734",  "max20796",  "max34451",  "pmbus",
--    "pxe1610",  "raa228000", "raa228228", "raa229004", "tps546d24"};
-+    "pxe1610",  "raa228000", "raa228228", "raa229004", "tps546d24",
-+    "flexpower", "tps53659", "tps53679"};
- 
- namespace fs = std::filesystem;
+@@ -99,7 +99,10 @@ static constexpr auto pmbusNames{std::to_array<const char*>({
+     "raa228228",
+     "raa229004",
+     "tps546d24",
+-    "xdpe12284"
++    "xdpe12284",
++    "flexpower",
++    "tps53659",
++    "tps53679"
+ })};
+ //clang-format on
  
 -- 
 2.17.1


### PR DESCRIPTION
Update dbus sensor patch to fix build break for distro olympus-entity

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
