### PR TITLE
meta-evb: evb-npcm845: support mmc update

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/flash/phosphor-software-manager/0001-Restore-and-verify-BIOS.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/flash/phosphor-software-manager/0001-Restore-and-verify-BIOS.patch
@@ -1,0 +1,81 @@
+From ec0d0b7a6db0151726cebacbad9c1ed2ea9c63b8 Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Wed, 15 Jun 2022 16:07:53 +0800
+Subject: [PATCH 1/2] Restore and verify BIOS
+
+---
+ image_verify.cpp |  1 +
+ item_updater.cpp | 24 +++++++++++++++++++++++-
+ meson.build      |  2 ++
+ 3 files changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/image_verify.cpp b/image_verify.cpp
+index 9551e4e..01836e0 100644
+--- a/image_verify.cpp
++++ b/image_verify.cpp
+@@ -105,6 +105,7 @@ bool Signature::verifyFullImage()
+     }
+ 
+     std::vector<std::string> fullImages = {
++        fs::path(imageDirPath) / "image-bios.sig",
+         fs::path(imageDirPath) / "image-bmc.sig",
+         fs::path(imageDirPath) / "image-hostfw.sig",
+         fs::path(imageDirPath) / "image-kernel.sig",
+diff --git a/item_updater.cpp b/item_updater.cpp
+index c8fda76..6128e50 100644
+--- a/item_updater.cpp
++++ b/item_updater.cpp
+@@ -834,6 +834,28 @@ bool ItemUpdater::checkImage(const std::string& filePath,
+ }
+ 
+ #ifdef HOST_BIOS_UPGRADE
++std::string restoreBIOSVersion()
++{
++    std::string version = "null";
++    fs::path release = fs::path(PERSIST_DIR) / HOST_RELEASE_FILE;
++    if (fs::exists(release))
++    {
++        try
++        {
++            version = VersionClass::getBMCVersion(release.string());
++        }
++        catch (const std::exception& e)
++        {
++            warning("Failed to parse BIOS version: {ERROR}", "ERROR", e);
++        }
++    }
++    else
++    {
++        info("No bios version file exist");
++    }
++    return version;
++}
++
+ void ItemUpdater::createBIOSObject()
+ {
+     std::string path = BIOS_OBJPATH;
+@@ -849,7 +871,7 @@ void ItemUpdater::createBIOSObject()
+     createFunctionalAssociation(path);
+ 
+     auto versionId = path.substr(pos + 1);
+-    auto version = "null";
++    auto version = restoreBIOSVersion();
+     AssociationList assocs = {};
+     biosActivation = std::make_unique<Activation>(
+         bus, path, *this, versionId, server::Activation::Activations::Active,
+diff --git a/meson.build b/meson.build
+index 0dca8c0..2bf7700 100644
+--- a/meson.build
++++ b/meson.build
+@@ -57,6 +57,8 @@ conf.set_quoted('UPDATEABLE_REV_ASSOCIATION', 'software_version')
+ conf.set_quoted('BMC_ROFS_PREFIX', get_option('media-dir') + '/rofs-')
+ # The name of the BMC table of contents file
+ conf.set_quoted('OS_RELEASE_FILE', '/etc/os-release')
++# The name of the host firmware version file
++conf.set_quoted('HOST_RELEASE_FILE', 'bios-release')
+ # The dir where activation data is stored in files
+ conf.set_quoted('PERSIST_DIR', '/var/lib/phosphor-bmc-code-mgmt/')
+ 
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/flash/phosphor-software-manager/0002-Support-ignore-update-uboot-with-eMMC-image.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/flash/phosphor-software-manager/0002-Support-ignore-update-uboot-with-eMMC-image.patch
@@ -1,0 +1,119 @@
+From 57fcbef2b50e8373c504fa8f2570aded34960dd7 Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Thu, 17 Feb 2022 08:50:52 +0800
+Subject: [PATCH 2/2] Support ignore update uboot with eMMC image
+
+Signed-off-by: Brian Ma <chma0@nuvoton.com>
+---
+ obmc-flash-bmc | 41 +++++++++++++++++++++++++++++------------
+ 1 file changed, 29 insertions(+), 12 deletions(-)
+
+diff --git a/obmc-flash-bmc b/obmc-flash-bmc
+index 67e3a88..a024c8a 100644
+--- a/obmc-flash-bmc
++++ b/obmc-flash-bmc
+@@ -1,6 +1,8 @@
+ #!/bin/bash
+ set -eo pipefail
+ 
++ulog="/var/log/update.log"
++
+ # Get the root mtd device number (mtdX) from "/dev/ubiblockX_Y on /"
+ findrootmtd() {
+   rootmatch=" on / "
+@@ -387,7 +389,7 @@ ubi_setenv() {
+ mtd_write() {
+   flashmtd="$(findmtd "${reqmtd}")"
+   img="/tmp/images/${version}/${imgfile}"
+-  flashcp -v "${img}" /dev/"${flashmtd}"
++  flashcp -v "${img}" /dev/"${flashmtd}" >> "${ulog}"
+ }
+ 
+ backup_env_vars() {
+@@ -491,6 +493,13 @@ cmp_uboot() {
+   device="$1"
+   image="$2"
+ 
++  # if no uboot image need to update
++  if [ ! -f "${image}" ];then
++    echo "no uboot file for update" >> "${ulog}"
++    echo 0
++    return
++  fi
++
+   # Since the image file can be smaller than the device, copy the device to a
+   # tmp file and write the image file on top, then compare the sum of each.
+   # Use cat / redirection since busybox does not have the conv=notrunc option.
+@@ -501,6 +510,9 @@ cmp_uboot() {
+   imgSum="$(sha256sum "${tmpFile}")"
+   rm -f "${tmpFile}"
+ 
++  echo "image checksum: ${imgSum}" >> "${ulog}"
++  echo "mtd device checksum: ${devSum}" >> "${ulog}"
++
+   if [ "${imgSum}" == "${devSum}" ]; then
+     echo "0";
+   else
+@@ -555,35 +567,33 @@ mmc_mount() {
+ }
+ 
+ mmc_update() {
+-  # Update u-boot if needed
+-  bootPartition="mmcblk0boot0"
+-  devUBoot="/dev/${bootPartition}"
+-  imgUBoot="${imgpath}/${version}/image-u-boot"
+-  if [ "$(cmp_uboot "${devUBoot}" "${imgUBoot}")" != "0" ]; then
+-    echo 0 > "/sys/block/${bootPartition}/force_ro"
+-    dd if="${imgUBoot}" of="${devUBoot}"
+-    echo 1 > "/sys/block/${bootPartition}/force_ro"
+-  fi
++  echo "start mmc update, version: ${version}" >> "${ulog}"
++  echo $(date) >> "${ulog}"
+ 
+   # Update the secondary (non-running) boot and rofs partitions.
+   label="$(mmc_get_secondary_label)"
+ 
+   # Update the boot and rootfs partitions, restore their labels after the update
+   # by getting the partition number mmcblk0pX from their label.
++  echo "start update kernel: boot-${label}" >> "${ulog}"
+   zstd -d -c "${imgpath}"/"${version}"/image-kernel | dd of="/dev/disk/by-partlabel/boot-${label}"
+   number="$(readlink -f /dev/disk/by-partlabel/boot-"${label}")"
+   number="${number##*mmcblk0p}"
+   sgdisk --change-name="${number}":boot-"${label}" /dev/mmcblk0 1>/dev/null
+ 
++  echo "start update rofs: rofs-${label}" >> "${ulog}"
+   zstd -d -c "${imgpath}"/"${version}"/image-rofs | dd of="/dev/disk/by-partlabel/rofs-${label}"
+   number="$(readlink -f /dev/disk/by-partlabel/rofs-"${label}")"
+   number="${number##*mmcblk0p}"
+   sgdisk --change-name="${number}":rofs-"${label}" /dev/mmcblk0 1>/dev/null
+ 
+   # Run this after sgdisk for labels to take effect.
+-  partprobe
++  echo "start partprobe" >> "${ulog}"
++  # fix some mtd device get Invalid partition table
++  partprobe /dev/mmcblk0
+ 
+   # Update hostfw
++  echo "start try to update hostfw" >> "${ulog}"
+   if [ -f "${imgpath}"/"${version}"/image-hostfw ]; then
+     # Remove patches
+     patchdir="/usr/local/share/hostfw/alternate"
+@@ -596,7 +606,14 @@ mmc_update() {
+     mount "${hostfwdir}"/hostfw-"${label}" "${hostfwdir}"/alternate -o ro
+   fi
+ 
+-  set_flashid "${label}"
++  # handle the ipmi flash bmc update
++  if [ "${version}" == "bmc-image" ]; then
++    echo "directly update bootside for ipmi flash bmc" >> "${ulog}"
++    fw_setenv bootside "${label}"
++  else
++    set_flashid "${label}"
++  fi
++  echo "end of mmc update" >> "${ulog}"
+ }
+ 
+ mmc_remove() {
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/flash/phosphor-software-manager/obmc-flash-host-bios@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/flash/phosphor-software-manager/obmc-flash-host-bios@.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Flash Host Bios image %I to Host
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStartPre=/bin/mv /tmp/images/%i/image-bios /tmp/image-bios
+ExecStartPre=/usr/bin/obmc-flash-bmc rebootguardenable
+ExecStart=/usr/bin/bios-update.sh
+ExecStopPost=/usr/bin/obmc-flash-bmc rebootguarddisable

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend:evb-npcm845 := "${THISDIR}/${PN}:"
+
+SRC_URI:append:evb-npcm845 = " file://0001-Restore-and-verify-BIOS.patch"
+SRC_URI:append:evb-npcm845 = " file://0002-Support-ignore-update-uboot-with-eMMC-image.patch"
+
+PACKAGECONFIG:evb-npcm845 += "verify_signature flash_bios"
+EXTRA_OEMESON:append:evb-npcm845 = " -Doptional-images=image-bios"


### PR DESCRIPTION
Ignore U-boot update process in mmc distro to due to we put U-Boot image
on SPI flash ,not mmc. After ignore U-Boot update, software manager
update process work well.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
