### PR TITLE
meta-evb-npcm845: save MAC address to U-boot env

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/network/phosphor-network_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/network/phosphor-network_%.bbappend
@@ -1,1 +1,3 @@
-EXTRA_OECONF:append:evb-npcm845 = " --disable-link-local-autoconfiguration --with-uboot-env"
+PACKAGECONFIG:append:evb-npcm845 = " nic-ethtool"
+PACKAGECONFIG:append:evb-npcm845 = " uboot-env"
+PACKAGECONFIG:remove:evb-npcm845 = "default-link-local-autoconf"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/network/phosphor-network_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/network/phosphor-network_%.bbappend
@@ -1,1 +1,3 @@
-EXTRA_OECONF:append:scm-npcm845 = " --disable-link-local-autoconfiguration --with-uboot-env"
+PACKAGECONFIG:append:scm-npcm845 = " nic-ethtool"
+PACKAGECONFIG:append:scm-npcm845 = " uboot-env"
+PACKAGECONFIG:remove:scm-npcm845 = "default-link-local-autoconf"


### PR DESCRIPTION
Save MAC address to U-Boot environment to avoid missing MAC addrress
adfer update BMC image.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
