### PR TITLE
Update README for update eMMC image via U-Boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,23 +152,37 @@ $ bitbake obmc-phosphor-image  # the image will be at build/olympus-nuvoton-spi/
 #### Build eMMC image
 ```
 $ exit  # exit the bash for build SPI image
-$  source setup  olympus-nuvoton
+$ source setup  olympus-nuvoton
 $ bitbake obmc-phosphor-image  # the image will be at build/olympus-nuvoton-spi/tmp/deploy/images/olympus-nuvoton/
 ```
 
-#### Flash eMMC image (first time, update partition layout)
+#### Flash eMMC image in OpenBMC with SPI image(first time, update partition layout)
 ```
 # update SPI image with newest codebase
 
 # boot to Openbmc
 
-# cp eMMC WIC image *obmc-phosphor-image-buv-runbmc.wic.xz* to BMC, like scp, usb, …ect
+# cp eMMC WIC image *obmc-phosphor-image-olympus-nuvoton-xxx.rootfs.wic.xz* to BMC, like scp, usb, …ect
 
 # assume we put the WIC image in /tmp
-$ xz --decompress --stdout /tmp/obmc-phosphor-image-olympus-nuvoton.wic.xz | dd of=/dev/mmcblk0 bs=1M
+$ xz --decompress --stdout /tmp/obmc-phosphor-image-olympus-nuvoton-xxx.rootfs.wic.xz | dd of=/dev/mmcblk0 bs=1M
 
 # reboot to uboot
+```
 
+#### Flash eMMC image in U-Boot
+Flash eMMC image in U-Boot need build image type as wic.gz. User can add *IMAGE_FSTYPES += "wic.gz"* in local.conf, then build image.
+After add wic.gz in IMAGE_FSTYPES, the output image will add new one named obmc-phosphor-image-olympus-nuvoton-xxx.rootfs.wic.gz, and add a symbolic link named image-emmc.gz. User do not need update eMMC image both in SPI image and U-boot, just choose one easy way.
+
+Here are example commands to update eMMC image in U-Boot via tftp:
+```
+> tftp 10000000 image-emmc.gz
+> mmc dev 1
+> gzwrite mmc 1 10000000 ${filesize}
+```
+
+#### Set up U-Boot bootargs for boot from eMMC
+```
 # set up uboot environment as following commands: 
 setenv bootcmd 'setenv origbootargs ${bootargs}; run mmc_bootargs; run bootsidecmd'
 setenv setmmcargs 'setenv bootargs ${bootargs} rootwait root=PARTLABEL=${rootfs}'

--- a/meta-phosphor/classes/image_types_phosphor_nuvoton.bbclass
+++ b/meta-phosphor/classes/image_types_phosphor_nuvoton.bbclass
@@ -105,6 +105,13 @@ do_generate_ext4_tar:npcm7xx() {
     ln -sf ${DEPLOY_DIR_IMAGE}/${FLASH_KERNEL_IMAGE} image-kernel
     ln -sf ${S}/ext4/${IMAGE_LINK_NAME}.${FLASH_EXT4_BASETYPE}.zst image-rofs
     ln -sf ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.rwfs.${FLASH_EXT4_OVERLAY_BASETYPE} image-rwfs
+    # if "wic.gz" in d.getVar('IMAGE_FSTYPES')
+    wic_gz="${@bb.utils.contains('IMAGE_FSTYPES', 'wic.gz', 'yes', '', d)}"
+    if [ -n "$wic_gz" ];then
+        ln -sf ${IMAGE_NAME}.rootfs.wic.gz image-emmc.gz
+    elif [ -h image-emmc.gz ];then
+        rm -f image-emmc.gz
+    fi
 }
 
 do_make_ubi[depends] += "${PN}:do_prepare_bootloaders"


### PR DESCRIPTION
Also add symbolic link image-emmc.gz to wic.gz image.
User can add IMAGE_FSTYPES += "wic.gz" in local.conf to build
eMMC image with gz compression. This image can be used in U-Boot
by command gzwrite for update eMMC.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
