### PR TITLE
meta-nuvoton: linux-nuvoton: bump srcrev: 9ecbd27ae9..6dbbbd5bb7

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_git.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_git.bb
@@ -1,7 +1,7 @@
 KBRANCH ?= "NPCM-5.10-OpenBMC"
 LINUX_VERSION ?= "5.10.67"
 
-SRCREV="9ecbd27ae90c936dd828ed148c94313bcb4e2073"
+SRCREV="6dbbbd5bb701b72c97e993cb06d4f1151c49d5d6"
 
 require linux-nuvoton.inc
 


### PR DESCRIPTION
Jason M. Bills (1):
      Fix truncated WrEndPointConfig MMIO command

Joseph Liu (2):
      gpio: nuvoton spgio: fixed format
      gpio: nuvoton: sgpio: fix incorrect index of array

Medad CChien (1):
      driver: edac: npcm8xx: Support Cadence DDR4-ECC EDAC Driver

Stanley Chu (9):
      i3c: master: svc: remove free_irq from remove function
      i3c: Add description of setaasa variable in i3c_bus structure
      i3c: Add I3CDEV support
      npcm845-evb: enable I3C bus2 for connecting with SPD5118 module
      arm: dts: npcm845-evb: add a PMIC i3c slave device on bus 2
      misc: eeprom: Add remove function for spd5118 driver
      i3c: i3cdev: update i3cdev driver
      arm: dts: npcm845-evb: remove devices on i3c2
      arm: dts: npcm845-evb: remove spi-rx-bus-width property from FIU1 node

Tim Lee (4):
      dt-bindings: hwmon: Add NPCM7XX MCU I2C ADC support
      dt-bindings: bmc: add NPCM7XX MCU Flash documentation
      dt-bindings: fix document format for mcu
      misc: npcm7xx-mcu-flash: change default pin configuration

Tomer Maimon (2):
      crypto: npcm-sha: Add NPCM SHA driver
      pci: pcie-npcm: Modify NPCM PCI driver

jimliu2 (3):
      dt-bindings: gpio: Add NPCM7XX MCU_GPI and SGPIO support
      drivers: gpio: add npcm7xx mcu gpi expander driver
      drivers: gpio: rename gpio-npcm-gpi.c

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
