### PR TITLE
meta-olympus-nuvoton: fix ipmi mc info error

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-Add-set-BIOS-version-support.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-Add-set-BIOS-version-support.patch
@@ -1,14 +1,14 @@
-From 477a5180e1f488da59e58ac6dfe16b16aa181c65 Mon Sep 17 00:00:00 2001
+From 1ff24df3b9517f1f28ff282e7230b4ef82b89e78 Mon Sep 17 00:00:00 2001
 From: Brian Ma <chma0@nuvoton.com>
 Date: Fri, 13 May 2022 10:30:14 +0800
-Subject: [PATCH 1/3] Add set BIOS version support
+Subject: [PATCH] Add set BIOS version support
 
 ---
- apphandler.cpp | 51 ++++++++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 51 insertions(+)
+ apphandler.cpp | 45 +++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 45 insertions(+)
 
 diff --git a/apphandler.cpp b/apphandler.cpp
-index 6cdd78f2..f3701d8d 100644
+index 0577c07..615c329 100644
 --- a/apphandler.cpp
 +++ b/apphandler.cpp
 @@ -50,6 +50,8 @@ static constexpr auto versionIntf = "xyz.openbmc_project.Software.Version";
@@ -20,24 +20,19 @@ index 6cdd78f2..f3701d8d 100644
  
  void register_netfn_app_functions() __attribute__((constructor));
  
-@@ -1366,6 +1368,52 @@ ipmi::RspType<uint8_t,                // Parameter revision
+@@ -1366,6 +1368,46 @@ ipmi::RspType<uint8_t,                // Parameter revision
      return ipmi::responseSuccess(paramRevision, setSelector, configData);
  }
  
