### PR TITLE
meta-scm-npcm845: Add ipmi session command get mac

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0018-Add-session-RemoteMACAddress-support.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0018-Add-session-RemoteMACAddress-support.patch
@@ -1,0 +1,60 @@
+diff --git a/apphandler.cpp b/apphandler.cpp
+index 45c73fb..a39121c 100644
+--- a/apphandler.cpp
++++ b/apphandler.cpp
+@@ -695,7 +695,7 @@ auto ipmiAppGetSelfTestResults() -> ipmi::RspType<uint8_t, uint8_t>
+     //      [2] 1b = Internal Use Area of BMC FRU corrupted.
+     //      [1] 1b = controller update 'boot block' firmware corrupted.
+     //      [0] 1b = controller operational firmware corrupted.
+-    //constexpr uint8_t notImplemented = 0x56;
++    // constexpr uint8_t notImplemented = 0x56;
+     constexpr uint8_t zero = 0;
+     return ipmi::responseSuccess(0x55, zero);
+ }
+@@ -1064,7 +1064,6 @@ uint8_t getSessionState(ipmi::Context::ptr ctx, const std::string& service,
+     return ipmi::ccSuccess;
+ }
+ 
+-static constexpr uint8_t macAddrLen = 6;
+ /** Alias SessionDetails - contain the optional information about an
+  *        RMCP+ session.
+  *
+@@ -1080,7 +1079,7 @@ static constexpr uint8_t macAddrLen = 6;
+  */
+ using SessionDetails =
+     std::tuple<uint2_t, uint6_t, uint4_t, uint4_t, uint4_t, uint4_t, uint32_t,
+-               std::array<uint8_t, macAddrLen>, uint16_t>;
++               std::vector<uint8_t>, uint16_t>;
+ 
+ /** @brief get session details for a given session
+  *
+@@ -1129,7 +1128,10 @@ ipmi::Cc getSessionDetails(ipmi::Context::ptr ctx, const std::string& service,
+         std::get<5>(details) = rmcpPlusProtocol;
+         std::get<6>(details) =
+             ipmi::mappedVariant<uint32_t>(sessionProps, "RemoteIPAddr", 0);
+-        // std::get<7>(details) = {{0}}; // default constructed to all 0
++        std::get<7>(details) =
++            ipmi::mappedVariant<std::vector<uint8_t>>(
++                sessionProps, "RemoteMACAddress",
++                std::vector<uint8_t>(6, 0));
+         std::get<8>(details) =
+             ipmi::mappedVariant<uint16_t>(sessionProps, "RemotePort", 0);
+     }
+diff --git a/include/ipmid/types.hpp b/include/ipmid/types.hpp
+index 9c59ea0..aae0ed4 100644
+--- a/include/ipmid/types.hpp
++++ b/include/ipmid/types.hpp
+@@ -19,9 +19,10 @@ using DbusProperty = std::string;
+ 
+ using Association = std::tuple<std::string, std::string, std::string>;
+ 
+-using Value = std::variant<bool, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
+-                           int64_t, uint64_t, double, std::string,
+-                           std::vector<std::string>, std::vector<Association>>;
++using Value =
++    std::variant<bool, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
++                 uint64_t, double, std::string, std::vector<uint8_t>,
++                 std::vector<std::string>, std::vector<Association>>;
+ 
+ using PropertyMap = std::map<DbusProperty, Value>;
+ 

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -23,6 +23,7 @@ SRC_URI:append:evb-npcm845 = " file://0013-Set-is-from-system-interface-return-f
 SRC_URI:append:evb-npcm845 = " file://0014-Add-SEL-event-after-SEL-clear.patch"
 SRC_URI:append:evb-npcm845 = " file://0015-Fix-seesion-handle-duplicated.patch"
 SRC_URI:append:evb-npcm845 = " file://0016-Add-reset-SEL.patch"
+SRC_URI:append:evb-npcm845 = " file://0018-Add-session-RemoteMACAddress-support.patch"
 
 # Add send/get message support
 # ipmid <-> ipmb <-> i2c

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-net/0001-Add-RemoteIPAddr-support.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-net/0001-Add-RemoteIPAddr-support.patch
@@ -1,0 +1,106 @@
+diff --git a/message_handler.cpp b/message_handler.cpp
+index 33bb195..d032227 100644
+--- a/message_handler.cpp
++++ b/message_handler.cpp
+@@ -50,8 +50,9 @@ void Handler::updSessionData(std::shared_ptr<Message>& inMessage)
+     session->channelPtr = channel;
+     session->remotePort(channel->getPort());
+     uint32_t ipAddr = 0;
+-    channel->getRemoteAddress(ipAddr);
++    std::string _ip = channel->getRemoteAddress(ipAddr);
+     session->remoteIPAddr(ipAddr);
++    session->remoteMACAddress(channel->getRemoteMac(_ip));
+ }
+ 
+ Handler::~Handler()
+diff --git a/socket_channel.hpp b/socket_channel.hpp
+index b993f0e..c9cdb14 100644
+--- a/socket_channel.hpp
++++ b/socket_channel.hpp
+@@ -4,6 +4,7 @@
+ #include <sys/types.h>
+ 
+ #include <boost/asio/ip/udp.hpp>
++#include <fstream>
+ #include <memory>
+ #include <optional>
+ #include <phosphor-logging/log.hpp>
+@@ -105,6 +106,78 @@ class Channel
+         return std::string();
+     }
+ 
++    std::vector<uint8_t> getRemoteMac(std::string remoteIpv4Addr)
++    {
++        using namespace phosphor::logging;
++        std::vector<uint8_t> ret(6, 0);
++        constexpr auto ARP_FILE = "/proc/net/arp";
++        std::ifstream istrm(ARP_FILE, std::ifstream::in);
++        std::string line, msg, mac;
++        std::string::size_type pos, mac_start;
++        bool found = false;
++        // remoteIpv4Addr will be like ::ffff:192.168.56.105
++        pos = remoteIpv4Addr.rfind(":");
++        if (pos != std::string::npos)
++        {
++            pos += 1;
++            remoteIpv4Addr =
++                remoteIpv4Addr.substr(pos, remoteIpv4Addr.size() - pos);
++        }
++        msg = "new remote ip address: " + remoteIpv4Addr;
++        log<level::INFO>(msg.c_str());
++        // ignore header
++        std::getline(istrm, line);
++        // lookup arp table
++        while (std::getline(istrm, line))
++        {
++            pos = line.find(" ");
++            if (pos != std::string::npos)
++            {
++                std::string ip = line.substr(0, pos);
++                if (ip == remoteIpv4Addr)
++                {
++                    found = true;
++                    break;
++                }
++            }
++        }
++        if (!found)
++        {
++            msg = "Cannot find IP in arp table, " + remoteIpv4Addr;
++            log<level::INFO>(msg.c_str());
++            return ret;
++        }
++
++        // parse mac string
++        try
++        {
++            pos = line.find(":", pos);
++            pos = line.find(" ", pos);
++            mac_start = line.rfind(" ", pos - 1) + 1;
++            mac = line.substr(mac_start, pos - mac_start);
++            msg = "get remote mac: " + mac;
++            log<level::INFO>(msg.c_str());
++            ret.clear();
++            for (size_t i = 0; i < mac.size(); i += 3)
++            {
++                ret.push_back(static_cast<uint8_t>(
++                    std::stoul(mac.substr(i, 2), nullptr, 16)));
++            }
++        }
++        catch (const std::exception& e)
++        {
++            msg = "unkown error while find mac";
++            log<level::ERR>(msg.c_str(), entry("LINE=%s", line.c_str()),
++                            entry("ERROR=%s", e.what()));
++        }
++        // should be equals 6, but only handle smaller case for debug
++        if (ret.size() < 6)
++        {
++            ret.resize(6, 0);
++        }
++        return ret;
++    }
++
+     /**
+      * @brief Fetch the port number of the remote peer
+      *

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-net_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-net_%.bbappend
@@ -1,1 +1,3 @@
+FILESEXTRAPATHS:append:evb-npcm845 := "${THISDIR}/${PN}:"
 RMCPP_IFACE = "eth0"
+SRC_URI:append:evb-npcm845 = " file://0001-Add-RemoteIPAddr-support.patch"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0018-Add-session-RemoteMACAddress-support.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0018-Add-session-RemoteMACAddress-support.patch
@@ -1,0 +1,60 @@
+diff --git a/apphandler.cpp b/apphandler.cpp
+index 45c73fb..a39121c 100644
+--- a/apphandler.cpp
++++ b/apphandler.cpp
+@@ -695,7 +695,7 @@ auto ipmiAppGetSelfTestResults() -> ipmi::RspType<uint8_t, uint8_t>
+     //      [2] 1b = Internal Use Area of BMC FRU corrupted.
+     //      [1] 1b = controller update 'boot block' firmware corrupted.
+     //      [0] 1b = controller operational firmware corrupted.
+-    //constexpr uint8_t notImplemented = 0x56;
++    // constexpr uint8_t notImplemented = 0x56;
+     constexpr uint8_t zero = 0;
+     return ipmi::responseSuccess(0x55, zero);
+ }
+@@ -1064,7 +1064,6 @@ uint8_t getSessionState(ipmi::Context::ptr ctx, const std::string& service,
+     return ipmi::ccSuccess;
+ }
+ 
+-static constexpr uint8_t macAddrLen = 6;
+ /** Alias SessionDetails - contain the optional information about an
+  *        RMCP+ session.
+  *
+@@ -1080,7 +1079,7 @@ static constexpr uint8_t macAddrLen = 6;
+  */
+ using SessionDetails =
+     std::tuple<uint2_t, uint6_t, uint4_t, uint4_t, uint4_t, uint4_t, uint32_t,
+-               std::array<uint8_t, macAddrLen>, uint16_t>;
++               std::vector<uint8_t>, uint16_t>;
+ 
+ /** @brief get session details for a given session
+  *
+@@ -1129,7 +1128,10 @@ ipmi::Cc getSessionDetails(ipmi::Context::ptr ctx, const std::string& service,
+         std::get<5>(details) = rmcpPlusProtocol;
+         std::get<6>(details) =
+             ipmi::mappedVariant<uint32_t>(sessionProps, "RemoteIPAddr", 0);
+-        // std::get<7>(details) = {{0}}; // default constructed to all 0
++        std::get<7>(details) =
++            ipmi::mappedVariant<std::vector<uint8_t>>(
++                sessionProps, "RemoteMACAddress",
++                std::vector<uint8_t>(6, 0));
+         std::get<8>(details) =
+             ipmi::mappedVariant<uint16_t>(sessionProps, "RemotePort", 0);
+     }
+diff --git a/include/ipmid/types.hpp b/include/ipmid/types.hpp
+index 9c59ea0..aae0ed4 100644
+--- a/include/ipmid/types.hpp
++++ b/include/ipmid/types.hpp
+@@ -19,9 +19,10 @@ using DbusProperty = std::string;
+ 
+ using Association = std::tuple<std::string, std::string, std::string>;
+ 
+-using Value = std::variant<bool, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
+-                           int64_t, uint64_t, double, std::string,
+-                           std::vector<std::string>, std::vector<Association>>;
++using Value =
++    std::variant<bool, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
++                 uint64_t, double, std::string, std::vector<uint8_t>,
++                 std::vector<std::string>, std::vector<Association>>;
+ 
+ using PropertyMap = std::map<DbusProperty, Value>;
+ 

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -24,6 +24,7 @@ SRC_URI:append:scm-npcm845 = " file://0014-Add-SEL-event-after-SEL-clear.patch"
 SRC_URI:append:scm-npcm845 = " file://0015-Fix-seesion-handle-duplicated.patch"
 SRC_URI:append:scm-npcm845 = " file://0016-Add-reset-SEL.patch"
 SRC_URI:append:scm-npcm845 = " file://0017-dbus-sdr-do-not-replace-_-for-sensor-name.patch"
+SRC_URI:append:scm-npcm845 = " file://0018-Add-session-RemoteMACAddress-support.patch"
 
 # Add send/get message support
 # ipmid <-> ipmb <-> i2c

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-net/0001-Add-RemoteIPAddr-support.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-net/0001-Add-RemoteIPAddr-support.patch
@@ -1,0 +1,106 @@
+diff --git a/message_handler.cpp b/message_handler.cpp
+index 33bb195..d032227 100644
+--- a/message_handler.cpp
++++ b/message_handler.cpp
+@@ -50,8 +50,9 @@ void Handler::updSessionData(std::shared_ptr<Message>& inMessage)
+     session->channelPtr = channel;
+     session->remotePort(channel->getPort());
+     uint32_t ipAddr = 0;
+-    channel->getRemoteAddress(ipAddr);
++    std::string _ip = channel->getRemoteAddress(ipAddr);
+     session->remoteIPAddr(ipAddr);
++    session->remoteMACAddress(channel->getRemoteMac(_ip));
+ }
+ 
+ Handler::~Handler()
+diff --git a/socket_channel.hpp b/socket_channel.hpp
+index b993f0e..c9cdb14 100644
+--- a/socket_channel.hpp
++++ b/socket_channel.hpp
+@@ -4,6 +4,7 @@
+ #include <sys/types.h>
+ 
+ #include <boost/asio/ip/udp.hpp>
++#include <fstream>
+ #include <memory>
+ #include <optional>
+ #include <phosphor-logging/log.hpp>
+@@ -105,6 +106,78 @@ class Channel
+         return std::string();
+     }
+ 
++    std::vector<uint8_t> getRemoteMac(std::string remoteIpv4Addr)
++    {
++        using namespace phosphor::logging;
++        std::vector<uint8_t> ret(6, 0);
++        constexpr auto ARP_FILE = "/proc/net/arp";
++        std::ifstream istrm(ARP_FILE, std::ifstream::in);
++        std::string line, msg, mac;
++        std::string::size_type pos, mac_start;
++        bool found = false;
++        // remoteIpv4Addr will be like ::ffff:192.168.56.105
++        pos = remoteIpv4Addr.rfind(":");
++        if (pos != std::string::npos)
++        {
++            pos += 1;
++            remoteIpv4Addr =
++                remoteIpv4Addr.substr(pos, remoteIpv4Addr.size() - pos);
++        }
++        msg = "new remote ip address: " + remoteIpv4Addr;
++        log<level::INFO>(msg.c_str());
++        // ignore header
++        std::getline(istrm, line);
++        // lookup arp table
++        while (std::getline(istrm, line))
++        {
++            pos = line.find(" ");
++            if (pos != std::string::npos)
++            {
++                std::string ip = line.substr(0, pos);
++                if (ip == remoteIpv4Addr)
++                {
++                    found = true;
++                    break;
++                }
++            }
++        }
++        if (!found)
++        {
++            msg = "Cannot find IP in arp table, " + remoteIpv4Addr;
++            log<level::INFO>(msg.c_str());
++            return ret;
++        }
++
++        // parse mac string
++        try
++        {
++            pos = line.find(":", pos);
++            pos = line.find(" ", pos);
++            mac_start = line.rfind(" ", pos - 1) + 1;
++            mac = line.substr(mac_start, pos - mac_start);
++            msg = "get remote mac: " + mac;
++            log<level::INFO>(msg.c_str());
++            ret.clear();
++            for (size_t i = 0; i < mac.size(); i += 3)
++            {
++                ret.push_back(static_cast<uint8_t>(
++                    std::stoul(mac.substr(i, 2), nullptr, 16)));
++            }
++        }
++        catch (const std::exception& e)
++        {
++            msg = "unkown error while find mac";
++            log<level::ERR>(msg.c_str(), entry("LINE=%s", line.c_str()),
++                            entry("ERROR=%s", e.what()));
++        }
++        // should be equals 6, but only handle smaller case for debug
++        if (ret.size() < 6)
++        {
++            ret.resize(6, 0);
++        }
++        return ret;
++    }
++
+     /**
+      * @brief Fetch the port number of the remote peer
+      *

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-net_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-net_%.bbappend
@@ -1,4 +1,5 @@
 FILESEXTRAPATHS:append:scm-npcm845 := "${THISDIR}/${PN}:"
 SRC_URI:append:scm-npcm845 = " file://0001-Revert-Remove-HMAC-SHA1-from-Authentication-Integrit.patch"
+SRC_URI:append:scm-npcm845 = " file://0001-Add-RemoteIPAddr-support.patch"
 
 RMCPP_IFACE = "eth0"


### PR DESCRIPTION
Add support ipmi session command get remote MAC address feature, here we
simply search ARP table by read /proc/net/arp.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
