### PR TITLE
Update Readme due to default mmc move to mmc 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ After add wic.gz in IMAGE_FSTYPES, the output image will add new one named obmc-
 Here are example commands to update eMMC image in U-Boot via tftp:
 ```
 > tftp 10000000 image-emmc.gz
-> mmc dev 1
-> gzwrite mmc 1 10000000 ${filesize}
+> mmc dev 0
+> gzwrite mmc 0 10000000 ${filesize}
 ```
 
 #### Set up U-Boot bootargs for boot from eMMC
@@ -189,7 +189,7 @@ setenv setmmcargs 'setenv bootargs ${bootargs} rootwait root=PARTLABEL=${rootfs}
 setenv mmc_bootargs 'setenv bootargs earlycon=${earlycon} console=${console} mem=${mem}'
 setenv boota 'setenv bootpart 2; setenv rootfs rofs-a; run bootmmc'
 setenv bootb 'setenv bootpart 3; setenv rootfs rofs-b; run bootmmc'
-setenv bootmmc 'run setmmcargs; ext4load mmc 1:${bootpart} ${loadaddr} fitImage && bootm; echo Error loading kernel FIT image'
+setenv bootmmc 'run setmmcargs; ext4load mmc 0:${bootpart} ${loadaddr} fitImage && bootm; echo Error loading kernel FIT image'
 setenv bootsidecmd 'if test "${bootside}" = b; then run bootb; run boota; else run boota; run bootb; fi'
 setenv bootside 'a'
 setenv loadaddr '0x1200000'

--- a/meta-nuvoton/recipes-bsp/u-boot/files/u-boot-env-emmc.txt
+++ b/meta-nuvoton/recipes-bsp/u-boot/files/u-boot-env-emmc.txt
@@ -6,7 +6,7 @@ setmmcargs=setenv bootargs ${bootargs} rootwait root=PARTLABEL=${rootfs}
 mmc_bootargs=setenv bootargs earlycon=${earlycon} console=${console} mem=${mem}
 boota=setenv bootpart 2; setenv rootfs rofs-a; run bootmmc
 bootb=setenv bootpart 3; setenv rootfs rofs-b; run bootmmc
-bootmmc=run setmmcargs; ext4load mmc 1:${bootpart} ${loadaddr} fitImage && bootm; echo Error loading kernel FIT image
+bootmmc=run setmmcargs; ext4load mmc 0:${bootpart} ${loadaddr} fitImage && bootm; echo Error loading kernel FIT image
 bootsidecmd=if test ${bootside} = b; then run bootb; run boota; else run boota; run bootb; fi
 bootside=a
 loadaddr=0x1200000


### PR DESCRIPTION
After we update U-Boot to 2021.04, we also move move default mmc to mmc
0 for making U-Boot and Kernel have same device settings. Update the
readme file and U-Boot environment file for this change.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
