### PR TITLE
meta-olympus-nuvoton: create user without ssh group

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0002-Create-new-user-without-SSH-group.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb/0002-Create-new-user-without-SSH-group.patch
@@ -1,0 +1,43 @@
+From 5f98f4af540d6808b6a910713ea11621cc97784c Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Tue, 29 Mar 2022 10:13:24 +0800
+Subject: [PATCH 2/2] Create new user without SSH group
+
+Remove SSH group permission from default groups when create new user.
+---
+ redfish-core/lib/account_service.hpp | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/redfish-core/lib/account_service.hpp b/redfish-core/lib/account_service.hpp
+index 232f51c17..dc619ad5a 100644
+--- a/redfish-core/lib/account_service.hpp
++++ b/redfish-core/lib/account_service.hpp
+@@ -1625,6 +1625,16 @@ inline void requestAccountServiceRoutes(App& app)
+                         messages::internalError(asyncResp->res);
+                         return;
+                     }
++                    // Remove ssh from all group list
++                    std::vector<std::string> nonSshGroups;
++                    for (auto group = allGroupsList.begin();
++                         group != allGroupsList.end(); ++group)
++                    {
++                        if (*group != "ssh")
++                        {
++                            nonSshGroups.push_back(*group);
++                        }
++                    }
+ 
+                     crow::connections::systemBus->async_method_call(
+                         [asyncResp, username,
+@@ -1682,7 +1692,7 @@ inline void requestAccountServiceRoutes(App& app)
+                         "xyz.openbmc_project.User.Manager",
+                         "/xyz/openbmc_project/user",
+                         "xyz.openbmc_project.User.Manager", "CreateUser",
+-                        username, allGroupsList, *roleId, *enabled);
++                        username, nonSshGroups, *roleId, *enabled);
+                 });
+         });
+ 
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -4,6 +4,7 @@ SRC_URI:append:olympus-nuvoton = " file://0001-Redfish-Add-power-metrics-support
 SRC_URI:append:olympus-nuvoton = " file://0005-bmcweb-chassis-add-indicatorLED-support.patch"
 SRC_URI:append:olympus-nuvoton = " file://0018-redfish-log_services-fix-createDump-functionality.patch"
 SRC_URI:append:olympus-nuvoton = " file://0001-Handle-now-allow-execption-in-account-service.patch"
+SRC_URI:append:olympus-nuvoton = " file://0002-Create-new-user-without-SSH-group.patch"
 
 # Enable CPU Log support
 EXTRA_OEMESON:append:olympus-nuvoton = " -Dredfish-cpu-log=enabled"


### PR DESCRIPTION
Remove SSH from default groups when create new user.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Test:
  redfish/account_service/test_user_account.robot
