### PR TITLE
Add support for CPLD FW upgrade via WebUI.

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/dbus/phosphor-dbus-interfaces/0001-Software-Add-CPLD-VersionPurpose.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/dbus/phosphor-dbus-interfaces/0001-Software-Add-CPLD-VersionPurpose.patch
@@ -1,0 +1,23 @@
+From 80edbd9f4af75e92718a9ca90e4c23846070eb63 Mon Sep 17 00:00:00 2001
+From: jhkang <jhkang@nuvoton.com>
+Date: Wed, 29 Jun 2022 01:01:39 -0700
+Subject: [PATCH] Software: Add CPLD VersionPurpose
+
+---
+ yaml/xyz/openbmc_project/Software/Version.interface.yaml | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/yaml/xyz/openbmc_project/Software/Version.interface.yaml b/yaml/xyz/openbmc_project/Software/Version.interface.yaml
+index e13594f4..3b366147 100644
+--- a/yaml/xyz/openbmc_project/Software/Version.interface.yaml
++++ b/yaml/xyz/openbmc_project/Software/Version.interface.yaml
+@@ -44,3 +44,6 @@ enumerations:
+           - name: MCU
+             description: >
+                 The version is a version for a MCU.
++          - name: CPLD
++            description: >
++                The version is a version for a CPLD.
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/dbus/phosphor-dbus-interfaces_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/dbus/phosphor-dbus-interfaces_%.bbappend
@@ -2,3 +2,4 @@ FILESEXTRAPATHS:prepend:buv-runbmc := "${THISDIR}/${PN}:"
 
 #SRC_URI:append:buv-runbmc = " file://0028-MCTP-Daemon-D-Bus-interface-definition.patch"
 SRC_URI:append:buv-runbmc = " file://0001-Software-Add-MCU-VersionPurpose.patch"
+SRC_URI:append:buv-runbmc = " file://0001-Software-Add-CPLD-VersionPurpose.patch"

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager/0002-porting-bios-verify-feature.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager/0002-porting-bios-verify-feature.patch
@@ -11,22 +11,22 @@ Signed-off-by: Brian Ma <chma0@nuvoton.com>
  3 files changed, 26 insertions(+), 1 deletion(-)
 
 diff --git a/image_verify.cpp b/image_verify.cpp
-index d67cfac..071e124 100644
+index 9551e4e..01836e0 100644
 --- a/image_verify.cpp
 +++ b/image_verify.cpp
