### PR TITLE
meta-evb-npcm845: dbus-sensors: add thermal zone support

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/sensors/dbus-sensors/0002-Add-thermal-zone-support-in-hwmon-sensor.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/sensors/dbus-sensors/0002-Add-thermal-zone-support-in-hwmon-sensor.patch
@@ -1,0 +1,88 @@
+From f20bfeda7e22931ea5d0a5c3ebf35124b45d2d78 Mon Sep 17 00:00:00 2001
+From: Medad CChien <ctcchien@nuvoton.com>
+Date: Tue, 15 Feb 2022 11:04:32 +0800
+Subject: [PATCH 2/2] Add thermal zone support in hwmon sensor
+
+Signed-off-by: Medad CChien <ctcchien@nuvoton.com>
+---
+ src/HwmonTempMain.cpp | 41 +++++++++++++++++++++++++++++++----------
+ 1 file changed, 31 insertions(+), 10 deletions(-)
+
+diff --git a/src/HwmonTempMain.cpp b/src/HwmonTempMain.cpp
+index 3a3248da..1e3b701e 100644
+--- a/src/HwmonTempMain.cpp
++++ b/src/HwmonTempMain.cpp
+@@ -50,13 +50,14 @@ static auto sensorTypes{
+                                 "xyz.openbmc_project.Configuration.NCT7802",
+                                 "xyz.openbmc_project.Configuration.SBTSI",
+                                 "xyz.openbmc_project.Configuration.LM95234",
+-                                "xyz.openbmc_project.Configuration.TMP100",
+                                 "xyz.openbmc_project.Configuration.TMP112",
+                                 "xyz.openbmc_project.Configuration.TMP175",
+                                 "xyz.openbmc_project.Configuration.TMP421",
+                                 "xyz.openbmc_project.Configuration.TMP441",
+                                 "xyz.openbmc_project.Configuration.LM75A",
+                                 "xyz.openbmc_project.Configuration.TMP75",
++                                "xyz.openbmc_project.Configuration.TMP100",
++                                "xyz.openbmc_project.Configuration.THERMALZONE",
+                                 "xyz.openbmc_project.Configuration.W83773G",
+                                 "xyz.openbmc_project.Configuration.JC42"})};
+ 
+@@ -99,25 +100,45 @@ void createSensors(
+ 
+                 fs::path device = directory / "device";
+                 std::string deviceName = fs::canonical(device).stem();
++                static const std::string thermalZone = "thermal_zone";
+                 auto findHyphen = deviceName.find('-');
+-                if (findHyphen == std::string::npos)
++                auto findThermalZone = deviceName.find(thermalZone);
++                if (findHyphen == std::string::npos &&
++                    findThermalZone == std::string::npos)
+                 {
+                     std::cerr << "found bad device " << deviceName << "\n";
+                     continue;
+                 }
+-                std::string busStr = deviceName.substr(0, findHyphen);
+-                std::string addrStr = deviceName.substr(findHyphen + 1);
+ 
+                 size_t bus = 0;
+                 size_t addr = 0;
+-                try
++                if (findThermalZone == std::string::npos)
+                 {
+-                    bus = std::stoi(busStr);
+-                    addr = std::stoi(addrStr, nullptr, 16);
++                    std::string busStr = deviceName.substr(0, findHyphen);
++                    std::string addrStr = deviceName.substr(findHyphen + 1);
++
++                    try
++                    {
++                        bus = std::stoi(busStr);
++                        addr = std::stoi(addrStr, nullptr, 16);
++                    }
++                    catch (std::invalid_argument&)
++                    {
++                        continue;
++                    }
+                 }
+-                catch (const std::invalid_argument&)
+-                {
+-                    continue;
++                else{
++                    // ex: thermal_zone0
++                    std::string addrStr = deviceName.substr(findThermalZone + thermalZone.length());
++                    try
++                    {
++                        addr = std::stoi(addrStr);
++                    }
++                    catch(const std::invalid_argument&)
++                    {
++                        std::cerr << "Cannot get zone number: " << deviceName << "\n";
++                        continue;
++                    }
+                 }
+                 const SensorData* sensorData = nullptr;
+                 const std::string* interfacePath = nullptr;
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/sensors/dbus-sensors_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/sensors/dbus-sensors_%.bbappend
@@ -2,4 +2,5 @@ FILESEXTRAPATHS:prepend:evb-npcm845 := "${THISDIR}/${PN}:"
 
 SRC_URI:append:evb-npcm845 = " \
     file://0001-hwmon-temp-add-tmp100-support.patch \
+    file://0002-Add-thermal-zone-support-in-hwmon-sensor.patch \
     "


### PR DESCRIPTION
Add thermal zone support as hwmon temperture sensor, and also
update entity manager configuration.

Signed-off-by: Medad CChien <ctcchien@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
