### PR TITLE
[runbmc] Fix typo caused runbmc build error.

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/local.conf.sample
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/local.conf.sample
@@ -3,7 +3,7 @@ DISTRO ?= "openbmc-phosphor"
 PACKAGE_CLASSES ?= "package_ipk"
 SANITY_TESTED_DISTROS:append ?= " *"
 EXTRA_IMAGE_FEATURES = "debug-tweaks"
-USER_CLASSES ?= "buildstats
+USER_CLASSES ?= "buildstats"
 PATCHRESOLVE = "noop"
 BB_DISKMON_DIRS = "\
     STOPTASKS,${TMPDIR},1G,100K \


### PR DESCRIPTION
Miss a double quotation mark which caused following build error:
ERROR: ParseError at local.conf:6: unparsed line: 'USER_CLASSES ?= "buildstats'
