### PR TITLE
meta-nuvoton: update uboot source

### DIFF
--- a/meta-nuvoton/recipes-bsp/u-boot/u-boot-common-nuvoton.inc
+++ b/meta-nuvoton/recipes-bsp/u-boot/u-boot-common-nuvoton.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 
 UBRANCH = "npcm-v2021.04"
 SRC_URI = "git://github.com/Nuvoton-Israel/u-boot.git;branch=${UBRANCH};protocol=https"
-SRCREV = "2ac30dca81b658e423879d51eacb91199bcceab3"
+SRCREV = "f33412159be1f88dc2ae5f82ac03c8960ff616cb"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
use new uboot-2021 commit to fix olympus reset failed.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
