### PR TITLE
meta-nuvoton: set default empty entity map

### DIFF
--- a/meta-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-config.bbappend
+++ b/meta-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-config.bbappend
@@ -1,0 +1,9 @@
+ENTITY_MAPPING ?= "empty"
+
+do_install:append:nuvoton() {
+  # Set entity-map.json to empty json for Nuvoton BMC by default.
+  # Each system can override it if needed.
+  if [ "${ENTITY_MAPPING}" = "empty" ]; then
+    echo "[]" > ${D}${datadir}/ipmi-providers/entity-map.json
+  fi
+}


### PR DESCRIPTION
Set Nuvoton machine default has empty entity map, user can overwrite
ENTITY_MAPPING and set up entity-map.json to replace it.

test:
  ipmi/test_ipmi_sdr.robot

Signed-off-by: Brian_Ma <chma0@nuvoton.com>


