### PR TITLE
meta-quanta :olympus-nuvoton: sel-logger: remove log pulse

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/sel-logger/phosphor-sel-logger_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/sel-logger/phosphor-sel-logger_%.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS:append:olympus-nuvoton := "${THISDIR}/${PN}:"
 
-PACKAGECONFIG:append:olympus-nuvoton= " log-threshold log-alarm log-pulse log-watchdog"
+PACKAGECONFIG:append:olympus-nuvoton= " log-threshold log-alarm log-watchdog"


### PR DESCRIPTION
The x86 power control already report host power on/off log with
redifsh journal format, we don't need enable this function in
sel logger.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

