### PR TITLE
meta-nuvoton: fix tz branch build break

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/conf/machine/evb-npcm845.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/conf/machine/evb-npcm845.conf
@@ -49,9 +49,12 @@ PREFERRED_PROVIDER_virtual/obmc-system-mgmt = "packagegroup-evb-npcm845-apps"
 PREFERRED_PROVIDER_virtual/obmc-host-ipmi-hw = "phosphor-ipmi-kcs"
 PREFERRED_PROVIDER_virtual/phosphor-led-manager-config-native = "evb-npcm845-led-manager-config-native"
 
-EXTRA_IMAGEDEPENDS += "arm-trusted-firmware"
-EXTRA_IMAGEDEPENDS += "optee-os"
+#EXTRA_IMAGEDEPENDS += "arm-trusted-firmware"
+#EXTRA_IMAGEDEPENDS += "optee-os"
 
 # Remove unneeded binaries from image
 IMAGE_FEATURES_remove = "obmc-fan-control"
 IMAGE_FEATURES_remove = "obmc-health-monitor"
+
+MACHINEOVERRIDES .= ":evb-npcm845"
+DISTRO_FEATURES += "tee"

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-evb-npcm845/packagegroups/packagegroup-evb-npcm845-apps.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-evb-npcm845/packagegroups/packagegroup-evb-npcm845-apps.bb
@@ -60,4 +60,5 @@ RDEPENDS_${PN}-system = " \
         i3c-tools \
         phosphor-ipmi-blobs \
         phosphor-image-signing \
+        nuvoton-mkimage \
         "

--- a/meta-nuvoton/classes/image_types_phosphor_nuvoton_npcm8xx.bbclass
+++ b/meta-nuvoton/classes/image_types_phosphor_nuvoton_npcm8xx.bbclass
@@ -185,8 +185,7 @@ do_prepare_bootloaders[depends] += " \
     npcm8xx-tipfw-l0:do_deploy \
     npcm8xx-tipfw-l1:do_deploy \
     npcm8xx-bootblock:do_deploy \
-    arm-trusted-firmware:do_deploy \
-    optee-os:do_deploy \
+    nuvoton-mkimage:do_install \
     npcm8xx-bingo-native:do_populate_sysroot \
     npcm8xx-igps-native:do_populate_sysroot \
     "

--- a/meta-nuvoton/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware.inc
+++ b/meta-nuvoton/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware.inc
@@ -18,15 +18,15 @@ inherit image-artifact-names
 
 
 COMPATIBLE_MACHINE = "(evb-npcm845)"
-MACHINE ?= "npcm8xx"
+MACHINE_SOC ?= "npcm8xx"
 PLATFORM = "npcm845x"
 
 # requires CROSS_COMPILE set by hand as there is no configure script
 # Some versions of u-boot use .bin and others use .img.  By default use .bin
 # but enable individual recipes to change this value.
 ATF_SUFFIX ?= "bin"
-ATF_IMAGE ?= "bl31-${MACHINE}-${PV}-${PR}.${ATF_SUFFIX}"
-ATF_SYMLINK ?= "bl31-${MACHINE}.${ATF_SUFFIX}"
+ATF_IMAGE ?= "bl31-${MACHINE_SOC}-${PV}-${PR}.${ATF_SUFFIX}"
+ATF_SYMLINK ?= "bl31-${MACHINE_SOC}.${ATF_SUFFIX}"
 
 export CROSS_COMPILE="${TARGET_PREFIX}"
 

--- a/meta-nuvoton/recipes-nuvoton/images/nuvoton-mkimage.bb
+++ b/meta-nuvoton/recipes-nuvoton/images/nuvoton-mkimage.bb
@@ -1,0 +1,35 @@
+DESCRIPTION = "Generate Boot image for npcm SOC"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+DEPENDS += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'tee', 'optee-os', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'tee', 'arm-trusted-firmware', '', d)} \
+"
+
+inherit deploy
+BOOT_STAGING  = "${S}/${SOC_FAMILY}"
+
+do_compile () {
+    cp ${DEPLOY_DIR_IMAGE}/tee.bin   ${BOOT_STAGING}
+    cp ${DEPLOY_DIR_IMAGE}/bl31.bin  ${BOOT_STAGING}
+    # run bingo stuff
+}
+
+do_compile[depends] += " \
+    arm-trusted-firmware:do_deploy \
+    optee-os:do_deploy \
+"
+
+# install file to image
+do_install () {
+    install -d ${D}/boot
+}
+
+# copy boot image to deploy folder
+do_deploy () {
+
+}
+
+FILES_${PN} = "/boot"
+#addtask deploy before do_build after do_compile

--- a/meta-nuvoton/recipes-security/optee/optee-os.bb
+++ b/meta-nuvoton/recipes-security/optee/optee-os.bb
@@ -6,9 +6,8 @@ LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
 
 PV="1.0.0+git${SRCPV}"
 
-DEPENDS += " python3-pyelftools-native python3-cryptography python3-native python3-pycrypto-native python3-pycryptodome"
-
-inherit deploy
+inherit deploy python3native
+DEPENDS = "python3-pyelftools-native python3-pycryptodome-native python3-cryptography-native"
 
 S = "${WORKDIR}/git"
 BRANCH ?= "nuvoton"
@@ -21,13 +20,14 @@ SRCREV = "6b716e224f6162ea37d549ef42aaf3b165423716"
 
 COMPATIBLE_MACHINE = "(evb-npcm845)"
 OPTEEMACHINE ?= "nuvoton"
-MACHINE ?= "npcm8xx"
+#MACHINE ?= "npcm8xx"
+MACHINE_SOC ?= "npcm8xx"
 
 # Some versions of u-boot use .bin and others use .img.  By default use .bin
 # but enable individual recipes to change this value.
 OPTEE_SUFFIX ?= "bin"
-OPTEE_IMAGE ?= "tee-${MACHINE}-${PV}-${PR}.${OPTEE_SUFFIX}"
-OPTEE_SYMLINK ?= "tee-${MACHINE}.${OPTEE_SUFFIX}"
+OPTEE_IMAGE ?= "tee-${MACHINE_SOC}-${PV}-${PR}.${OPTEE_SUFFIX}"
+OPTEE_SYMLINK ?= "tee-${MACHINE_SOC}.${OPTEE_SUFFIX}"
 CFG_TEE_TA_LOG_LEVEL ?= "1"
 CFG_TEE_CORE_LOG_LEVEL ?= "1"
 
@@ -50,7 +50,7 @@ do_compile() {
 # do_install() nothing
 do_install[noexec] = "1"
 
-PACKAGE_ARCH = "${MACHINE_ARCH}"
+#PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 do_deploy() {
     install -d ${DEPLOYDIR}


### PR DESCRIPTION
Move optee and atf task dependency to mkimage recipe to avoid pacakge
manifest install error.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
