### PR TITLE
meta-evb-npcm845: Force set self test command pass

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0012-Force-self-test-OK.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0012-Force-self-test-OK.patch
@@ -1,0 +1,16 @@
+diff --git a/apphandler.cpp b/apphandler.cpp
+index a20d61a..7a7bfcc 100644
+--- a/apphandler.cpp
++++ b/apphandler.cpp
+@@ -695,9 +695,9 @@ auto ipmiAppGetSelfTestResults() -> ipmi::RspType<uint8_t, uint8_t>
+     //      [2] 1b = Internal Use Area of BMC FRU corrupted.
+     //      [1] 1b = controller update 'boot block' firmware corrupted.
+     //      [0] 1b = controller operational firmware corrupted.
+-    constexpr uint8_t notImplemented = 0x56;
++    //constexpr uint8_t notImplemented = 0x56;
+     constexpr uint8_t zero = 0;
+-    return ipmi::responseSuccess(notImplemented, zero);
++    return ipmi::responseSuccess(0x55, zero);
+ }
+ 
+ static constexpr size_t uuidBinaryLength = 16;

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -15,6 +15,7 @@ SRC_URI:append:evb-npcm845 = " file://0006-Correct-IPMI-firmware-revision-report
 SRC_URI:append:evb-npcm845 = " file://0007-dbus-sdr-storagecommands-Add-option-to-use-Clear-met.patch"
 SRC_URI:append:evb-npcm845 = " file://0008-Add-sensor-type-command.patch"
 SRC_URI:append:evb-npcm845 = " file://0011-Add-SEL-time-set-command.patch"
+SRC_URI:append:evb-npcm845 = " file://0012-Force-self-test-OK.patch"
 
 # Add send/get message support
 # ipmid <-> ipmb <-> i2c

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0012-Force-self-test-OK.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0012-Force-self-test-OK.patch
@@ -1,0 +1,16 @@
+diff --git a/apphandler.cpp b/apphandler.cpp
+index a20d61a..7a7bfcc 100644
+--- a/apphandler.cpp
++++ b/apphandler.cpp
+@@ -695,9 +695,9 @@ auto ipmiAppGetSelfTestResults() -> ipmi::RspType<uint8_t, uint8_t>
+     //      [2] 1b = Internal Use Area of BMC FRU corrupted.
+     //      [1] 1b = controller update 'boot block' firmware corrupted.
+     //      [0] 1b = controller operational firmware corrupted.
+-    constexpr uint8_t notImplemented = 0x56;
++    //constexpr uint8_t notImplemented = 0x56;
+     constexpr uint8_t zero = 0;
+-    return ipmi::responseSuccess(notImplemented, zero);
++    return ipmi::responseSuccess(0x55, zero);
+ }
+ 
+ static constexpr size_t uuidBinaryLength = 16;

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -18,6 +18,7 @@ SRC_URI:append:scm-npcm845 = " file://0008-Add-sensor-type-command.patch"
 SRC_URI:append:scm-npcm845 = " file://0009-implement-warm-reset-command.patch"
 SRC_URI:append:scm-npcm845 = " file://0010-get-system-guid-command.patch"
 SRC_URI:append:scm-npcm845 = " file://0011-Add-SEL-time-set-command.patch"
+SRC_URI:append:scm-npcm845 = " file://0012-Force-self-test-OK.patch"
 
 # Add send/get message support
 # ipmid <-> ipmb <-> i2c


### PR DESCRIPTION
The BMC functions must always ready, maybe we can implement the function
later.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

