### PR TITLE
meta-olympus-nuvoton/meta-buv-runbmc: phosphor-ipmi-host: correct fw

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-Correct-IPMI-firmware-revision-report.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-Correct-IPMI-firmware-revision-report.patch
@@ -1,0 +1,48 @@
+From 2eadd6ccd0cdc8ddb4edc5a20b28a951e3857fe8 Mon Sep 17 00:00:00 2001
+From: Hieu Huynh <hieuh@os.amperecomputing.com>
+Date: Tue, 21 Sep 2021 12:04:51 +0000
+Subject: [PATCH] Correct IPMI firmware revision report
+
+OpenBMC currently uses firmware revision from the VERSION parameters
+from /etc/os-release. While WebUI and Redfish uses entire string for
+the revision, IPMI extracts major and minor numbers from that string.
+However, phosphor-host-ipmd mistakenly converts the number to
+hexa-decimal which make the mismatch between Redfish and IPMI.
+This commit fixes the issue by updating the conversion to use decimal
+number.
+
+Tested:
+1. Tag with v1.11.0001-ampere and check ipmitool mc info report
+   firmware revision to 1.11
+
+Signed-off-by: Hieu Huynh <hieuh@os.amperecomputing.com>
+Change-Id: I7340827dfc6de6664dde4b58e61197f81b4f89ca
+---
+ apphandler.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/apphandler.cpp b/apphandler.cpp
+index a20d61a..9b76e7b 100644
+--- a/apphandler.cpp
++++ b/apphandler.cpp
+@@ -498,7 +498,7 @@ int convertVersion(std::string s, Revision& rev)
+         if (location != std::string::npos)
+         {
+             rev.major =
+-                static_cast<char>(std::stoi(s.substr(0, location), 0, 16));
++                static_cast<char>(std::stoi(s.substr(0, location), 0, 10));
+             token = s.substr(location + 1);
+         }
+ 
+@@ -508,7 +508,7 @@ int convertVersion(std::string s, Revision& rev)
+             if (location != std::string::npos)
+             {
+                 rev.minor = static_cast<char>(
+-                    std::stoi(token.substr(0, location), 0, 16));
++                    std::stoi(token.substr(0, location), 0, 10));
+                 token = token.substr(location + 1);
+             }
+         }
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -2,6 +2,7 @@ inherit buv-entity-utils
 
 FILESEXTRAPATHS:append:buv-runbmc := "${THISDIR}/${PN}:"
 SRC_URI:append:buv-runbmc = " file://Add-Set-BIOS-version-support.patch"
+SRC_URI:append:buv-runbmc = " file://0001-Correct-IPMI-firmware-revision-report.patch"
 
 DEPENDS:append:buv-runbmc= " \
     ${@entity_enabled(d, '', ' buv-runbmc-yaml-config')}"

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-Correct-IPMI-firmware-revision-report.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-Correct-IPMI-firmware-revision-report.patch
@@ -1,0 +1,48 @@
+From 2eadd6ccd0cdc8ddb4edc5a20b28a951e3857fe8 Mon Sep 17 00:00:00 2001
+From: Hieu Huynh <hieuh@os.amperecomputing.com>
+Date: Tue, 21 Sep 2021 12:04:51 +0000
+Subject: [PATCH] Correct IPMI firmware revision report
+
+OpenBMC currently uses firmware revision from the VERSION parameters
+from /etc/os-release. While WebUI and Redfish uses entire string for
+the revision, IPMI extracts major and minor numbers from that string.
+However, phosphor-host-ipmd mistakenly converts the number to
+hexa-decimal which make the mismatch between Redfish and IPMI.
+This commit fixes the issue by updating the conversion to use decimal
+number.
+
+Tested:
+1. Tag with v1.11.0001-ampere and check ipmitool mc info report
+   firmware revision to 1.11
+
+Signed-off-by: Hieu Huynh <hieuh@os.amperecomputing.com>
+Change-Id: I7340827dfc6de6664dde4b58e61197f81b4f89ca
+---
+ apphandler.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/apphandler.cpp b/apphandler.cpp
+index a20d61a..9b76e7b 100644
+--- a/apphandler.cpp
++++ b/apphandler.cpp
+@@ -498,7 +498,7 @@ int convertVersion(std::string s, Revision& rev)
+         if (location != std::string::npos)
+         {
+             rev.major =
+-                static_cast<char>(std::stoi(s.substr(0, location), 0, 16));
++                static_cast<char>(std::stoi(s.substr(0, location), 0, 10));
+             token = s.substr(location + 1);
+         }
+ 
+@@ -508,7 +508,7 @@ int convertVersion(std::string s, Revision& rev)
+             if (location != std::string::npos)
+             {
+                 rev.minor = static_cast<char>(
+-                    std::stoi(token.substr(0, location), 0, 16));
++                    std::stoi(token.substr(0, location), 0, 10));
+                 token = token.substr(location + 1);
+             }
+         }
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -8,6 +8,7 @@ SRC_URI:append:olympus-nuvoton = " \
     file://0001-Add-Set-BIOS-version-support.patch \
     file://0002-Add-option-for-SEL-commands-for-Journal-based-SEL-en.patch \
     file://0003-Add-support-for-enabling-disabling-network-IPMI.patch \
+    file://0001-Correct-IPMI-firmware-revision-report.patch \
     "
 
 DEPENDS:append:olympus-nuvoton = " \


### PR DESCRIPTION
revision

Apply patch for correct IPMI firmware revision report

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
