### PR TITLE
meta-evb-npcm845: dbus-sensors: add thermal zone support

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/configuration/entity-manager/NUVOTON-ARBEL-EVB.json
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/configuration/entity-manager/NUVOTON-ARBEL-EVB.json
@@ -457,6 +457,74 @@
                 }
             ],
             "Type": "TMP100"
+        },
+        {
+            "Address": "0",
+            "Bus": "0",
+            "EntityId": 7,
+            "EntityInstance": 4,
+            "Name": "BMC_CPU_Temp0",
+            "Thresholds": [
+                {
+                    "Direction": "greater than",
+                    "Name": "upper critical",
+                    "Severity": 1,
+                    "Value": 75.000
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 60.000
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 15.000
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 0
+                }
+            ],
+            "Type": "THERMALZONE"
+        },
+        {
+            "Address": "1",
+            "Bus": "0",
+            "EntityId": 7,
+            "EntityInstance": 5,
+            "Name": "BMC_CPU_Temp1",
+            "Thresholds": [
+                {
+                    "Direction": "greater than",
+                    "Name": "upper critical",
+                    "Severity": 1,
+                    "Value": 75.000
+                },
+                {
+                    "Direction": "greater than",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 60.000
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 15.000
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 0
+                }
+            ],
+            "Type": "THERMALZONE"
         }
     ],
     "Name": "EVB_ARBEL_NUVOTON",

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/sensors/dbus-sensors/0002-Add-thermal-zone-support-in-hwmon-sensor.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/sensors/dbus-sensors/0002-Add-thermal-zone-support-in-hwmon-sensor.patch
@@ -1,0 +1,96 @@
+From 4ed4c936391d2a708a29cad55cd9b461ff47f8dd Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Fri, 11 Feb 2022 14:51:03 +0800
+Subject: [PATCH 2/2] Add thermal zone support in hwmon sensor
+
+---
+ src/HwmonTempMain.cpp | 44 +++++++++++++++++++++++++++++++------------
+ 1 file changed, 32 insertions(+), 12 deletions(-)
+
+diff --git a/src/HwmonTempMain.cpp b/src/HwmonTempMain.cpp
+index 022c4837..dc32dd49 100644
+--- a/src/HwmonTempMain.cpp
++++ b/src/HwmonTempMain.cpp
+@@ -40,7 +40,7 @@ static constexpr bool debug = false;
+ static constexpr float pollRateDefault = 0.5;
+ 
+ namespace fs = std::filesystem;
+-static constexpr std::array<const char*, 17> sensorTypes = {
++static constexpr std::array<const char*, 18> sensorTypes = {
+     "xyz.openbmc_project.Configuration.EMC1412",
+     "xyz.openbmc_project.Configuration.EMC1413",
+     "xyz.openbmc_project.Configuration.EMC1414",
+@@ -50,13 +50,14 @@ static constexpr std::array<const char*, 17> sensorTypes = {
+     "xyz.openbmc_project.Configuration.MAX6654",
+     "xyz.openbmc_project.Configuration.SBTSI",
+     "xyz.openbmc_project.Configuration.LM95234",
+-    "xyz.openbmc_project.Configuration.TMP100",
+     "xyz.openbmc_project.Configuration.TMP112",
+     "xyz.openbmc_project.Configuration.TMP175",
+     "xyz.openbmc_project.Configuration.TMP421",
+     "xyz.openbmc_project.Configuration.TMP441",
+     "xyz.openbmc_project.Configuration.LM75A",
+     "xyz.openbmc_project.Configuration.TMP75",
++    "xyz.openbmc_project.Configuration.TMP100",
++    "xyz.openbmc_project.Configuration.THERMALZONE",
+     "xyz.openbmc_project.Configuration.W83773G"};
+ 
+ void createSensors(
+@@ -100,25 +101,44 @@ void createSensors(
+ 
+                 fs::path device = directory / "device";
+                 std::string deviceName = fs::canonical(device).stem();
++                static const std::string thermalZone = "thermal_zone";
+                 auto findHyphen = deviceName.find('-');
+-                if (findHyphen == std::string::npos)
++                auto findThermalZone = deviceName.find(thermalZone);
++                if (findHyphen == std::string::npos &&
++                    findThermalZone == std::string::npos)
+                 {
+                     std::cerr << "found bad device " << deviceName << "\n";
+                     continue;
+                 }
+-                std::string busStr = deviceName.substr(0, findHyphen);
+-                std::string addrStr = deviceName.substr(findHyphen + 1);
+-
+                 size_t bus = 0;
+                 size_t addr = 0;
+-                try
++                if (findThermalZone == std::string::npos)
+                 {
+-                    bus = std::stoi(busStr);
+-                    addr = std::stoi(addrStr, nullptr, 16);
++                    std::string busStr = deviceName.substr(0, findHyphen);
++                    std::string addrStr = deviceName.substr(findHyphen + 1);
++
++                    try
++                    {
++                        bus = std::stoi(busStr);
++                        addr = std::stoi(addrStr, nullptr, 16);
++                    }
++                    catch (std::invalid_argument&)
++                    {
++                        continue;
++                    }
+                 }
+-                catch (std::invalid_argument&)
+-                {
+-                    continue;
++                else{
++                    // ex: thermal_zone0
++                    std::string addrStr = deviceName.substr(findThermalZone + thermalZone.length());
++                    try
++                    {
++                        addr = std::stoi(addrStr);
++                    }
++                    catch(const std::invalid_argument&)
++                    {
++                        std::cerr << "Cannot get zone number: " << deviceName << "\n";
++                        continue;
++                    }
+                 }
+                 const SensorData* sensorData = nullptr;
+                 const std::string* interfacePath = nullptr;
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/sensors/dbus-sensors_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/sensors/dbus-sensors_%.bbappend
@@ -2,4 +2,5 @@ FILESEXTRAPATHS_prepend_evb-npcm845 := "${THISDIR}/${PN}:"
 
 SRC_URI_append_evb-npcm845 = " \
     file://0001-hwmon-temp-add-tmp100-support.patch \
+    file://0002-Add-thermal-zone-support-in-hwmon-sensor.patch \
     "


### PR DESCRIPTION
Add thermal zone support as hwmon temperture sensor, and also
update entity manager configuration.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
