### PR TITLE
meta-buv-runbmc: fix ipmi sdr list error

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-config.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-config.bbappend
@@ -13,6 +13,8 @@ python do_patch:buv-runbmc() {
 
     # count from the commit version
     count = re.findall("-(\d{1,4})-", version_id)
+    if len(count) == 0:
+        count.append("0")
 
     release = re.findall("-r(\d{1,4})", version_id)
     if release:

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -10,13 +10,11 @@ DEPENDS:append:buv-runbmc= " \
     ${@entity_enabled(d, '', ' buv-runbmc-yaml-config')}"
 
 EXTRA_OECONF:buv-runbmc = " \
-    --enable-boot-flag-safe-mode-support \
-    --with-journal-sel \
     ${@entity_enabled(d, '', ' SENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/buv-runbmc-yaml-config/ipmi-sensors.yaml')} \
     ${@entity_enabled(d, '', ' FRU_YAML_GEN=${STAGING_DIR_HOST}${datadir}/buv-runbmc-yaml-config/ipmi-fru-read.yaml')} \
     ${@entity_enabled(d, '', ' INVSENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/buv-runbmc-yaml-config/ipmi-inventory-sensors.yaml')} \
-    ${@entity_enabled(d, '', ' --disable-dynamic_sensors')} \
     "
+PACKAGECONFIG:append:buv-entity = " dynamic-sensors"
 
 do_install:append:buv-entity(){
     install -d ${D}${includedir}/phosphor-ipmi-host


### PR DESCRIPTION
Update phosphor-ipmi-host recipe to fix dynamic sensor not work in
entity manager distro.
And also fix build break if current commit at annotated tag

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
