### PR TITLE
meta-scm-npcm845: add SEL after execute ipmi reset

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0009-implement-warm-reset-command.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0009-implement-warm-reset-command.patch
@@ -1,0 +1,122 @@
+From a329b90f1957c0576dafbea792145fd12e8a5cfa Mon Sep 17 00:00:00 2001
+From: Stanley Chu <yschu@nuvoton.com>
+Date: Tue, 5 Jul 2022 12:56:01 +0800
+Subject: [PATCH] ipmi warm reset command
+
+Signed-off-by: Stanley Chu <yschu@nuvoton.com>
+---
+ globalhandler.cpp | 64 ++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 63 insertions(+), 1 deletion(-)
+
+diff --git a/globalhandler.cpp b/globalhandler.cpp
+index 2561e087..394274f6 100644
+--- a/globalhandler.cpp
++++ b/globalhandler.cpp
+@@ -1,13 +1,18 @@
+ #include "globalhandler.hpp"
+ 
++#include <atomic>
++#include <chrono>
+ #include <ipmid/api.hpp>
+ #include <ipmid/utils.hpp>
+ #include <phosphor-logging/elog-errors.hpp>
+ #include <phosphor-logging/log.hpp>
+ #include <string>
++#include <thread>
+ #include <xyz/openbmc_project/Common/error.hpp>
+ #include <xyz/openbmc_project/State/BMC/server.hpp>
+ 
++static std::atomic_flag reset_queued = ATOMIC_FLAG_INIT;
++
+ static constexpr auto bmcStateRoot = "/xyz/openbmc_project/state";
+ static constexpr auto bmcStateIntf = "xyz.openbmc_project.State.BMC";
+ static constexpr auto reqTransition = "RequestedBMCTransition";
+@@ -18,6 +23,11 @@ using BMC = sdbusplus::xyz::openbmc_project::State::server::BMC;
+ 
+ void register_netfn_global_functions() __attribute__((constructor));
+ 
++constexpr auto SYSTEMD_SERVICE = "org.freedesktop.systemd1";
++constexpr auto SYSTEMD_OBJ_PATH = "/org/freedesktop/systemd1";
++constexpr auto SYSTEMD_INTERFACE = "org.freedesktop.systemd1.Manager";
++constexpr auto SYSTEMD_WARM_RESET_TARGET = "phosphor-ipmi-warm-reset.target";
++
+ void resetBMC()
+ {
+     sdbusplus::bus::bus bus{ipmid_get_sd_bus_connection()};
+@@ -32,7 +42,30 @@ void resetBMC()
+                           convertForMessage(BMC::Transition::Reboot));
+ }
+ 
+-/** @brief implements cold and warm reset commands
++void warmResetBMC()
++{
++    try
++    {
++        std::this_thread::sleep_for(std::chrono::milliseconds(100));
++        //sdbusplus::bus::bus bus{ipmid_get_sd_bus_connection()};
++        auto bus = sdbusplus::bus::new_default();
++        // Reset the failed units so we don't end up having systemd not properly restart if the command is spammed.
++        auto reset = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH, SYSTEMD_INTERFACE, "ResetFailed");
++        bus.call_noreply(reset);
++        std::this_thread::sleep_for(std::chrono::milliseconds(100));
++        // Restart the target (restart will propagate to units).
++        auto restart = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH, SYSTEMD_INTERFACE, "RestartUnit");
++        restart.append(SYSTEMD_WARM_RESET_TARGET, "replace");
++        bus.call_noreply(restart);
++    }
++    catch (std::exception& e)
++    {
++        log<level::ERR>(e.what());
++        reset_queued.clear();
++    }
++}
++
++/** @brief implements cold reset command
+  *  @param - None
+  *  @returns IPMI completion code.
+  */
+@@ -52,6 +85,32 @@ ipmi::RspType<> ipmiGlobalReset()
+     return ipmi::responseSuccess();
+ }
+ 
++
++/** @brief implements warm reset command
++ *  @param - None
++ *  @returns IPMI completion code.
++ */
++ipmi::RspType<> ipmiWarmReset()
++{
++    try
++    {
++        if (!reset_queued.test_and_set()) {
++            // Do this asynchronously so that we can properly return this command.
++            std::thread t(warmResetBMC);
++            t.detach();
++        }
++    }
++    catch (std::exception& e)
++    {
++        log<level::ERR>(e.what());
++        reset_queued.clear();
++        return ipmi::responseUnspecifiedError();
++    }
++
++    // Status code.
++    return ipmi::responseSuccess();
++}
++
+ void register_netfn_global_functions()
+ {
+ 
+@@ -59,5 +118,8 @@ void register_netfn_global_functions()
+     ipmi::registerHandler(ipmi::prioOpenBmcBase, ipmi::netFnApp,
+                           ipmi::app::cmdColdReset, ipmi::Privilege::Admin,
+                           ipmiGlobalReset);
++    ipmi::registerHandler(ipmi::prioOpenBmcBase, ipmi::netFnApp,
++                          ipmi::app::cmdWarmReset, ipmi::Privilege::Admin,
++                          ipmiWarmReset);
+     return;
+ }
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0016-Add-reset-SEL.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0016-Add-reset-SEL.patch
@@ -1,0 +1,143 @@
+diff --git a/dbus-sdr/sdrutils.cpp b/dbus-sdr/sdrutils.cpp
+index 3df0dc1..d6b469d 100644
+--- a/dbus-sdr/sdrutils.cpp
++++ b/dbus-sdr/sdrutils.cpp
+@@ -261,6 +261,10 @@ uint16_t getSensorNumberFromPath(const std::string& path)
+     {
+         return invalidSensorNumber;
+     }
++    if (path.find("oem_health") != std::string::npos)
++    {
++        return 0x00FF;
++    }
+ 
+     try
+     {
+diff --git a/globalhandler.cpp b/globalhandler.cpp
+index 394274f..028a7d3 100644
+--- a/globalhandler.cpp
++++ b/globalhandler.cpp
+@@ -27,9 +27,44 @@ constexpr auto SYSTEMD_SERVICE = "org.freedesktop.systemd1";
+ constexpr auto SYSTEMD_OBJ_PATH = "/org/freedesktop/systemd1";
+ constexpr auto SYSTEMD_INTERFACE = "org.freedesktop.systemd1.Manager";
+ constexpr auto SYSTEMD_WARM_RESET_TARGET = "phosphor-ipmi-warm-reset.target";
++static constexpr char const* ipmiSELObject = "xyz.openbmc_project.Logging.IPMI";
++static constexpr char const* ipmiSELPath = "/xyz/openbmc_project/Logging/IPMI";
++static constexpr char const* ipmiSELAddInterface =
++    "xyz.openbmc_project.Logging.IPMI";
++static constexpr char const* oemHealthSensor =
++    "/xyz/openbmc_project/sensors/oem_health/bmc_reset";
++
++enum reset_type
++{
++    COLD_RESET = 0x1,
++    WARM_RESET = 0x2,
++};
++
++ipmi::RspType<> resetSEL(uint8_t resetType)
++{
++    // MS spec 18.2.5 BMC health status, BMC reset SEL
++    static const std::string ipmiSELAddMessage = "BMC reset SEL";
++    static const std::vector<uint8_t> eventData = {0x8, resetType, 0};
++    uint16_t genId = 0x2000; // byte 1 0x20 BMC
++    sdbusplus::bus::bus bus{ipmid_get_sd_bus_connection()};
++    sdbusplus::message::message writeSEL = bus.new_method_call(
++        ipmiSELObject, ipmiSELPath, ipmiSELAddInterface, "IpmiSelAdd");
++    writeSEL.append(ipmiSELAddMessage, oemHealthSensor, eventData, true, genId);
++    try
++    {
++        bus.call(writeSEL);
++    }
++    catch (sdbusplus::exception_t& e)
++    {
++        phosphor::logging::log<phosphor::logging::level::ERR>(e.what());
++        return ipmi::responseUnspecifiedError();
++    }
++    return ipmi::responseSuccess();
++}
+ 
+ void resetBMC()
+ {
++    resetSEL(COLD_RESET);
+     sdbusplus::bus::bus bus{ipmid_get_sd_bus_connection()};
+ 
+     auto bmcStateObj =
+@@ -44,17 +79,21 @@ void resetBMC()
+ 
+ void warmResetBMC()
+ {
++    resetSEL(WARM_RESET);
+     try
+     {
+         std::this_thread::sleep_for(std::chrono::milliseconds(100));
+-        //sdbusplus::bus::bus bus{ipmid_get_sd_bus_connection()};
++        // sdbusplus::bus::bus bus{ipmid_get_sd_bus_connection()};
+         auto bus = sdbusplus::bus::new_default();
+-        // Reset the failed units so we don't end up having systemd not properly restart if the command is spammed.
+-        auto reset = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH, SYSTEMD_INTERFACE, "ResetFailed");
++        // Reset the failed units so we don't end up having systemd not properly
++        // restart if the command is spammed.
++        auto reset = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH,
++                                         SYSTEMD_INTERFACE, "ResetFailed");
+         bus.call_noreply(reset);
+         std::this_thread::sleep_for(std::chrono::milliseconds(100));
+         // Restart the target (restart will propagate to units).
+-        auto restart = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH, SYSTEMD_INTERFACE, "RestartUnit");
++        auto restart = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH,
++                                           SYSTEMD_INTERFACE, "RestartUnit");
+         restart.append(SYSTEMD_WARM_RESET_TARGET, "replace");
+         bus.call_noreply(restart);
+     }
+@@ -85,7 +124,6 @@ ipmi::RspType<> ipmiGlobalReset()
+     return ipmi::responseSuccess();
+ }
+ 
+-
+ /** @brief implements warm reset command
+  *  @param - None
+  *  @returns IPMI completion code.
+@@ -94,8 +132,10 @@ ipmi::RspType<> ipmiWarmReset()
+ {
+     try
+     {
+-        if (!reset_queued.test_and_set()) {
+-            // Do this asynchronously so that we can properly return this command.
++        if (!reset_queued.test_and_set())
++        {
++            // Do this asynchronously so that we can properly return this
++            // command.
+             std::thread t(warmResetBMC);
+             t.detach();
+         }
+diff --git a/include/dbus-sdr/sdrutils.hpp b/include/dbus-sdr/sdrutils.hpp
+index cfd76b3..c099419 100644
+--- a/include/dbus-sdr/sdrutils.hpp
++++ b/include/dbus-sdr/sdrutils.hpp
+@@ -311,13 +311,15 @@ enum class SensorTypeCodes : uint8_t
+     power_unit = 0x09,
+     buttons = 0x14,
+     watchdog2 = 0x23,
++    subsystem_health = 0xE0,
+ };
+ 
+ enum class SensorEventTypeCodes : uint8_t
+ {
+     unspecified = 0x00,
+     threshold = 0x01,
+-    sensorSpecified = 0x6f
++    sensorSpecified = 0x6f,
++    oem = 0x70,
+ };
+ 
+ const static boost::container::flat_map<
+@@ -342,7 +344,9 @@ const static boost::container::flat_map<
+          {"buttons", std::make_pair(SensorTypeCodes::buttons,
+                                     SensorEventTypeCodes::sensorSpecified)},
+          {"watchdog", std::make_pair(SensorTypeCodes::watchdog2,
+-                                     SensorEventTypeCodes::sensorSpecified)}}};
++                                     SensorEventTypeCodes::sensorSpecified)},
++         {"oem_health", std::make_pair(SensorTypeCodes::subsystem_health,
++                                       SensorEventTypeCodes::oem)}}};
+ 
+ std::string getSensorTypeStringFromPath(const std::string& path);
+ 

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -15,11 +15,14 @@ SRC_URI:append:evb-npcm845 = " file://0004-Add-SEL-add-command.patch"
 SRC_URI:append:evb-npcm845 = " file://0006-Correct-IPMI-firmware-revision-report.patch"
 SRC_URI:append:evb-npcm845 = " file://0007-dbus-sdr-storagecommands-Add-option-to-use-Clear-met.patch"
 SRC_URI:append:evb-npcm845 = " file://0008-Add-sensor-type-command.patch"
+# warm reset command may not work, but function can sync with SCM
+SRC_URI:append:evb-npcm845 = " file://0009-implement-warm-reset-command.patch"
 SRC_URI:append:evb-npcm845 = " file://0011-Add-SEL-time-set-command.patch"
 SRC_URI:append:evb-npcm845 = " file://0012-Force-self-test-OK.patch"
 SRC_URI:append:evb-npcm845 = " file://0013-Set-is-from-system-interface-return-false.patch"
 SRC_URI:append:evb-npcm845 = " file://0014-Add-SEL-event-after-SEL-clear.patch"
 SRC_URI:append:evb-npcm845 = " file://0015-Fix-seesion-handle-duplicated.patch"
+SRC_URI:append:evb-npcm845 = " file://0016-Add-reset-SEL.patch"
 
 # Add send/get message support
 # ipmid <-> ipmb <-> i2c

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0016-Add-reset-SEL.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0016-Add-reset-SEL.patch
@@ -1,0 +1,143 @@
+diff --git a/dbus-sdr/sdrutils.cpp b/dbus-sdr/sdrutils.cpp
+index 3df0dc1..d6b469d 100644
+--- a/dbus-sdr/sdrutils.cpp
++++ b/dbus-sdr/sdrutils.cpp
+@@ -261,6 +261,10 @@ uint16_t getSensorNumberFromPath(const std::string& path)
+     {
+         return invalidSensorNumber;
+     }
++    if (path.find("oem_health") != std::string::npos)
++    {
++        return 0x00FF;
++    }
+ 
+     try
+     {
+diff --git a/globalhandler.cpp b/globalhandler.cpp
+index 394274f..028a7d3 100644
+--- a/globalhandler.cpp
++++ b/globalhandler.cpp
+@@ -27,9 +27,44 @@ constexpr auto SYSTEMD_SERVICE = "org.freedesktop.systemd1";
+ constexpr auto SYSTEMD_OBJ_PATH = "/org/freedesktop/systemd1";
+ constexpr auto SYSTEMD_INTERFACE = "org.freedesktop.systemd1.Manager";
+ constexpr auto SYSTEMD_WARM_RESET_TARGET = "phosphor-ipmi-warm-reset.target";
++static constexpr char const* ipmiSELObject = "xyz.openbmc_project.Logging.IPMI";
++static constexpr char const* ipmiSELPath = "/xyz/openbmc_project/Logging/IPMI";
++static constexpr char const* ipmiSELAddInterface =
++    "xyz.openbmc_project.Logging.IPMI";
++static constexpr char const* oemHealthSensor =
++    "/xyz/openbmc_project/sensors/oem_health/bmc_reset";
++
++enum reset_type
++{
++    COLD_RESET = 0x1,
++    WARM_RESET = 0x2,
++};
++
++ipmi::RspType<> resetSEL(uint8_t resetType)
++{
++    // MS spec 18.2.5 BMC health status, BMC reset SEL
++    static const std::string ipmiSELAddMessage = "BMC reset SEL";
++    static const std::vector<uint8_t> eventData = {0x8, resetType, 0};
++    uint16_t genId = 0x2000; // byte 1 0x20 BMC
++    sdbusplus::bus::bus bus{ipmid_get_sd_bus_connection()};
++    sdbusplus::message::message writeSEL = bus.new_method_call(
++        ipmiSELObject, ipmiSELPath, ipmiSELAddInterface, "IpmiSelAdd");
++    writeSEL.append(ipmiSELAddMessage, oemHealthSensor, eventData, true, genId);
++    try
++    {
++        bus.call(writeSEL);
++    }
++    catch (sdbusplus::exception_t& e)
++    {
++        phosphor::logging::log<phosphor::logging::level::ERR>(e.what());
++        return ipmi::responseUnspecifiedError();
++    }
++    return ipmi::responseSuccess();
++}
+ 
+ void resetBMC()
+ {
++    resetSEL(COLD_RESET);
+     sdbusplus::bus::bus bus{ipmid_get_sd_bus_connection()};
+ 
+     auto bmcStateObj =
+@@ -44,17 +79,21 @@ void resetBMC()
+ 
+ void warmResetBMC()
+ {
++    resetSEL(WARM_RESET);
+     try
+     {
+         std::this_thread::sleep_for(std::chrono::milliseconds(100));
+-        //sdbusplus::bus::bus bus{ipmid_get_sd_bus_connection()};
++        // sdbusplus::bus::bus bus{ipmid_get_sd_bus_connection()};
+         auto bus = sdbusplus::bus::new_default();
+-        // Reset the failed units so we don't end up having systemd not properly restart if the command is spammed.
+-        auto reset = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH, SYSTEMD_INTERFACE, "ResetFailed");
++        // Reset the failed units so we don't end up having systemd not properly
++        // restart if the command is spammed.
++        auto reset = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH,
++                                         SYSTEMD_INTERFACE, "ResetFailed");
+         bus.call_noreply(reset);
+         std::this_thread::sleep_for(std::chrono::milliseconds(100));
+         // Restart the target (restart will propagate to units).
+-        auto restart = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH, SYSTEMD_INTERFACE, "RestartUnit");
++        auto restart = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_OBJ_PATH,
++                                           SYSTEMD_INTERFACE, "RestartUnit");
+         restart.append(SYSTEMD_WARM_RESET_TARGET, "replace");
+         bus.call_noreply(restart);
+     }
+@@ -85,7 +124,6 @@ ipmi::RspType<> ipmiGlobalReset()
+     return ipmi::responseSuccess();
+ }
+ 
+-
+ /** @brief implements warm reset command
+  *  @param - None
+  *  @returns IPMI completion code.
+@@ -94,8 +132,10 @@ ipmi::RspType<> ipmiWarmReset()
+ {
+     try
+     {
+-        if (!reset_queued.test_and_set()) {
+-            // Do this asynchronously so that we can properly return this command.
++        if (!reset_queued.test_and_set())
++        {
++            // Do this asynchronously so that we can properly return this
++            // command.
+             std::thread t(warmResetBMC);
+             t.detach();
+         }
+diff --git a/include/dbus-sdr/sdrutils.hpp b/include/dbus-sdr/sdrutils.hpp
+index cfd76b3..c099419 100644
+--- a/include/dbus-sdr/sdrutils.hpp
++++ b/include/dbus-sdr/sdrutils.hpp
+@@ -311,13 +311,15 @@ enum class SensorTypeCodes : uint8_t
+     power_unit = 0x09,
+     buttons = 0x14,
+     watchdog2 = 0x23,
++    subsystem_health = 0xE0,
+ };
+ 
+ enum class SensorEventTypeCodes : uint8_t
+ {
+     unspecified = 0x00,
+     threshold = 0x01,
+-    sensorSpecified = 0x6f
++    sensorSpecified = 0x6f,
++    oem = 0x70,
+ };
+ 
+ const static boost::container::flat_map<
+@@ -342,7 +344,9 @@ const static boost::container::flat_map<
+          {"buttons", std::make_pair(SensorTypeCodes::buttons,
+                                     SensorEventTypeCodes::sensorSpecified)},
+          {"watchdog", std::make_pair(SensorTypeCodes::watchdog2,
+-                                     SensorEventTypeCodes::sensorSpecified)}}};
++                                     SensorEventTypeCodes::sensorSpecified)},
++         {"oem_health", std::make_pair(SensorTypeCodes::subsystem_health,
++                                       SensorEventTypeCodes::oem)}}};
+ 
+ std::string getSensorTypeStringFromPath(const std::string& path);
+ 

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -22,6 +22,7 @@ SRC_URI:append:scm-npcm845 = " file://0012-Force-self-test-OK.patch"
 SRC_URI:append:scm-npcm845 = " file://0013-Set-is-from-system-interface-return-false.patch"
 SRC_URI:append:scm-npcm845 = " file://0014-Add-SEL-event-after-SEL-clear.patch"
 SRC_URI:append:scm-npcm845 = " file://0015-Fix-seesion-handle-duplicated.patch"
+SRC_URI:append:scm-npcm845 = " file://0016-Add-reset-SEL.patch"
 
 # Add send/get message support
 # ipmid <-> ipmb <-> i2c


### PR DESCRIPTION
For customer request, add SEL after execute ipmi reset command.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
