### PR TITLE
meta-evb-npcm845: Fix ipmitool event command fail

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0013-Set-is-from-system-interface-return-false.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0013-Set-is-from-system-interface-return-false.patch
@@ -1,0 +1,27 @@
+From 466653ba47fb8f3781353526e53091a3afdee4f4 Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Fri, 8 Jul 2022 16:41:26 +0800
+Subject: [PATCH] Set is from system interface return false
+
+The ipmitool get the event is from system interface return false, but
+ipmid set true as default. Change the ipmid default value to send event.
+---
+ sensorhandler.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sensorhandler.cpp b/sensorhandler.cpp
+index a523f3e..9cbb61d 100644
+--- a/sensorhandler.cpp
++++ b/sensorhandler.cpp
+@@ -1017,7 +1017,7 @@ static bool isFromSystemChannel()
+     // TODO we could not figure out where the request is from based on IPMI
+     // command handler parameters. because of it, we can not differentiate
+     // request from SMS/SMM or IPMB channel
+-    return true;
++    return false;
+ }
+ 
+ ipmi_ret_t ipmicmdPlatformEvent(ipmi_netfn_t netfn, ipmi_cmd_t cmd,
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -7,6 +7,7 @@ EXTRA_OECONF:append:evb-npcm845 = " ${@entity_enabled(d, '', 'SENSOR_YAML_GEN=${
 EXTRA_OECONF:append:evb-npcm845 = " ${@entity_enabled(d, '', 'FRU_YAML_GEN=${STAGING_DIR_HOST}${datadir}/evb-npcm845-yaml-config/ipmi-fru-read.yaml')}"
 EXTRA_OECONF:append:evb-npcm845 = " ${@entity_enabled(d, '', 'INVSENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/evb-npcm845-yaml-config/ipmi-inventory-sensors.yaml')}"
 EXTRA_OECONF:append:evb-npcm845 = " --disable-i2c-whitelist-check"
+EXTRA_OECONF:append:evb-npcm845 = " --enable-sel_logger_clears_sel"
 
 SRC_URI:append:evb-npcm845 = " file://0001-Add-Set-BIOS-version-support.patch"
 SRC_URI:append:evb-npcm845 = " file://0001-dbus-sdr-Support-NaN-thresholds.patch"
@@ -16,6 +17,7 @@ SRC_URI:append:evb-npcm845 = " file://0007-dbus-sdr-storagecommands-Add-option-t
 SRC_URI:append:evb-npcm845 = " file://0008-Add-sensor-type-command.patch"
 SRC_URI:append:evb-npcm845 = " file://0011-Add-SEL-time-set-command.patch"
 SRC_URI:append:evb-npcm845 = " file://0012-Force-self-test-OK.patch"
+SRC_URI:append:evb-npcm845 = " file://0013-Set-is-from-system-interface-return-false.patch"
 
 # Add send/get message support
 # ipmid <-> ipmb <-> i2c
@@ -25,6 +27,4 @@ PACKAGECONFIG:append:evb-npcm845 = " ${@entity_enabled(d, 'dynamic-sensors', '')
 
 # avoid build error after remove ipmi-fru
 WHITELIST_CONF:evb-npcm845 = "${S}/host-ipmid-whitelist.conf"
-
-EXTRA_OECONF:append:evb-npcm845 = " --enable-sel_logger_clears_sel"
 

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0013-Set-is-from-system-interface-return-false.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0013-Set-is-from-system-interface-return-false.patch
@@ -1,0 +1,27 @@
+From 466653ba47fb8f3781353526e53091a3afdee4f4 Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Fri, 8 Jul 2022 16:41:26 +0800
+Subject: [PATCH] Set is from system interface return false
+
+The ipmitool get the event is from system interface return false, but
+ipmid set true as default. Change the ipmid default value to send event.
+---
+ sensorhandler.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sensorhandler.cpp b/sensorhandler.cpp
+index a523f3e..9cbb61d 100644
+--- a/sensorhandler.cpp
++++ b/sensorhandler.cpp
+@@ -1017,7 +1017,7 @@ static bool isFromSystemChannel()
+     // TODO we could not figure out where the request is from based on IPMI
+     // command handler parameters. because of it, we can not differentiate
+     // request from SMS/SMM or IPMB channel
+-    return true;
++    return false;
+ }
+ 
+ ipmi_ret_t ipmicmdPlatformEvent(ipmi_netfn_t netfn, ipmi_cmd_t cmd,
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -19,6 +19,7 @@ SRC_URI:append:scm-npcm845 = " file://0009-implement-warm-reset-command.patch"
 SRC_URI:append:scm-npcm845 = " file://0010-get-system-guid-command.patch"
 SRC_URI:append:scm-npcm845 = " file://0011-Add-SEL-time-set-command.patch"
 SRC_URI:append:scm-npcm845 = " file://0012-Force-self-test-OK.patch"
+SRC_URI:append:scm-npcm845 = " file://0013-Set-is-from-system-interface-return-false.patch"
 
 # Add send/get message support
 # ipmid <-> ipmb <-> i2c


### PR DESCRIPTION
Set ipmid function isFromSystemChannel to false to avoid ipmitool
sending data is not match spec.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

