### PR TITLE
meta-scm-npcm845: fix led-manager startup errors

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/leds/phosphor-led-manager/service-override.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/leds/phosphor-led-manager/service-override.conf
@@ -3,8 +3,8 @@ StartLimitBurst=10
 
 [Service]
 RestartSec=3s
-ExecStartPre=mapper get-service /xyz/openbmc_project/led/physical/blade_attention
-ExecStartPre=mapper get-service /xyz/openbmc_project/led/physical/caterr
-ExecStartPre=mapper get-service /xyz/openbmc_project/led/physical/power_amber
-ExecStartPre=mapper get-service /xyz/openbmc_project/led/physical/power_green
-ExecStartPre=mapper get-service /xyz/openbmc_project/led/physical/identify
+ExecStartPre=mapper wait /xyz/openbmc_project/led/physical/blade_attention
+ExecStartPre=mapper wait /xyz/openbmc_project/led/physical/caterr
+ExecStartPre=mapper wait /xyz/openbmc_project/led/physical/power_amber
+ExecStartPre=mapper wait /xyz/openbmc_project/led/physical/power_green
+ExecStartPre=mapper wait /xyz/openbmc_project/led/physical/identify


### PR DESCRIPTION
Use mapper wait to wait required object path create.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
