### PR TITLE
meta-quanta: meta-olympus-nuvoton: nslcd: disalbe rate limiting

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-support/nss-pam-ldapd/nss-pam-ldapd/nslcd.service
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-support/nss-pam-ldapd/nss-pam-ldapd/nslcd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=LDAP daemon
+After=syslog.target network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/nslcd
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-quanta/meta-olympus-nuvoton/recipes-support/nss-pam-ldapd/nss-pam-ldapd_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-support/nss-pam-ldapd/nss-pam-ldapd_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend:olympus-nuvoton := "${THISDIR}/${PN}:"


### PR DESCRIPTION
When LDAP configuration change by bmcweb, the nslcd will be disabled
first, then be enabled after configuration modified. This action not
take much time, then systemd will count the restart. In LDAP testing,
the case will reach "start-limit-hit" after we continue update LDAP
configuration or update configuraion after BMC reboot.
Set StartLimitIntervalSec=0 to disable the restart counter, because
nslcd service may restart many time in real case.

Ref: man systemd.unit
Test:
  redfish/account_service/test_ldap_configuration.robot

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
