### PR TITLE
olympus-nuvoton: throw not allow when delete root

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0001-Handle-now-allow-execption-in-account-service.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0001-Handle-now-allow-execption-in-account-service.patch
@@ -1,0 +1,66 @@
+From 56bf5f46112cf494090410492987f438ae000fd4 Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Fri, 25 Mar 2022 16:42:57 +0800
+Subject: [PATCH] Handle now allow execption in account service
+
+Return message resourceCannotBeDeleted when get NowAllowed execption
+during delete user instead of resourceNotFound.
+
+Signed-off-by: Brian Ma <chma0@nuvoton.com>
+---
+ redfish-core/lib/account_service.hpp | 35 ++++++++++++++++++----------
+ 1 file changed, 23 insertions(+), 12 deletions(-)
+
+diff --git a/redfish-core/lib/account_service.hpp b/redfish-core/lib/account_service.hpp
+index 232f51c17..f2b75ae25 100644
+--- a/redfish-core/lib/account_service.hpp
++++ b/redfish-core/lib/account_service.hpp
+@@ -1933,22 +1933,33 @@ inline void requestAccountServiceRoutes(App& app)
+                 tempObjPath /= username;
+                 const std::string userPath(tempObjPath);
+ 
+-                crow::connections::systemBus->async_method_call(
+-                    [asyncResp, username](const boost::system::error_code ec) {
+-                        if (ec)
++            crow::connections::systemBus->async_method_call(
++                [asyncResp, username](const boost::system::error_code ec,
++                                      const sdbusplus::message::message& msg) {
++                    if (ec)
++                    {
++                        const sd_bus_error* dbusErr = msg.get_error();
++                        if (dbusErr != nullptr &&
++                            strcmp(
++                                dbusErr->name,
++                                "xyz.openbmc_project.Common.Error.NotAllowed") ==
++                                0)
+                         {
+-                            messages::resourceNotFound(
+-                                asyncResp->res,
+-                                "#ManagerAccount.v1_4_0.ManagerAccount",
+-                                username);
++                            messages::resourceCannotBeDeleted(asyncResp->res);
+                             return;
+                         }
+ 
+-                        messages::accountRemoved(asyncResp->res);
+-                    },
+-                    "xyz.openbmc_project.User.Manager", userPath,
+-                    "xyz.openbmc_project.Object.Delete", "Delete");
+-            });
++                        messages::resourceNotFound(
++                            asyncResp->res,
++                            "#ManagerAccount.v1_4_0.ManagerAccount", username);
++                        return;
++                    }
++
++                    messages::accountRemoved(asyncResp->res);
++                },
++                "xyz.openbmc_project.User.Manager", userPath,
++                "xyz.openbmc_project.Object.Delete", "Delete");
++        });
+ }
+ 
+ } // namespace redfish
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS:prepend:olympus-nuvoton := "${THISDIR}/${PN}:"
 SRC_URI:append:olympus-nuvoton = " file://0001-Redfish-Add-power-metrics-support.patch"
 SRC_URI:append:olympus-nuvoton = " file://0005-bmcweb-chassis-add-indicatorLED-support.patch"
 SRC_URI:append:olympus-nuvoton = " file://0018-redfish-log_services-fix-createDump-functionality.patch"
