### PR TITLE
meta-evb: nuvoton: evb-npcm845: support IPMI inband firmware update

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-evb-npcm845/packagegroups/packagegroup-evb-npcm845-apps.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-evb-npcm845/packagegroups/packagegroup-evb-npcm845-apps.bb
@@ -28,6 +28,7 @@ RDEPENDS:${PN}-fans = " \
 
 SUMMARY:${PN}-flash = "EVB NPCM845 Flash"
 RDEPENDS:${PN}-flash = " \
+        phosphor-ipmi-flash \
         "
 
 SUMMARY:${PN}-system = "EVB NPCM845 System"
@@ -55,4 +56,6 @@ RDEPENDS:${PN}-system = " \
         rw-perf \
         phosphor-ecc \
         i3c-tools \
+        phosphor-ipmi-blobs \
+        phosphor-image-signing \
         "

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-flash_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-flash_%.bbappend
@@ -1,0 +1,10 @@
+NUVOTON_FLASH_PCIMBOX1 = "0xF0848000"
+NUVOTON_FLASH_PCIMBOX2 = "0xF0868000"
+NUVOTON_FLASH_LPC     = "0xC0008000"
+
+#PACKAGECONFIG:append:evb-npcm845 = " nuvoton-lpc static-bmc reboot-update"
+PACKAGECONFIG:append:evb-npcm845 = " nuvoton-p2a-mbox static-bmc reboot-update"
+
+IMAGE_PATH = "/run/initramfs/image-bmc"
+EXTRA_OECONF:append:evb-npcm845 = " STATIC_HANDLER_STAGED_NAME=${IMAGE_PATH}"
+IPMI_FLASH_BMC_ADDRESS:evb-npcm845 = "${NUVOTON_FLASH_PCIMBOX1}"


### PR DESCRIPTION
Note: Use pci-mailbox1 to transfer image
      reboot BMC after image is verifed

Signed-off-by: Medad CChien <ctcchien@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
