### PR TITLE
meta-quanta: olympus-nuvoton: smbios: no SMBIOS version check

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/smbios/smbios-mdr_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/smbios/smbios-mdr_%.bbappend
@@ -1,4 +1,5 @@
 FILESEXTRAPATHS:prepend:olympus-nuvoton := "${THISDIR}/${PN}:"
+SRCREV:olympus-nuvoton = "bc924d0f9f590d7d420b9f7bc98bdb9b8688618e"
 
 SRC_URI:append:olympus-nuvoton = " file://smbios2"
 SRC_URI:append:olympus-nuvoton = " file://smbios-mdrv2.service"


### PR DESCRIPTION
Symptom:
1. Too few "Memory" FRUs found, found only 0.
2. MemorySummary State is not 'Enabled'.: Enabled != Disabled.
3. **ERROR** The following variable is not within the expected range: num_cpus: 0 <int>

Journal log:
olympus-nuvoton smbiosmdrv2app[490]: Anchor String not found
olympus-nuvoton smbiosmdrv2app[490]: Unsupported SMBIOS table version

Root cause:
Intel add SMBIOS version check mechanism to verify the version whether match their BIOS sent table version.
However, out BIOS didn’t send it then cause smbiosmdrv2app report error cause related test items got failed.

Solution:
Parsing SMBIOS table without checking version.

Tested:
test_systems_inventory.robot "Verify CPU And Core Count"
test_systems_inventory.robot "Get Memory Inventory Via Redfish And Verify"
test_systems_inventory.robot "Get Memory Summary State And Verify Enabled"

Signed-off-by: Tim Lee <timlee660101@gmail.com>
