### PR TITLE
bitbake: fetch/git: Handle github dropping git:// support

### DIFF
--- a/poky/bitbake/lib/bb/fetch2/git.py
+++ b/poky/bitbake/lib/bb/fetch2/git.py
@@ -142,6 +142,10 @@ class Git(FetchMethod):
             ud.proto = 'file'
         else:
             ud.proto = "git"
+        if ud.host == "github.com" and ud.proto == "git":
+            # github stopped supporting git protocol
+            # https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git
+            ud.proto = "https"
 
         if not ud.proto in ('git', 'file', 'ssh', 'http', 'https', 'rsync'):
             raise bb.fetch2.ParameterError("Invalid protocol type", ud.url)


### PR DESCRIPTION
github is dropping support for git protocol in Git urls. Add code to remap
this to https in a way that could be used in older bitbake versions.

(Bitbake rev: f05e19135b3ddee509c0cb427b3b9376bb4738d1)

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>

cherr-pick from poky gerrit commit: 5fb6b453f633796f28e230420e17b644adde8b11