-@@ -93,6 +93,7 @@ bool Signature::verifyFullImage()
-     bool ret = true;
- #ifdef WANT_SIGNATURE_FULL_VERIFY
+@@ -105,6 +105,7 @@ bool Signature::verifyFullImage()
+     }
+
      std::vector<std::string> fullImages = {
 +        fs::path(imageDirPath) / "image-bios.sig",
          fs::path(imageDirPath) / "image-bmc.sig",
          fs::path(imageDirPath) / "image-hostfw.sig",
          fs::path(imageDirPath) / "image-kernel.sig",
 diff --git a/item_updater.cpp b/item_updater.cpp
-index fe9c808..730b9f7 100644
+index c8fda76..6128e50 100644
 --- a/item_updater.cpp
 +++ b/item_updater.cpp
-@@ -749,6 +749,28 @@ bool ItemUpdater::checkImage(const std::string& filePath,
+@@ -834,6 +834,28 @@ bool ItemUpdater::checkImage(const std::string& filePath,
  }
  
  #ifdef HOST_BIOS_UPGRADE
@@ -55,7 +55,7 @@ index fe9c808..730b9f7 100644
  void ItemUpdater::createBIOSObject()
  {
      std::string path = BIOS_OBJPATH;
-@@ -764,7 +786,7 @@ void ItemUpdater::createBIOSObject()
+@@ -849,7 +871,7 @@ void ItemUpdater::createBIOSObject()
      createFunctionalAssociation(path);
  
      auto versionId = path.substr(pos + 1);
@@ -65,10 +65,10 @@ index fe9c808..730b9f7 100644
      biosActivation = std::make_unique<Activation>(
          bus, path, *this, versionId, server::Activation::Activations::Active,
 diff --git a/meson.build b/meson.build
-index 1367a72..0d16964 100644
+index 0dca8c0..2bf7700 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -58,6 +58,8 @@ conf.set_quoted('ALT_RWFS', '/media/alt/var/persist')
+@@ -57,6 +57,8 @@ conf.set_quoted('UPDATEABLE_REV_ASSOCIATION', 'software_version')
  conf.set_quoted('BMC_ROFS_PREFIX', get_option('media-dir') + '/rofs-')
  # The name of the BMC table of contents file
  conf.set_quoted('OS_RELEASE_FILE', '/etc/os-release')
@@ -79,4 +79,3 @@ index 1367a72..0d16964 100644
  
 -- 
 2.17.1
-

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager/0005-Add-support-for-CPLD-firmware-upgrade.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager/0005-Add-support-for-CPLD-firmware-upgrade.patch
@@ -1,0 +1,313 @@
+From 494a1379116b8f0af4d0fe923167b81a5de82fc7 Mon Sep 17 00:00:00 2001
+From: jhkang <jhkang@nuvoton.com>
+Date: Wed, 29 Jun 2022 20:26:42 -0700
+Subject: [PATCH 5/5] Add support for CPLD firmware upgrade
+
+---
+ activation.cpp    | 79 +++++++++++++++++++++++++++++++++++++++++++++++
+ activation.hpp    |  5 +++
+ item_updater.cpp  | 61 ++++++++++++++++++++++++++++++++++++
+ item_updater.hpp  | 20 ++++++++++++
+ meson.build       |  7 +++++
+ meson_options.txt |  9 ++++++
+ 6 files changed, 181 insertions(+)
+
+diff --git a/activation.cpp b/activation.cpp
+index 4a19222..d064376 100644
+--- a/activation.cpp
++++ b/activation.cpp
+@@ -168,6 +168,19 @@ auto Activation::activation(Activations value) -> Activations
+         }
+ #endif
+ 
++#ifdef CPLD_UPGRADE
++        if (purpose == VersionPurpose::CPLD)
++        {
++            // Enable systemd signals
++            subscribeToSystemdSignals();
++
++            // Set initial progress
++            activationProgress->progress(20);
++
++            return softwareServer::Activation::activation(value);
++        }
++#endif
++
+         activationProgress->progress(10);
+ 
+         parent.freeSpace(*this);
+@@ -352,6 +365,14 @@ void Activation::unitStateChange(sdbusplus::message::message& msg)
+     }
+ #endif
+ 
++#ifdef CPLD_UPGRADE
++    if (purpose == VersionPurpose::CPLD)
++    {
++        onStateChangesCpld(msg);
++        return;
++    }
++#endif
++
+     onStateChanges(msg);
+ 
+     return;
+@@ -560,6 +581,64 @@ void Activation::onStateChangesMcu(sdbusplus::message::message& msg)
+ 
+ #endif
+ 
++#ifdef CPLD_UPGRADE
++void Activation::onStateChangesCpld(sdbusplus::message::message& msg)
++{
++    uint32_t newStateID{};
++    sdbusplus::message::object_path newStateObjPath;
++    std::string newStateUnit{};
++    std::string newStateResult{};
++
++    // Read the msg and populate each variable
++    msg.read(newStateID, newStateObjPath, newStateUnit, newStateResult);
++
++    auto cpldServiceFile = "cpld-update.service";
++
++    if (newStateResult == "done")
++    {
++        // unsubscribe to systemd signals
++        unsubscribeFromSystemdSignals();
++        auto method = bus.new_method_call(SYSTEMD_BUSNAME, SYSTEMD_PATH,
++                                      SYSTEMD_INTERFACE, "StartUnit");
++        method.append(cpldServiceFile, "replace");
++        try
++        {
++            auto reply = bus.call(method);
++
++            // Wait a few seconds for the service file to finish, 
++            // otherwise the CPLD FW might be deleted before upgrading finished.
++            constexpr auto removeWait = std::chrono::seconds(10);
++            std::this_thread::sleep_for(removeWait);
++
++            // Set activation progress to 100
++            activationProgress->progress(100);
++
++            // Set Activation value to active
++            activation(softwareServer::Activation::Activations::Active);
++
++            info("CPLD upgrade completed successfully.");
++            parent.cpldVersion->version(
++                parent.versions.find(versionId)->second->version());
++
++            // Delete the uploaded activation
++            boost::asio::post(getIOContext(), [this]() {
++                this->parent.erase(this->versionId);
++            });
++        }
++        catch (const sdbusplus::exception::exception& e)
++        {
++            // Set Activation value to Failed
++            activation(softwareServer::Activation::Activations::Failed);
++
++            error("CPLD upgrade failed.");
++        }
++    }
++
++    return;
++}
++
++#endif
++
+ void Activation::rebootBmc()
+ {
+     auto method = bus.new_method_call(SYSTEMD_BUSNAME, SYSTEMD_PATH,
+diff --git a/activation.hpp b/activation.hpp
+index d71734c..d835475 100644
+--- a/activation.hpp
++++ b/activation.hpp
+@@ -256,6 +256,11 @@ class Activation : public ActivationInherit, public Flash
+     void onStateChangesMcu(sdbusplus::message::message&);
+ #endif
+ 
++#ifdef CPLD_UPGRADE
++    /** @brief Function that acts on CPLD upgrade service file state changes */
++    void onStateChangesCpld(sdbusplus::message::message&);
++#endif
++
+     /** @brief Overloaded function that acts on service file state changes */
+     void onStateChanges(sdbusplus::message::message&) override;
+ 
+diff --git a/item_updater.cpp b/item_updater.cpp
+index dbeacd4..7758ca4 100644
+--- a/item_updater.cpp
++++ b/item_updater.cpp
+@@ -73,6 +73,9 @@ void ItemUpdater::createActivation(sdbusplus::message::message& msg)
+ #endif
+ #ifdef MCU_UPGRADE
+                         value == VersionPurpose::MCU ||
++#endif
++#ifdef CPLD_UPGRADE
++                        value == VersionPurpose::CPLD ||
+ #endif
+                         value == VersionPurpose::System)
+                     {
+@@ -947,6 +950,64 @@ void ItemUpdater::createMCUObject()
+ }
+ #endif
+ 
++#ifdef CPLD_UPGRADE
++std::string restoreCPLDVersion()
++{
++    std::string version = "null";
++
++    fs::path release = fs::path(PERSIST_DIR) / CPLD_RELEASE_FILE;
++    if (fs::exists(release))
++    {
++        try
++        {
++            version = VersionClass::getBMCVersion(release.string());
++        }
++        catch (const std::exception& e)
++        {
++            warning("Failed to parse CPLD version: {ERROR}", "ERROR", e);
++        }
++    }
++    else
++    {
++        info("No cpld version file exist");
++    }
++
++    return version;
++}
++
++void ItemUpdater::createCPLDObject()
++{
++    std::string path = CPLD_OBJPATH;
++    // Get version id from last item in the path
++    auto pos = path.rfind("/");
++    if (pos == std::string::npos)
++    {
++        error("No CPLD version id found in object path {PATH}", "PATH", path);
++        return;
++    }
++
++    createActiveAssociation(path);
++    createFunctionalAssociation(path);
++
++    std::string versionId = path.substr(pos + 1);
++    auto version = restoreCPLDVersion();
++    AssociationList assocs = {};
++    cpldActivation = std::make_unique<Activation>(
++        bus, path, *this, versionId, server::Activation::Activations::Active,
++        assocs);
++    auto dummyErase = [](std::string /*entryId*/) {
++        // Do nothing;
++    };
++    cpldVersion = std::make_unique<VersionClass>(
++        bus, path, version, VersionPurpose::CPLD, "", "",
++        std::vector<std::string>(),
++        std::bind(dummyErase, std::placeholders::_1), "");
++    cpldVersion->deleteObject =
++        std::make_unique<phosphor::software::manager::Delete>(bus, path,
++                                                              *cpldVersion);
++}
++#endif
++
+ void ItemUpdater::getRunningSlot()
+ {
+     // Check /run/media/slot to get the slot number
+diff --git a/item_updater.hpp b/item_updater.hpp
+index d980deb..4be179c 100644
+--- a/item_updater.hpp
++++ b/item_updater.hpp
+@@ -70,6 +70,9 @@ class ItemUpdater : public ItemUpdaterInherit
+ #endif
+ #ifdef MCU_UPGRADE
+         createMCUObject();
++ #endif
++#ifdef CPLD_UPGRADE
++        createCPLDObject();
+  #endif
+         emit_object_added();
+     };
+@@ -300,6 +303,23 @@ class ItemUpdater : public ItemUpdaterInherit
+     std::unique_ptr<VersionClass> mcuVersion;
+ #endif
+ 
++#ifdef CPLD_UPGRADE
++    /** @brief Create the CPLD object without knowing the version.
++     *
++     *  The object is created only to provide the DBus access so that an
++     *  external service could set the correct CPLD version.
++     *  On CPLD code update, the version is updated accordingly.
++     */
++    void createCPLDObject();
++
++    /** @brief Persistent Activation D-Bus object for CPLD */
++    std::unique_ptr<Activation> cpldActivation;
++
++  public:
++    /** @brief Persistent Version D-Bus object for CPLD */
++    std::unique_ptr<VersionClass> cpldVersion;
++#endif
++
+     /** @brief Get the slot number of running image */
+     void getRunningSlot();
+ };
+diff --git a/meson.build b/meson.build
+index b27b6f2..27bf01e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -61,6 +61,8 @@ conf.set_quoted('OS_RELEASE_FILE', '/etc/os-release')
+ conf.set_quoted('HOST_RELEASE_FILE', 'bios-release')
+ # The name of the mcu firmware version file
+ conf.set_quoted('MCU_RELEASE_FILE', 'mcu-release')
++# The name of the cpld firmware version file
++conf.set_quoted('CPLD_RELEASE_FILE', 'cpld-release')
+ # The dir where activation data is stored in files
+ conf.set_quoted('PERSIST_DIR', '/var/lib/phosphor-bmc-code-mgmt/')
+ 
+@@ -72,6 +74,7 @@ conf.set('MMC_LAYOUT', get_option('bmc-layout').contains('mmc'))
+ # Configurable features
+ conf.set('HOST_BIOS_UPGRADE', get_option('host-bios-upgrade').enabled())
+ conf.set('MCU_UPGRADE', get_option('mcu-upgrade').enabled())
++conf.set('CPLD_UPGRADE', get_option('cpld-upgrade').enabled())
+ conf.set('WANT_SIGNATURE_VERIFY', \
+     get_option('verify-signature').enabled() or \
+     get_option('verify-full-signature').enabled())
+@@ -106,6 +109,10 @@ if get_option('mcu-upgrade').enabled()
+     conf.set_quoted('MCU_OBJPATH', get_option('mcu-object-path'))
+ endif
+ 
++if get_option('cpld-upgrade').enabled()
++    conf.set_quoted('CPLD_OBJPATH', get_option('cpld-object-path'))
++endif
++
+ if get_option('bmc-static-dual-image').enabled()
+   conf.set('BMC_STATIC_DUAL_IMAGE', get_option('bmc-static-dual-image').enabled())
+   conf.set_quoted('ALT_ROFS_DIR', get_option('alt-rofs-dir'))
+diff --git a/meson_options.txt b/meson_options.txt
+index 198d4de..ae00709 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -15,6 +15,9 @@ option('host-bios-upgrade', type: 'feature', value: 'enabled',
+ option('mcu-upgrade', type: 'feature', value: 'enabled',
+     description: 'Enable mcu upgrade support.')
+ 
++option('cpld-upgrade', type: 'feature', value: 'enabled',
++    description: 'Enable cpld upgrade support.')
++
+ option('sync-bmc-files', type: 'feature', value: 'enabled',
+     description: 'Enable sync of filesystem files.')
+ 
+@@ -135,6 +138,12 @@ option(
+     description: 'The MCU DBus object path.',
+ )
+ 
++option(
++    'cpld-object-path', type: 'string',
++    value: '/xyz/openbmc_project/software/cpld_active',
++    description: 'The CPLD DBus object path.',
++)
++
+ option('bmc-static-dual-image', type: 'feature', value: 'enabled',
+     description: 'Enable the dual image support for static layout.')
+ 
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -5,8 +5,10 @@ SRC_URI:append:buv-runbmc = " \
     file://0002-porting-bios-verify-feature.patch  \
     file://0003-Add-support-report-same-version-error.patch \
     file://0004-Add-support-for-MCU-firmware-upgrade.patch \
+    file://0005-Add-support-for-CPLD-firmware-upgrade.patch \
     "
 
 PACKAGECONFIG[flash_mcu] = "-Dmcu-upgrade=enabled, -Dmcu-upgrade=disabled"
-PACKAGECONFIG:append:buv-runbmc = " verify_signature flash_bios flash_mcu"
+PACKAGECONFIG[flash_cpld] = "-Dcpld-upgrade=enabled, -Dcpld-upgrade=disabled"
+PACKAGECONFIG:append:buv-runbmc = " verify_signature flash_bios flash_mcu flash_cpld"
 EXTRA_OEMESON:append:buv-runbmc = " -Doptional-images=image-bios"

--- a/meta-nuvoton/recipes-nuvoton/loadsvf/files/cpld-update.service
+++ b/meta-nuvoton/recipes-nuvoton/loadsvf/files/cpld-update.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=NPCM7xx CPLD F/W update service
+
+[Service]
+Restart=no
+Type=oneshot
+ExecStart=/usr/bin/cpld-update.sh
+SyslogIdentifier=cpld-update.sh

--- a/meta-nuvoton/recipes-nuvoton/loadsvf/files/cpld-update.sh
+++ b/meta-nuvoton/recipes-nuvoton/loadsvf/files/cpld-update.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+sleep 1
+
+# get cpld firmware file name as firmware version
+version=$(find /tmp/ -name "*.svf")
+filename=$(basename $version .svf)
+filename+=".svf"
+
+if [ -z "$version" ]
+then 
+   echo "No CPLD FW found."
+   echo "VERSION_ID=N/A" > /var/lib/phosphor-bmc-code-mgmt/cpld-release
+else
+   # Call loadsvf to process CPLD upgrade
+   loadsvf -d /dev/jtag0 -s `echo $version`
+
+   # Use file name as VERSION_ID to identify the cpld FW version
+   echo "VERSION_ID=$filename" > /var/lib/phosphor-bmc-code-mgmt/cpld-release
+fi

--- a/meta-nuvoton/recipes-nuvoton/loadsvf/loadsvf_git.bb
+++ b/meta-nuvoton/recipes-nuvoton/loadsvf/loadsvf_git.bb
@@ -1,14 +1,30 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}:"
 DESCRIPTION = "CPLD/FPGA Programmer"
 PR = "r1"
 
 LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/Nuvoton-Israel/loadsvf.git;branch=master;protocol=https"
+SRC_URI = "git://github.com/Nuvoton-Israel/loadsvf.git;branch=master;protocol=https \
+    	   file://cpld-update.service \
+           file://cpld-update.sh \
+          "
+
 SRCREV = "f2296005cbba13b49e5163340cac80efbec9cdf4"
 S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig
+inherit systemd
+inherit obmc-phosphor-systemd
 
 DEPENDS += "autoconf-archive-native"
+DEPENDS += "systemd"
+RDEPENDS:${PN} += "bash"
 
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "cpld-update.service"
+
+do_install:append() {
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/cpld-update.sh ${D}${bindir}/
+}

--- a/meta-nuvoton/recipes-phosphor/webui/webui-vue/0003-Add-Nuvoton-CPLD-firmware-support.patch
+++ b/meta-nuvoton/recipes-phosphor/webui/webui-vue/0003-Add-Nuvoton-CPLD-firmware-support.patch
@@ -1,0 +1,140 @@
+From 669553d40651790cc33c3cfed6299c913775c397 Mon Sep 17 00:00:00 2001
+From: jhkang <jhkang@nuvoton.com>
+Date: Wed, 29 Jun 2022 02:30:36 -0700
+Subject: [PATCH 3/3] Add Nuvoton CPLD firmware support
+
+---
+ src/locales/en-US.json                        |  1 +
+ src/store/modules/Operations/FirmwareStore.js |  7 ++++
+ src/views/Operations/Firmware/Firmware.vue    |  5 +++
+ .../Operations/Firmware/FirmwareCardsCpld.vue | 37 +++++++++++++++++++
+ 4 files changed, 50 insertions(+)
+ create mode 100644 src/views/Operations/Firmware/FirmwareCardsCpld.vue
+
+diff --git a/src/locales/en-US.json b/src/locales/en-US.json
+index 689bff9e..e29a685b 100644
+--- a/src/locales/en-US.json
++++ b/src/locales/en-US.json
+@@ -326,6 +326,7 @@
+     "sectionTitleBmcCardsCombined": "BMC and server",
+     "sectionTitleHostCards": "Host",
+     "sectionTitleMcuCards": "MCU",
++    "sectionTitleCpldCards": "CPLD",
+     "sectionTitleUpdateFirmware": "Update firmware",
+     "alert": {
+       "operationInProgress": "Server power operation in progress.",
+diff --git a/src/store/modules/Operations/FirmwareStore.js b/src/store/modules/Operations/FirmwareStore.js
+index 79f8638f..bc1ece4a 100644
+--- a/src/store/modules/Operations/FirmwareStore.js
++++ b/src/store/modules/Operations/FirmwareStore.js
+@@ -7,6 +7,7 @@ const FirmwareStore = {
+     bmcFirmware: [],
+     hostFirmware: [],
+     mcuFirmware: null,
++    cpldFirmware: null,
+     bmcActiveFirmwareId: null,
+     hostActiveFirmwareId: null,
+     applyTime: null,
+@@ -26,6 +27,7 @@ const FirmwareStore = {
+       );
+     },
+     mcuFirmware: (state) => state.mcuFirmware,
++    cpldFirmware: (state) => state.cpldFirmware,
+     backupBmcFirmware: (state) => {
+       return state.bmcFirmware.find(
+         (firmware) => firmware.id !== state.bmcActiveFirmwareId
+@@ -43,6 +45,7 @@ const FirmwareStore = {
+     setBmcFirmware: (state, firmware) => (state.bmcFirmware = firmware),
+     setHostFirmware: (state, firmware) => (state.hostFirmware = firmware),
+     setMcuFirmware: (state, firmware) => (state.mcuFirmware = firmware),
++    setCpldFirmware: (state, firmware) => (state.cpldFirmware = firmware),
+     setApplyTime: (state, applyTime) => (state.applyTime = applyTime),
+     setTftpUploadAvailable: (state, tftpAvailable) =>
+       (state.tftpAvailable = tftpAvailable),
+@@ -90,6 +93,10 @@ const FirmwareStore = {
+               const mcuFirmware = data?.Version;
+               commit('setMcuFirmware', mcuFirmware);
+             }
++            if (Description === 'CPLD image') {
++              const cpldFirmware = data?.Version;
++              commit('setCpldFirmware', cpldFirmware);
++            }
+             const firmwareType = data?.RelatedItem?.[0]?.['@odata.id']
+               .split('/')
+               .pop();
+diff --git a/src/views/Operations/Firmware/Firmware.vue b/src/views/Operations/Firmware/Firmware.vue
+index bfb9b785..dce1becc 100644
+--- a/src/views/Operations/Firmware/Firmware.vue
++++ b/src/views/Operations/Firmware/Firmware.vue
+@@ -17,6 +17,9 @@
+ 
+         <!-- MCU Firmware -->
+         <mcu-cards />
++
++        <!-- CPLD Firmware -->
++        <cpld-cards />
+       </b-col>
+     </b-row>
+ 
+@@ -43,6 +46,7 @@ import BmcCards from './FirmwareCardsBmc';
+ import FormUpdate from './FirmwareFormUpdate';
+ import HostCards from './FirmwareCardsHost';
+ import McuCards from './FirmwareCardsMcu';
++import CpldCards from './FirmwareCardsCpld';
+ import PageSection from '@/components/Global/PageSection';
+ import PageTitle from '@/components/Global/PageTitle';
+ 
+@@ -56,6 +60,7 @@ export default {
+     FormUpdate,
+     HostCards,
+     McuCards,
++    CpldCards,
+     PageSection,
+     PageTitle,
+   },
+diff --git a/src/views/Operations/Firmware/FirmwareCardsCpld.vue b/src/views/Operations/Firmware/FirmwareCardsCpld.vue
+new file mode 100644
+index 00000000..f5789265
+--- /dev/null
++++ b/src/views/Operations/Firmware/FirmwareCardsCpld.vue
+@@ -0,0 +1,37 @@
++<template>
++  <page-section :section-title="$t('pageFirmware.sectionTitleCpldCards')">
++    <b-card-group deck>
++      <!-- Running image -->
++      <b-card>
++        <template #header>
++          <p class="font-weight-bold m-0">
++            {{ $t('pageFirmware.cardTitleRunning') }}
++          </p>
++        </template>
++        <dl class="mb-0">
++          <dt>{{ $t('pageFirmware.cardBodyVersion') }}</dt>
++          <dd class="mb-0">{{ runningVersion }}</dd>
++        </dl>
++      </b-card>
++    </b-card-group>
++  </page-section>
++</template>
++
++<script>
++import PageSection from '@/components/Global/PageSection';
++
++export default {
++  components: { PageSection },
++  computed: {
++    runningVersion() {
++      return this.$store.getters['firmware/cpldFirmware'] || '--';
++    },
++  },
++};
++</script>
++
++<style lang="scss" scoped>
++.page-section {
++  margin-top: -$spacer * 1.5;
++}
++</style>
+-- 
+2.17.1
+

--- a/meta-nuvoton/recipes-phosphor/webui/webui-vue_%.bbappend
+++ b/meta-nuvoton/recipes-phosphor/webui/webui-vue_%.bbappend
@@ -2,3 +2,4 @@ FILESEXTRAPATHS:append:nuvoton := ":${THISDIR}/${PN}"
 
 SRC_URI:append:nuvoton = " file://0001-novnc-add-16-bit-hextile-support-for-nuvoton-ece-eng.patch"
 SRC_URI:append:nuvoton = " file://0002-Add-Nuvoton-MCU-firmware-support.patch"
+SRC_URI:append:nuvoton = " file://0003-Add-Nuvoton-CPLD-firmware-support.patch"


### PR DESCRIPTION
Add support for CPLD FW upgrade via WebUI.

Test done:
No build error.
Not boot error.
CPLD FW upgrade via WebUI function works fine.
CPLD FW version (file name) could be shown on WebUI.