### PR TITLE
meta-nuvoton: linux-nuvoton: srcrev bump 8a819af..e705947

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_git.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_git.bb
@@ -5,7 +5,7 @@
 
 KBRANCH ?= "NPCM-5.10-OpenBMC"
 LINUX_VERSION ?= "5.10.67"
-SRCREV = "8a819afdee7d0c33cb8648b70b1f0ba252179795"
+SRCREV = "e70594746e6f1048537f4188a23c05aa9b0c3685"
 
 require linux-nuvoton.inc
 


### PR DESCRIPTION
Joseph Liu (1):
      driver: gpio: npcm-sgpio: inactive sgpio before disabling irq

Marvin Lin (1):
      dts: Remove legacy VCD/ECE entries

Stanley Chu (1):
      i3c: master: svc: drop debug log

Tomer Maimon (1):
      udc: npcm: Fix UDC8 setting

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
