### PR TITLE
meta-nuvoton/buv-runbmc/olympus-nuvoton: use https intead of git

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/sensors/pldmsensors_git.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/sensors/pldmsensors_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "pldmsensors"
 DESCRIPTION = "PLDM Sensor Services Configured from D-Bus"
 
-SRC_URI = "git://github.com/Nuvoton-Israel/pldmsensors.git;protocol=ssh;branch=main;"
+SRC_URI = "git://github.com/Nuvoton-Israel/pldmsensors.git;protocol=https;branch=main;"
 
 SRCREV = "c0bac1546c0f4c5c38eaf0ab6b0cc473a6823ec2"
 

--- a/meta-nuvoton/recipes-bsp/images/npcm7xx-bingo-native_git.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm7xx-bingo-native_git.bb
@@ -6,7 +6,7 @@ PV = "0.1+git${SRCPV}"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI += "git://github.com/Nuvoton-Israel/bingo"
+SRC_URI += "git://github.com/Nuvoton-Israel/bingo;protocol=https"
 SRCREV = "4f102ff7851da9fd11965857edd1b3046c187b7a"
 
 S = "${WORKDIR}/git"

--- a/meta-nuvoton/recipes-bsp/images/npcm7xx-igps-native_02.01.12.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm7xx-igps-native_02.01.12.bb
@@ -5,7 +5,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRC_URI = " \
-    git://github.com/Nuvoton-Israel/igps \
+    git://github.com/Nuvoton-Israel/igps;protocol=https \
     file://0001-Adjust-paths-for-use-with-Bitbake.patch \
     file://0002-MFG-Test.patch \
 "

--- a/meta-nuvoton/recipes-nuvoton/ipmi/nuvoton-ipmi-oem_git.bb
+++ b/meta-nuvoton/recipes-nuvoton/ipmi/nuvoton-ipmi-oem_git.bb
@@ -17,7 +17,7 @@ DEPENDS += "phosphor-ipmi-host"
 DEPENDS += "nlohmann-json"
 
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/Nuvoton-Israel/nuvoton-ipmi-oem"
+SRC_URI = "git://github.com/Nuvoton-Israel/nuvoton-ipmi-oem;protocol=https"
 SRCREV = "fe6a355c1e8ac1eb334a40e11ae0e9ff52eda062"
 
 FILES:${PN}:append = " ${libdir}/ipmid-providers/lib*${SOLIBS}"

--- a/meta-nuvoton/recipes-nuvoton/loadmcu/loadmcu.bb
+++ b/meta-nuvoton/recipes-nuvoton/loadmcu/loadmcu.bb
@@ -13,11 +13,11 @@ DEPENDS += "systemd"
 DEPENDS += "autoconf-archive-native"
 RDEPENDS_${PN} += "bash"
 
-SRC_URI += " git://github.com/Nuvoton-Israel/loadmcu.git \
-             file://mcu-update.service \
-             file://mcu-version.sh \
-             file://mcu-version@.service \
-           "
+SRC_URI = "git://github.com/Nuvoton-Israel/loadmcu.git;protocol=https \
+           file://mcu-update.service \
+           file://mcu-version.sh \
+           file://mcu-version@.service \
+          "
 SRCREV = "12fed94b53f6fa0fe1c96bee264c7e363f2ed7d8"
 S = "${WORKDIR}/git"
 

--- a/meta-nuvoton/recipes-nuvoton/loadsvf/loadsvf_git.bb
+++ b/meta-nuvoton/recipes-nuvoton/loadsvf/loadsvf_git.bb
@@ -4,7 +4,7 @@ PR = "r1"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/Nuvoton-Israel/loadsvf.git"
+SRC_URI = "git://github.com/Nuvoton-Israel/loadsvf.git;protocol=https"
 SRCREV = "aba0e177c6c7ca58e240d384892f452c5aec6a21"
 S = "${WORKDIR}/git"
 

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/sensors/pldmsensors_git.bb
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/sensors/pldmsensors_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "pldmsensors"
 DESCRIPTION = "PLDM Sensor Services Configured from D-Bus"
 
-SRC_URI = "git://github.com/Nuvoton-Israel/pldmsensors.git;protocol=ssh;branch=main;"
+SRC_URI = "git://github.com/Nuvoton-Israel/pldmsensors.git;protocol=https;branch=main;"
 
 SRCREV = "c904995efa2865e4091841a582d0c39fc4333769"
 

--- a/meta-quanta/meta-olympus-nuvoton/recipes-x86/asd/asd.bb
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-x86/asd/asd.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Intel at-scale-debug"
 
-SRC_URI = "git://github.com/Intel-BMC/asd.git"
+SRC_URI = "git://github.com/Intel-BMC/asd.git;protocol=https"
 SRCREV = "1.4.4"
 PV = "0.1+git${SRCPV}"
 

--- a/meta-quanta/meta-olympus-nuvoton/recipes-x86/crashdump/crashdump_git.bb
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-x86/crashdump/crashdump_git.bb
@@ -12,7 +12,7 @@ EXTRA_OECMAKE = "-DYOCTO_DEPENDENCIES=ON -DCRASHDUMP_BUILD_UT=OFF"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=43c09494f6b77f344027eea0a1c22830"
 
-SRC_URI = "git://git@github.com/Intel-BMC/crashdump;protocol=ssh;nobranch=1"
+SRC_URI = "git://git@github.com/Intel-BMC/crashdump;protocol=https;nobranch=1"
 SRCREV = "wht-1.0.6"
 
 S = "${WORKDIR}/git"

--- a/meta-quanta/meta-olympus-nuvoton/recipes-x86/node-manager/phosphor-node-manager-proxy_git.bb
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-x86/node-manager/phosphor-node-manager-proxy_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "Node Manager Proxy"
 DESCRIPTION = "The Node Manager Proxy provides a simple interface for communicating \
 with Management Engine via IPMB"
 
-SRC_URI = "git://git@github.com/Intel-BMC/node-manager;protocol=ssh"
+SRC_URI = "git://git@github.com/Intel-BMC/node-manager;protocol=https"
 SRCREV = "de212d839bb515939bd089c66072e4fcf33b8653"
 PV = "0.1+git${SRCPV}"
 


### PR DESCRIPTION
Github is no longer support git protocol from now, update all Nuvoton
own recipe to use https protocol instead.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
