### PR TITLE
meta-nuvoton: move u-boot branch from npcm7xx-v2019.01 to npcm-v2021.04

### DIFF
--- a/meta-nuvoton/recipes-bsp/u-boot/u-boot-common-nuvoton.inc
+++ b/meta-nuvoton/recipes-bsp/u-boot/u-boot-common-nuvoton.inc
@@ -3,11 +3,12 @@ SECTION = "bootloaders"
 DEPENDS += "flex-native bison-native"
 
 LICENSE = "GPLv2+"
-LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 
-UBRANCH = "npcm7xx-v2019.01"
+UBRANCH = "npcm-v2021.04"
+SRCREV = "6276a5d430d0287a05a5e978fdd03010463c5d92"
+
 SRC_URI = "git://github.com/Nuvoton-Israel/u-boot.git;branch=${UBRANCH};protocol=https"
-SRCREV = "ab1fb4143ee08c16dea8ffa6d491c82d7b10a194"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