-+void handleFirmwareVersion(uint8_t paramSelector, std::vector<uint8_t> data){
-+    // just handle FW version
++void handleFirmwareVersion(uint8_t paramSelector, std::string version){
++    // only handle FW version
 +    if (paramSelector != IPMI_SYSINFO_SYSTEM_FW_VERSION)
 +    {
 +        return;
 +    }
 +    sdbusplus::bus::bus bus{ipmid_get_sd_bus_connection()};
 +
-+    // read host version
-+    uint8_t str_len = data[1];
-+    auto iter = data.begin();
-+    std::string fwVer(iter + 2, iter + str_len + 2);
-+    log<level::INFO>(("ipmid get BIOS version:" + fwVer).c_str(),
-+            entry("VERSION=%s", fwVer.c_str()));
++    log<level::INFO>(("ipmid get BIOS version:" + version).c_str());
 +
 +    // update host version to software manager
 +    std::string service;
@@ -45,7 +40,7 @@ index 6cdd78f2..f3701d8d 100644
 +    {
 +        service = ipmi::getService(bus, versionIntf, biosObjPath);
 +        ipmi::setDbusProperty(bus, service, biosObjPath, versionIntf,
-+                              "Version", fwVer);
++                              "Version", version);
 +    }
 +    catch (const std::runtime_error& e)
 +    {
@@ -63,9 +58,8 @@ index 6cdd78f2..f3701d8d 100644
 +    // write version file to storage
 +    log<level::DEBUG>("write BIOS version file.");
 +    std::ofstream myfile(biosFile, std::ofstream::out);
-+    std::string version =
-+         std::string("VERSION_ID=\"") + std::string(fwVer) + "\"";
-+    myfile << version << std::endl;
++    std::string ver = "VERSION_ID=\"" + version + "\"";
++    myfile << ver << std::endl;
 +    myfile.close();
 +}
 +
@@ -73,16 +67,16 @@ index 6cdd78f2..f3701d8d 100644
  ipmi::RspType<> ipmiAppSetSystemInfo(uint8_t paramSelector, uint8_t data1,
                                       std::vector<uint8_t> configData)
  {
-@@ -1429,6 +1477,9 @@ ipmi::RspType<> ipmiAppSetSystemInfo(uint8_t paramSelector, uint8_t data1,
-         paramString = "";
+@@ -1455,6 +1497,9 @@ ipmi::RspType<> ipmiAppSetSystemInfo(uint8_t paramSelector, uint8_t data1,
+         std::copy_n(configData.begin(), count, paramString.begin() + offset);
      }
- 
-+    // read bios version from Intel ipmi command
-+    handleFirmwareVersion(paramSelector, configData);
+     sysInfoParamStore->update(paramSelector, paramString);
 +
-     uint8_t setSelector = data1;
-     size_t count = 0;
-     if (setSelector == 0) // First chunk has only 14 bytes.
++    // update BIOS version
++    handleFirmwareVersion(paramSelector, paramString);
+     return ipmi::responseSuccess();
+ }
+ 
 -- 
 2.17.1
 

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-Fix-firmware-version-missing-at-dev-tag.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-Fix-firmware-version-missing-at-dev-tag.patch
@@ -1,0 +1,30 @@
+From 3f2952b42b8806558c2a0184914f5545433b5c76 Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Fri, 17 Jun 2022 10:46:34 +0800
+Subject: [PATCH] Fix firmware version missing at dev tag
+
+The firmware version "v" must at the first character, wwe should not
+handle other "v" (like "dev") to avoid parsing string error.
+
+Signed-off-by: Brian Ma <chma0@nuvoton.com>
+Change-Id: I274e7158b44f2c5dd566e47940bfc1fd7e5ebe83
+---
+ apphandler.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/apphandler.cpp b/apphandler.cpp
+index 0577c07..7aa5c54 100644
+--- a/apphandler.cpp
++++ b/apphandler.cpp
+@@ -486,7 +486,7 @@ int convertVersion(std::string s, Revision& rev)
+     std::string token;
+     uint16_t commits;
+ 
+-    auto location = s.find_first_of('v');
++    auto location = s.find_last_of('v', 0);
+     if (location != std::string::npos)
+     {
+         s = s.substr(location + 1);
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -3,6 +3,7 @@ inherit buv-entity-utils
 FILESEXTRAPATHS:append:buv-runbmc := "${THISDIR}/${PN}:"
 SRC_URI:append:buv-runbmc = " file://0001-Add-set-BIOS-version-support.patch"
 SRC_URI:append:buv-runbmc = " file://0003-Add-option-for-SEL-commands-for-Journal-based-SEL-en.patch"
+SRC_URI:append:buv-runbmc = " file://0001-Fix-firmware-version-missing-at-dev-tag.patch"
 
 
 DEPENDS:append:buv-runbmc= " \

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-Add-set-BIOS-version-support.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-Add-set-BIOS-version-support.patch
@@ -1,14 +1,14 @@
-From 477a5180e1f488da59e58ac6dfe16b16aa181c65 Mon Sep 17 00:00:00 2001
+From 1ff24df3b9517f1f28ff282e7230b4ef82b89e78 Mon Sep 17 00:00:00 2001
 From: Brian Ma <chma0@nuvoton.com>
 Date: Fri, 13 May 2022 10:30:14 +0800
-Subject: [PATCH 1/3] Add set BIOS version support
+Subject: [PATCH] Add set BIOS version support
 
 ---
- apphandler.cpp | 51 ++++++++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 51 insertions(+)
+ apphandler.cpp | 45 +++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 45 insertions(+)
 
 diff --git a/apphandler.cpp b/apphandler.cpp
-index 6cdd78f2..f3701d8d 100644
+index 0577c07..615c329 100644
 --- a/apphandler.cpp
 +++ b/apphandler.cpp
 @@ -50,6 +50,8 @@ static constexpr auto versionIntf = "xyz.openbmc_project.Software.Version";
@@ -20,24 +20,19 @@ index 6cdd78f2..f3701d8d 100644
  
  void register_netfn_app_functions() __attribute__((constructor));
  
-@@ -1366,6 +1368,52 @@ ipmi::RspType<uint8_t,                // Parameter revision
+@@ -1366,6 +1368,46 @@ ipmi::RspType<uint8_t,                // Parameter revision
      return ipmi::responseSuccess(paramRevision, setSelector, configData);
  }
  
-+void handleFirmwareVersion(uint8_t paramSelector, std::vector<uint8_t> data){
-+    // just handle FW version
++void handleFirmwareVersion(uint8_t paramSelector, std::string version){
++    // only handle FW version
 +    if (paramSelector != IPMI_SYSINFO_SYSTEM_FW_VERSION)
 +    {
 +        return;
 +    }
 +    sdbusplus::bus::bus bus{ipmid_get_sd_bus_connection()};
 +
-+    // read host version
-+    uint8_t str_len = data[1];
-+    auto iter = data.begin();
-+    std::string fwVer(iter + 2, iter + str_len + 2);
-+    log<level::INFO>(("ipmid get BIOS version:" + fwVer).c_str(),
-+            entry("VERSION=%s", fwVer.c_str()));
++    log<level::INFO>(("ipmid get BIOS version:" + version).c_str());
 +
 +    // update host version to software manager
 +    std::string service;
@@ -45,7 +40,7 @@ index 6cdd78f2..f3701d8d 100644
 +    {
 +        service = ipmi::getService(bus, versionIntf, biosObjPath);
 +        ipmi::setDbusProperty(bus, service, biosObjPath, versionIntf,
-+                              "Version", fwVer);
++                              "Version", version);
 +    }
 +    catch (const std::runtime_error& e)
 +    {
@@ -63,9 +58,8 @@ index 6cdd78f2..f3701d8d 100644
 +    // write version file to storage
 +    log<level::DEBUG>("write BIOS version file.");
 +    std::ofstream myfile(biosFile, std::ofstream::out);
-+    std::string version =
-+         std::string("VERSION_ID=\"") + std::string(fwVer) + "\"";
-+    myfile << version << std::endl;
++    std::string ver = "VERSION_ID=\"" + version + "\"";
++    myfile << ver << std::endl;
 +    myfile.close();
 +}
 +
@@ -73,16 +67,16 @@ index 6cdd78f2..f3701d8d 100644
  ipmi::RspType<> ipmiAppSetSystemInfo(uint8_t paramSelector, uint8_t data1,
                                       std::vector<uint8_t> configData)
  {
-@@ -1429,6 +1477,9 @@ ipmi::RspType<> ipmiAppSetSystemInfo(uint8_t paramSelector, uint8_t data1,
-         paramString = "";
+@@ -1455,6 +1497,9 @@ ipmi::RspType<> ipmiAppSetSystemInfo(uint8_t paramSelector, uint8_t data1,
+         std::copy_n(configData.begin(), count, paramString.begin() + offset);
      }
- 
-+    // read bios version from Intel ipmi command
-+    handleFirmwareVersion(paramSelector, configData);
+     sysInfoParamStore->update(paramSelector, paramString);
 +
-     uint8_t setSelector = data1;
-     size_t count = 0;
-     if (setSelector == 0) // First chunk has only 14 bytes.
++    // update BIOS version
++    handleFirmwareVersion(paramSelector, paramString);
+     return ipmi::responseSuccess();
+ }
+ 
 -- 
 2.17.1
 

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-Fix-firmware-version-missing-at-dev-tag.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host/0001-Fix-firmware-version-missing-at-dev-tag.patch
@@ -1,0 +1,30 @@
+From 3f2952b42b8806558c2a0184914f5545433b5c76 Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Fri, 17 Jun 2022 10:46:34 +0800
+Subject: [PATCH] Fix firmware version missing at dev tag
+
+The firmware version "v" must at the first character, wwe should not
+handle other "v" (like "dev") to avoid parsing string error.
+
+Signed-off-by: Brian Ma <chma0@nuvoton.com>
+Change-Id: I274e7158b44f2c5dd566e47940bfc1fd7e5ebe83
+---
+ apphandler.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/apphandler.cpp b/apphandler.cpp
+index 0577c07..7aa5c54 100644
+--- a/apphandler.cpp
++++ b/apphandler.cpp
+@@ -486,7 +486,7 @@ int convertVersion(std::string s, Revision& rev)
+     std::string token;
+     uint16_t commits;
+ 
+-    auto location = s.find_first_of('v');
++    auto location = s.find_last_of('v', 0);
+     if (location != std::string::npos)
+     {
+         s = s.substr(location + 1);
+-- 
+2.17.1
+

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -6,6 +6,7 @@ SRC_URI:append:olympus-nuvoton = " \
     file://0001-Add-set-BIOS-version-support.patch \
     file://0002-Add-support-for-enabling-disabling-network-IPMI.patch \
     file://0003-Add-option-for-SEL-commands-for-Journal-based-SEL-en.patch \
+    file://0001-Fix-firmware-version-missing-at-dev-tag.patch \
     "
 
 DEPENDS:append:olympus-nuvoton = " \


### PR DESCRIPTION
When our device version contains dev like: 2.12.0-dev-1361..., the ipmi
mc info command cannot return firmware version correctly. Fix it by
modify convertVersion function.
Also update set BIOS version patch with newest version.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
