### PR TITLE
meta-buv-runbmc: clean up use of OBMC_MACHINE_FEATURES

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/machine/buv-runbmc-spi.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/machine/buv-runbmc-spi.conf
@@ -18,13 +18,9 @@ IGPS_MACHINE = "RunBMC"
 IMAGE_FSTYPES += " cpio.${INITRAMFS_CTYPE}.u-boot"
 KERNEL_ALT_IMAGETYPE = "vmlinux"
 
-OBMC_MACHINE_FEATURES += "\
+MACHINE_FEATURES += "\
         obmc-phosphor-fan-mgmt \
         obmc-host-ipmi \
-        obmc-bmc-state-mgmt \
-        obmc-host-state-mgmt \
-        obmc-chassis-state-mgmt \
-        obmc-bmc-state-mgmt \
         obmc-phosphor-chassis-mgmt \
         "
 VIRTUAL-RUNTIME_obmc-host-state-manager = "x86-power-control"


### PR DESCRIPTION
From commmit ade3e145ead0beedad181394fcaa63856176bdee
the OBMC_MACHINE_FEATURES on longer use, use MACHINE_FEATURES
instead it.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

this change will fix pid controll not build in image
