### PR TITLE
meta-scm-npcm845: mount /var/log persistent

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/conf/machine/scm-npcm845.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/conf/machine/scm-npcm845.conf
@@ -54,3 +54,4 @@ PREFERRED_PROVIDER_virtual/phosphor-led-manager-config-native = "scm-npcm845-led
 IMAGE_FEATURES:remove = "obmc-fan-control"
 
 MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"
+VOLATILE_LOG_DIR = "no"


### PR DESCRIPTION
By default Openbmc design, /var/log mount on tmpfs. Change the log path
to RW file system.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

