### PR TITLE
meta-scm-npcm845: Add BMC health SPI boot SEL

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-evb-npcm845/boot-health/boot-health.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-evb-npcm845/boot-health/boot-health.bb
@@ -1,0 +1,15 @@
+PR = "r1"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit obmc-phosphor-systemd
+DEPENDS = "systemd"
+
+SRC_URI = "file://scm-boot-health.service"
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "scm-boot-health.service"
+
+do_install() {
+    install -D -m 0644 ${WORKDIR}/scm-boot-health.service \
+        ${D}${systemd_unitdir}/system/scm-boot-health.service
+}

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-evb-npcm845/boot-health/files/scm-boot-health.service
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-evb-npcm845/boot-health/files/scm-boot-health.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=BMC health SPI boot SEL add service
+Requires=xyz.openbmc_project.Logging.IPMI.service
+Wants=mapper-wait@-xyz-openbmc_project-Logging-IPMI.service
+After=xyz.openbmc_project.Logging.IPMI.service
+After=mapper-wait@-xyz-openbmc_project-Logging-IPMI.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Restart=no
+ExecStart=/bin/sh -c "busctl call `mapper get-service /xyz/openbmc_project/Logging/IPMI` /xyz/openbmc_project/Logging/IPMI xyz.openbmc_project.Logging.IPMI IpmiSelAdd ssaybq 'OEM BMC health SPI boot' '/xyz/openbmc_project/sensors/oem_health/spi_boot' 3 168 1 0 true 0x2000"
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-evb-npcm845/packagegroups/packagegroup-evb-npcm845-apps.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-evb-npcm845/packagegroups/packagegroup-evb-npcm845-apps.bb
@@ -68,4 +68,6 @@ RDEPENDS:${PN}-system = " \
         program-vbios \
         optee-client \
         optee-test \
+        net-tools \
+        boot-health \
         "

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0016-Add-reset-SEL.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0016-Add-reset-SEL.patch
@@ -8,7 +8,7 @@ index 3df0dc1..d6b469d 100644
      }
 +    if (path.find("oem_health") != std::string::npos)
 +    {
-+        return 0x00FF;
++        return 0x00EF;
 +    }
  
      try

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0021-sensor-reading-optional-zero.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0021-sensor-reading-optional-zero.patch
@@ -1,0 +1,13 @@
+diff --git a/dbus-sdr/sensorcommands.cpp b/dbus-sdr/sensorcommands.cpp
+index 9075966..c10d4d5 100644
+--- a/dbus-sdr/sensorcommands.cpp
++++ b/dbus-sdr/sensorcommands.cpp
+@@ -838,7 +838,7 @@ ipmi::RspType<uint8_t, uint8_t, uint8_t, std::optional<uint8_t>>
+     }
+ 
+     // no discrete as of today so optional byte is never returned
+-    return ipmi::responseSuccess(value, operation, thresholds, std::nullopt);
++    return ipmi::responseSuccess(value, operation, thresholds, (uint8_t)0);
+ }
+ 
+ /** @brief implements the Set Sensor threshold command

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -25,6 +25,7 @@ SRC_URI:append:evb-npcm845 = " file://0015-Fix-seesion-handle-duplicated.patch"
 SRC_URI:append:evb-npcm845 = " file://0016-Add-reset-SEL.patch"
 SRC_URI:append:evb-npcm845 = " file://0018-Add-session-RemoteMACAddress-support.patch"
 SRC_URI:append:evb-npcm845 = " file://0020-fix-percentage-type-show.patch"
+SRC_URI:append:evb-npcm845 = " file://0021-sensor-reading-optional-zero.patch"
 
 # Add send/get message support
 # ipmid <-> ipmb <-> i2c

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0016-Add-reset-SEL.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0016-Add-reset-SEL.patch
@@ -8,7 +8,7 @@ index 3df0dc1..d6b469d 100644
      }
 +    if (path.find("oem_health") != std::string::npos)
 +    {
-+        return 0x00FF;
++        return 0x00EF;
 +    }
  
      try

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0021-sensor-reading-optional-zero.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0021-sensor-reading-optional-zero.patch
@@ -1,0 +1,13 @@
+diff --git a/dbus-sdr/sensorcommands.cpp b/dbus-sdr/sensorcommands.cpp
+index 9075966..c10d4d5 100644
+--- a/dbus-sdr/sensorcommands.cpp
++++ b/dbus-sdr/sensorcommands.cpp
+@@ -838,7 +838,7 @@ ipmi::RspType<uint8_t, uint8_t, uint8_t, std::optional<uint8_t>>
+     }
+ 
+     // no discrete as of today so optional byte is never returned
+-    return ipmi::responseSuccess(value, operation, thresholds, std::nullopt);
++    return ipmi::responseSuccess(value, operation, thresholds, (uint8_t)0);
+ }
+ 
+ /** @brief implements the Set Sensor threshold command

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -27,6 +27,7 @@ SRC_URI:append:scm-npcm845 = " file://0017-dbus-sdr-do-not-replace-_-for-sensor-
 SRC_URI:append:scm-npcm845 = " file://0018-Add-session-RemoteMACAddress-support.patch"
 SRC_URI:append:scm-npcm845 = " file://0019-add-server-type-and-oem-id-to-meet-MS-spec.patch"
 SRC_URI:append:scm-npcm845 = " file://0020-fix-percentage-type-show.patch"
+SRC_URI:append:scm-npcm845 = " file://0021-sensor-reading-optional-zero.patch"
 
 # Add send/get message support
 # ipmid <-> ipmb <-> i2c

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-scm-npcm845/boot-health/boot-health.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-scm-npcm845/boot-health/boot-health.bb
@@ -1,0 +1,15 @@
+PR = "r1"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit obmc-phosphor-systemd
+DEPENDS = "systemd"
+
+SRC_URI = "file://scm-boot-health.service"
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "scm-boot-health.service"
+
+do_install() {
+    install -D -m 0644 ${WORKDIR}/scm-boot-health.service \
+        ${D}${systemd_unitdir}/system/scm-boot-health.service
+}

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-scm-npcm845/boot-health/files/scm-boot-health.service
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-scm-npcm845/boot-health/files/scm-boot-health.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=BMC health SPI boot SEL add service
+Requires=xyz.openbmc_project.Logging.IPMI.service
+Wants=mapper-wait@-xyz-openbmc_project-Logging-IPMI.service
+After=xyz.openbmc_project.Logging.IPMI.service
+After=mapper-wait@-xyz-openbmc_project-Logging-IPMI.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Restart=no
+ExecStart=/bin/sh -c "busctl call `mapper get-service /xyz/openbmc_project/Logging/IPMI` /xyz/openbmc_project/Logging/IPMI xyz.openbmc_project.Logging.IPMI IpmiSelAdd ssaybq 'OEM BMC health SPI boot' '/xyz/openbmc_project/sensors/oem_health/spi_boot' 3 168 1 0 true 0x2000"
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-scm-npcm845/packagegroups/packagegroup-scm-npcm845-apps.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-scm-npcm845/packagegroups/packagegroup-scm-npcm845-apps.bb
@@ -73,4 +73,5 @@ RDEPENDS:${PN}-system = " \
         dhcp-check \
         phosphor-virtual-sensor \
         esmi-oob-tool \
+        boot-health \
         "


### PR DESCRIPTION
Add BMC health SPI boot SEL to match OEM spec.
Move oem_health sensor number from 0xFF to 0xEF.
And let get senor reading always return optional byte for test criteria.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