+SRC_URI:append:olympus-nuvoton = " file://0001-Handle-now-allow-execption-in-account-service.patch"
 
 # Enable CPU Log support
 EXTRA_OEMESON:append:olympus-nuvoton = " -Dredfish-cpu-log=enabled"

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/users/phosphor-user-manager/0001-Throw-NotAllowed-when-delete-or-disable-root.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/users/phosphor-user-manager/0001-Throw-NotAllowed-when-delete-or-disable-root.patch
@@ -1,0 +1,89 @@
+From a6cbd4d4bc57e8cd3897ada969f38049d422f810 Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Fri, 25 Mar 2022 16:28:25 +0800
+Subject: [PATCH] Throw NotAllowed when delete or disable root
+
+Throw NotAllowed execption when try to delete or disable root instead of
+throw InternalFailure execption.
+
+Signed-off-by: Brian Ma <chma0@nuvoton.com>
+Change-Id: I32430ab376c584ef7e4eec88cf604e00bfc6f415
+---
+ user_mgr.cpp | 14 ++++++++++++++
+ user_mgr.hpp |  7 +++++++
+ 2 files changed, 21 insertions(+)
+
+diff --git a/user_mgr.cpp b/user_mgr.cpp
+index 8fc899f..77945dd 100644
+--- a/user_mgr.cpp
++++ b/user_mgr.cpp
+@@ -89,6 +89,7 @@ using InternalFailure =
+     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+ using InvalidArgument =
+     sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
++using NotAllowed = sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;
+ using UserNameExists =
+     sdbusplus::xyz::openbmc_project::User::Common::Error::UserNameExists;
+ using UserNameDoesNotExist =
+@@ -99,6 +100,7 @@ using NoResource =
+     sdbusplus::xyz::openbmc_project::User::Common::Error::NoResource;
+ 
+ using Argument = xyz::openbmc_project::Common::InvalidArgument;
++using NotAllowedReason = xyz::openbmc_project::Common::NotAllowed;
+ 
+ template <typename... ArgTypes>
+ static std::vector<std::string> executeCmd(const char* path,
+@@ -208,6 +210,15 @@ void UserMgr::throwForUserExists(const std::string& userName)
+     }
+ }
+ 
++void UserMgr::throwForNotAllowRoot(const std::string& userName)
++{
++    if (userName == "root")
++    {
++        elog<NotAllowed>(
++            NotAllowedReason::REASON("Operation is not allow for root"));
++    }
++}
++
+ void UserMgr::throwForUserNameConstraints(
+     const std::string& userName, const std::vector<std::string>& groupNames)
+ {
+@@ -352,6 +363,7 @@ void UserMgr::deleteUser(std::string userName)
+     // All user management lock has to be based on /etc/shadow
+     // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
+     throwForUserDoesNotExist(userName);
++    throwForNotAllowRoot(userName);
+     try
+     {
+         executeCmd("/usr/sbin/userdel", userName.c_str(), "-r");
+@@ -653,6 +665,8 @@ void UserMgr::userEnable(const std::string& userName, bool enabled)
+     // All user management lock has to be based on /etc/shadow
+     // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
+     throwForUserDoesNotExist(userName);
++    if (!enabled)
++        throwForNotAllowRoot(userName);
+     try
+     {
+         // set EXPIRE_DATE to 0 to disable user, PAM takes 0 as expire on
+diff --git a/user_mgr.hpp b/user_mgr.hpp
+index f5aac22..1f621fa 100644
+--- a/user_mgr.hpp
++++ b/user_mgr.hpp
+@@ -244,6 +244,13 @@ class UserMgr : public Ifaces
+      */
+     void throwForUserExists(const std::string& userName);
+ 
++    /** @brief avoid not allow operation for root
++     *  method to check whether user is root, and throw if is.
++     *
++     *  @param[in] userName - name of the user
++     */
++    void throwForNotAllowRoot(const std::string& userName);
++
+     /** @brief check user name constraints
+      *  method to check user name constraints and throw if failed.
+      *
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/users/phosphor-user-manager_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/users/phosphor-user-manager_%.bbappend
@@ -1,5 +1,7 @@
 
 FILESEXTRAPATHS:append := "${THISDIR}/${PN}:"
 
-SRC_URI:append:olympus-nuvoton = " file://0001-meta-quanta-meta-olympus-nuvoton-phosphor-user-manag.patch \
-                      "
+SRC_URI:append:olympus-nuvoton = " \
+    file://0001-meta-quanta-meta-olympus-nuvoton-phosphor-user-manag.patch \
+    file://0001-Throw-NotAllowed-when-delete-or-disable-root.patch \
+    "


### PR DESCRIPTION
Throw NotAllowed exeception instead of InternalFailure when delete root.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
