### PR TITLE
meta-evb: meta-evb-nuvoton: meta-buv-runbmc: fix buv-entity build error

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/packagegroups/packagegroup-buv-runbmc-apps.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/packagegroups/packagegroup-buv-runbmc-apps.bb
@@ -50,9 +50,9 @@ RDEPENDS:${PN}-system = " \
     "
 
 SUMMARY:${PN}-entity = "BUV RunBMC entity"
-RDEPENDS:${PN}-entity = " \
-    intel-ipmi-oem \
-    "
+#RDEPENDS:${PN}-entity = " \
+#    intel-ipmi-oem \
+#    "
 
 SUMMARY:${PN}-dev = "BUV RunBMC development tools"
 RDEPENDS:${PN}-dev = " \


### PR DESCRIPTION
Test done:

No build error (DISTRO=buv-entity bitbake obmc-phosphor-image)
Boot OK.
systemctl status xyz.openbmc_project.EntityManager.service work OK.
ipmitool sdr