### PR TITLE
meta-nuvoton: npcm7xx-bingo: upgrade latest version 0.0.5 support Arbel

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm7xx-bingo-native_git.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm7xx-bingo-native_git.bb
@@ -7,7 +7,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRC_URI += "git://github.com/Nuvoton-Israel/bingo;branch=master;protocol=https"
-SRCREV = "4f102ff7851da9fd11965857edd1b3046c187b7a"
+SRCREV = "7c35658b667d04d6cc78b7ed569f4401168ae133"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Bingo 0.0.5 is required for Arbel. It is also backward compatible for Poleg.

Signed-off-by: Tim Lee <timlee660101@gmail.com>