### PR TITLE
meta-scm-npcm845: increase adc sensor max reading

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0008-increase-adc-max-reading.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0008-increase-adc-max-reading.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ADCSensor.cpp b/src/ADCSensor.cpp
+index 9758168c..14db3a8d 100644
+--- a/src/ADCSensor.cpp
++++ b/src/ADCSensor.cpp
+@@ -37,7 +37,7 @@
+ static constexpr unsigned int sensorScaleFactor = 1000;
+ 
+ static constexpr double roundFactor = 10000;     // 3 decimal places
+-static constexpr double maxVoltageReading = 1.8; // pre sensor scaling
++static constexpr double maxVoltageReading = 2.0; // pre sensor scaling
+ static constexpr double minVoltageReading = 0;
+ 
+ ADCSensor::ADCSensor(const std::string& path,

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors_%.bbappend
@@ -9,6 +9,7 @@ SRC_URI:append:scm-npcm845 = " \
     file://0005-hwmontemp-add-adm-stbsi-support.patch \
     file://0006-add-dimm-sensor.patch \
     file://0007-add-nic-temp-sensor.patch \
+    file://0008-increase-adc-max-reading.patch \
     file://xyz.openbmc_project.dimmsensor.service \
     "
 


### PR DESCRIPTION
To avoid the sensor reading and threshold error after IPMI scaling.
The current ADC max reading is const value 1.8 / [scale factor].
When we read the 1V8 power, we will set scale factor = 1, and this time
max reading will be 1.8. But in real world the power voltage may greater
than 1.8, may 1.85 or 1.9. In this case, we will recieve error reading
after IPMI scaling.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
