### PR TITLE
meta-evb-nuvoton: meta-buv-runbmc: fix build error after upgrading Op…

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -2,17 +2,17 @@ inherit buv-entity-utils
 
 FILESEXTRAPATHS:append:buv-runbmc := "${THISDIR}/${PN}:"
 SRC_URI:append:buv-runbmc = " file://0001-Add-set-BIOS-version-support.patch"
-SRC_URI:append:buv-runbmc = " file://0003-Add-option-for-SEL-commands-for-Journal-based-SEL-en.patch"
+#SRC_URI:append:buv-runbmc = " file://0003-Add-option-for-SEL-commands-for-Journal-based-SEL-en.patch"
 SRC_URI:append:buv-runbmc = " file://0001-Fix-firmware-version-missing-at-dev-tag.patch"
 
 
 DEPENDS:append:buv-runbmc= " \
     ${@entity_enabled(d, '', ' buv-runbmc-yaml-config')}"
 
-EXTRA_OECONF:buv-runbmc = " \
-    ${@entity_enabled(d, '', ' SENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/buv-runbmc-yaml-config/ipmi-sensors.yaml')} \
-    ${@entity_enabled(d, '', ' FRU_YAML_GEN=${STAGING_DIR_HOST}${datadir}/buv-runbmc-yaml-config/ipmi-fru-read.yaml')} \
-    ${@entity_enabled(d, '', ' INVSENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/buv-runbmc-yaml-config/ipmi-inventory-sensors.yaml')} \
+EXTRA_OEMESON:append:buv-runbmc = " \
+    -Dsensor-yaml-gen=${@entity_enabled(d, '', '${STAGING_DIR_HOST}${datadir}/buv-runbmc-yaml-config/ipmi-sensors.yaml')} \
+    -Dfru-yaml-gen=${@entity_enabled(d, '', '${STAGING_DIR_HOST}${datadir}/buv-runbmc-yaml-config/ipmi-fru-read.yaml')} \
+    -Dinvsensor-yaml-gen=${@entity_enabled(d, '', '${STAGING_DIR_HOST}${datadir}/buv-runbmc-yaml-config/ipmi-inventory-sensors.yaml')} \
     "
 PACKAGECONFIG:append:buv-entity = " dynamic-sensors"
 


### PR DESCRIPTION
…enBmc

Disable patch: 0003-Add-option-for-SEL-commands-for-Journal-based-SEL-en.patch
The content of sensor-gen.cpp is generated by sensor yaml file.

Test Done:
Build OK.
Boot OK.
ipmitool sdr test OK.

Signed-off-by: jhkang <jhkang@nuvoton.com>
