### PR TITLE
meta-buv-runbmc: enable send-to-logger feature of phosphor-sel-logger

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/configuration/buv-runbmc-yaml-config.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/configuration/buv-runbmc-yaml-config.bb
@@ -9,6 +9,7 @@ SRC_URI:buv-runbmc = " \
     file://buv-runbmc-ipmi-fru.yaml \
     file://buv-runbmc-ipmi-fru-properties.yaml \
     file://buv-runbmc-ipmi-sensors.yaml \
+    file://buv-runbmc-ipmi-inventory-sensors.yaml \
     "
 
 S = "${WORKDIR}"
@@ -20,12 +21,15 @@ do_install:buv-runbmc() {
         ${D}${datadir}/${BPN}/ipmi-fru-read.yaml
     install -m 0644 -D buv-runbmc-ipmi-sensors.yaml \
         ${D}${datadir}/${BPN}/ipmi-sensors.yaml
+    install -m 0644 -D buv-runbmc-ipmi-inventory-sensors.yaml \
+        ${D}${datadir}/${BPN}/ipmi-inventory-sensors.yaml
 }
 
 FILES:${PN}-dev = " \
     ${datadir}/${BPN}/ipmi-extra-properties.yaml \
     ${datadir}/${BPN}/ipmi-fru-read.yaml \
     ${datadir}/${BPN}/ipmi-sensors.yaml \
+    ${datadir}/${BPN}/ipmi-inventory-sensors.yaml \
     "
 
 ALLOW_EMPTY:${PN} = "1"

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/configuration/buv-runbmc-yaml-config/buv-runbmc-ipmi-inventory-sensors.yaml
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/configuration/buv-runbmc-yaml-config/buv-runbmc-ipmi-inventory-sensors.yaml
@@ -1,0 +1,100 @@
+/xyz/openbmc_project/sensors/temperature/BMC_Temp:
+  sensorID: 0x01
+  sensorType: 1
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/temperature/BUV_Temp:
+  sensorID: 0x02
+  sensorType: 1
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/voltage/ADC1:
+  sensorID: 0x03
+  sensorType: 2
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/voltage/ADC2:
+  sensorID: 0x04
+  sensorType: 2
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/voltage/ADC3:
+  sensorID: 0x05
+  sensorType: 2 
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/voltage/ADC4:
+  sensorID: 0x06
+  sensorType: 2
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/voltage/ADC5:
+  sensorID: 0x07
+  sensorType: 2
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/voltage/ADC6:
+  sensorID: 0x08
+  sensorType: 2
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/voltage/ADC7:
+  sensorID: 0x09
+  sensorType: 2
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/voltage/ADC8:
+  sensorID: 0x0A
+  sensorType: 2
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/voltage/MB_P12V_INA219_Output_Voltage:
+  sensorID: 0x0B
+  sensorType: 2
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/voltage/MB_P3V3_INA219_Output_Voltage:
+  sensorID: 0x0C
+  sensorType: 2
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/fan_tach/Fan1:
+  sensorID: 0x0D
+  sensorType: 4
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/fan_tach/Fan2:
+  sensorID: 0x0E
+  sensorType: 4
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/fan_tach/Fan3:
+  sensorID: 0x0F
+  sensorType: 4
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/fan_tach/Fan4:
+  sensorID: 0x10
+  sensorType: 4
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/power/MB_P12V_INA219_Output_Power:
+  sensorID: 0x11
+  sensorType: 11
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/power/MB_P3V3_INA219_Output_Power:
+  sensorID: 0x12
+  sensorType: 11
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/current/MB_P12V_INA219_Output_Current:
+  sensorID: 0x13
+  sensorType: 3
+  eventReadingType: 1
+  offset: 0xff
+/xyz/openbmc_project/sensors/current/MB_P3V3_INA219_Output_Current:
+  sensorID: 0x14
+  sensorType: 3
+  eventReadingType: 1
+  offset: 0xff

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -11,6 +11,7 @@ EXTRA_OECONF:buv-runbmc = " \
     --enable-boot-flag-safe-mode-support \
     ${@entity_enabled(d, '', ' SENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/buv-runbmc-yaml-config/ipmi-sensors.yaml')} \
     ${@entity_enabled(d, '', ' FRU_YAML_GEN=${STAGING_DIR_HOST}${datadir}/buv-runbmc-yaml-config/ipmi-fru-read.yaml')} \
+    ${@entity_enabled(d, '', ' INVSENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/buv-runbmc-yaml-config/ipmi-inventory-sensors.yaml')} \
     ${@entity_enabled(d, '', ' --disable-dynamic_sensors')} \
     "
 

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/sel-logger/phosphor-sel-logger_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/sel-logger/phosphor-sel-logger_%.bbappend
@@ -1,1 +1,1 @@
-PACKAGECONFIG:append:buv-runbmc = " log-threshold log-alarm log-pulse log-watchdog"
+PACKAGECONFIG:append:buv-runbmc = " log-threshold log-alarm log-pulse log-watchdog send-to-logger"


### PR DESCRIPTION
Enable send-to-logger feature of phosphor-sel-logger.
Add buv-runbmc-ipmi-inventory-sensors.yaml file.
Modify the bb and bbappend file.
