### PR TITLE
meta-evb: evb-npcm845: systemd: fixed systemd network crash

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-core/systemd/systemd/0001-network-Fix-crash-while-dhcp4-address-gets-update.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-core/systemd/systemd/0001-network-Fix-crash-while-dhcp4-address-gets-update.patch
@@ -1,0 +1,73 @@
+From 5d0d622233a69c427ddba3ab70aef915e7a527bf Mon Sep 17 00:00:00 2001
+From: Joseph Liu <kwliu@nuvoton.com>
+Date: Tue, 4 May 2021 17:27:28 +0800
+Subject: [PATCH] network: Fix crash while dhcp4 address gets update
+
+---
+ src/network/networkd-address.c | 3 +++
+ src/network/networkd-address.h | 1 +
+ src/network/networkd-dhcp4.c   | 8 +++++++-
+ 3 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/src/network/networkd-address.c b/src/network/networkd-address.c
+index ef47af4628..8314662fd7 100644
+--- a/src/network/networkd-address.c
++++ b/src/network/networkd-address.c
+@@ -111,6 +111,9 @@ Address *address_free(Address *address) {
+         if (!address)
+                 return NULL;
+ 
++        if (address->keep_dhcp4_address)
++                return NULL;
++
+         if (address->network) {
+                 assert(address->section);
+                 ordered_hashmap_remove(address->network->addresses_by_section, address->section);
+diff --git a/src/network/networkd-address.h b/src/network/networkd-address.h
+index 56e81da822..197e435b63 100644
+--- a/src/network/networkd-address.h
++++ b/src/network/networkd-address.h
+@@ -37,6 +37,7 @@ typedef struct Address {
+         union in_addr_union in_addr_peer;
+ 
+         bool scope_set:1;
++        bool keep_dhcp4_address:1;
+         bool ip_masquerade_done:1;
+         AddressFamily duplicate_address_detection;
+ 
+diff --git a/src/network/networkd-dhcp4.c b/src/network/networkd-dhcp4.c
+index f3c1e5f609..3b24ed0baa 100644
+--- a/src/network/networkd-dhcp4.c
++++ b/src/network/networkd-dhcp4.c
+@@ -770,6 +770,11 @@ static int dhcp4_address_handler(sd_netlink *rtnl, sd_netlink_message *m, Link *
+         if (r < 0 && r != -EEXIST) {
+                 log_link_message_warning_errno(link, m, r, "Could not set DHCPv4 address");
+                 link_enter_failed(link);
++
++                /* If the dhcp4 address fails then remove the address */
++                address_remove(link->dhcp_address, link, NULL);
++                link->dhcp_address = NULL;
++
+                 return 1;
+         } else if (r >= 0)
+                 (void) manager_rtnl_process_address(rtnl, m, link->manager);
+@@ -783,6 +788,7 @@ static int dhcp4_address_handler(sd_netlink *rtnl, sd_netlink_message *m, Link *
+         } else
+                 link->dhcp_address->callback = dhcp4_address_ready_callback;
+ 
++        link->dhcp_address->keep_dhcp4_address = false;
+         return 1;
+ }
+ 
+@@ -874,7 +880,7 @@ static int dhcp4_update_address(Link *link, bool announce) {
+         if (!address_equal(link->dhcp_address, ret))
+                 link->dhcp_address_old = link->dhcp_address;
+         link->dhcp_address = ret;
+-
++        ret->keep_dhcp4_address = true;
+         return 0;
+ }
+ 
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-core/systemd/systemd/0001-networkd-create-new-socket.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-core/systemd/systemd/0001-networkd-create-new-socket.patch
@@ -1,0 +1,18 @@
+diff --git a/src/network/networkd-manager.c b/src/network/networkd-manager.c
+index a365bcbde7..85676bfb6a 100644
+--- a/src/network/networkd-manager.c
++++ b/src/network/networkd-manager.c
+@@ -1156,11 +1156,11 @@ static int manager_connect_genl(Manager *m) {
+ }
+ 
+ static int manager_connect_rtnl(Manager *m) {
+-        int fd, r;
++        int fd=-1, r;
+ 
+         assert(m);
+ 
+-        fd = systemd_netlink_fd();
++        //fd = systemd_netlink_fd();
+         if (fd < 0)
+                 r = sd_netlink_open(&m->rtnl);
+         else

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend_evb-npcm845 := "${THISDIR}/${PN}:"
+
+SRC_URI_append_evb-npcm845 += " \
+    file://0001-networkd-create-new-socket.patch \
+    file://0001-network-Fix-crash-while-dhcp4-address-gets-update.patch \
+"


### PR DESCRIPTION
Symptom:
systemd-networkd: Assertion 'a' failed at src/network/networkd-address.c:1868,
function address_is_ready(). Aborting.

Solution:
systemd-networkd: Fix crash while dhcp4 address gets update
https://github.com/systemd/systemd/pull/18306/commits/74b1c99521d7a97093ccfdf8ce68a12aff54f639

Verify:
Run Stress Test Arbel automation test.

Signed-off-by: Tim Lee <timlee660101@gmail.com>