### PR TITLE
meta-scm-npcm845: save IPMI system boot options

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0024-update-chassishandler-from-intel-oem-ipmi.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0024-update-chassishandler-from-intel-oem-ipmi.patch
@@ -1,0 +1,499 @@
+From 8b890aceaf2cc2ae8b01cbef3d1dc107d3e0137f Mon Sep 17 00:00:00 2001
+From: Joseph Liu <kwliu@nuvoton.com>
+Date: Tue, 26 Jul 2022 12:09:14 +0800
+Subject: [PATCH] update chassishandler from intel oem ipmi
+
+Signed-off-by: Joseph Liu <kwliu@nuvoton.com>
+---
+ chassishandler.cpp | 335 ++++++++++++++++++++++++---------------------
+ 1 file changed, 179 insertions(+), 156 deletions(-)
+
+diff --git a/chassishandler.cpp b/chassishandler.cpp
+index 737d3d27..de4bafa2 100644
+--- a/chassishandler.cpp
++++ b/chassishandler.cpp
+@@ -65,6 +65,7 @@ static constexpr size_t forceIdentifyPos = 1;
+ 
+ namespace ipmi
+ {
++
+ constexpr Cc ccParmNotSupported = 0x80;
+ 
+ static inline auto responseParmNotSupported()
+@@ -108,15 +109,17 @@ const static constexpr char chassisSMDevAddrProp[] = "SMDeviceAddress";
+ const static constexpr char chassisBridgeDevAddrProp[] = "BridgeDeviceAddress";
+ static constexpr uint8_t chassisCapFlagMask = 0x0f;
+ static constexpr uint8_t chassisCapAddrMask = 0xfe;
+-static constexpr const char* powerButtonIntf =
+-    "xyz.openbmc_project.Chassis.Buttons.Power";
++
++static constexpr const char* buttonIntf = "xyz.openbmc_project.Chassis.Buttons";
++
++const static constexpr char* idButtonPath =
++    "/xyz/openbmc_project/chassis/buttons/id";
+ static constexpr const char* powerButtonPath =
+-    "/xyz/openbmc_project/Chassis/Buttons/Power0";
+-static constexpr const char* resetButtonIntf =
+-    "xyz.openbmc_project.Chassis.Buttons.Reset";
++    "/xyz/openbmc_project/chassis/buttons/power";
+ static constexpr const char* resetButtonPath =
+-    "/xyz/openbmc_project/Chassis/Buttons/Reset0";
+-
++    "/xyz/openbmc_project/chassis/buttons/reset";
++static constexpr const char* interruptButtonPath =
++    "/xyz/openbmc_project/chassis/buttons/nmi";
+ // Phosphor Host State manager
+ namespace State = sdbusplus::xyz::openbmc_project::State::server;
+ 
+@@ -1024,47 +1027,44 @@ std::optional<bool> getPowerStatus()
+  */
+ bool getACFailStatus()
+ {
+-    constexpr const char* powerControlObj =
+-        "/xyz/openbmc_project/Chassis/Control/Power0";
+-    constexpr const char* powerControlIntf =
+-        "xyz.openbmc_project.Chassis.Control.Power";
+-    bool acFail = false;
++    constexpr const char* acBootObj =
++        "/xyz/openbmc_project/control/host0/ac_boot";
++    constexpr const char* acBootIntf = "xyz.openbmc_project.Common.ACBoot";
++    std::string acFail;
+     std::shared_ptr<sdbusplus::asio::connection> bus = getSdBus();
+     try
+     {
+-        auto service =
+-            ipmi::getService(*bus, powerControlIntf, powerControlObj);
++        auto service = ipmi::getService(*bus, acBootIntf, acBootObj);
+ 
+-        ipmi::Value variant = ipmi::getDbusProperty(
+-            *bus, service, powerControlObj, powerControlIntf, "PFail");
+-        acFail = std::get<bool>(variant);
++        ipmi::Value variant = ipmi::getDbusProperty(*bus, service, acBootObj,
++                                                    acBootIntf, "ACBoot");
++        acFail = std::get<std::string>(variant);
+     }
+     catch (const std::exception& e)
+     {
+-        log<level::ERR>("Failed to fetch PFail property",
+-                        entry("ERROR=%s", e.what()),
+-                        entry("PATH=%s", powerControlObj),
+-                        entry("INTERFACE=%s", powerControlIntf));
++        log<level::ERR>(
++            "Failed to fetch ACBoot property", entry("ERROR=%s", e.what()),
++            entry("PATH=%s", acBootObj), entry("INTERFACE=%s", acBootIntf));
+     }
+-    return acFail;
++    return acFail == "True";
+ }
+ } // namespace power_policy
+ 
+-static std::optional<bool> getButtonEnabled(const std::string& buttonPath,
+-                                            const std::string& buttonIntf)
++
++static std::optional<bool> getButtonEnabled(const std::string& buttonPath)
+ {
+-    std::shared_ptr<sdbusplus::asio::connection> busp = getSdBus();
+     bool buttonDisabled = false;
++    std::shared_ptr<sdbusplus::asio::connection> busp = getSdBus();
+     try
+     {
+-        auto service = ipmi::getService(*busp, buttonIntf, buttonPath);
+-        ipmi::Value enabled = ipmi::getDbusProperty(*busp, service, buttonPath,
+-                                                    buttonIntf, "Enabled");
+-        buttonDisabled = !std::get<bool>(enabled);
++        auto service = ipmi::getService(*getSdBus(), buttonIntf, buttonPath);
++        ipmi::Value disabled = ipmi::getDbusProperty(
++            *busp, service, buttonPath, buttonIntf, "ButtonMasked");
++        buttonDisabled = std::get<bool>(disabled);
+     }
+     catch (const sdbusplus::exception::exception& e)
+     {
+-        log<level::ERR>("Fail to get button Enabled property",
++        log<level::ERR>("Fail to get button disabled property",
+                         entry("PATH=%s", buttonPath.c_str()),
+                         entry("ERROR=%s", e.what()));
+         return std::nullopt;
+@@ -1072,29 +1072,71 @@ static std::optional<bool> getButtonEnabled(const std::string& buttonPath,
+     return std::make_optional(buttonDisabled);
+ }
+ 
+-static bool setButtonEnabled(ipmi::Context::ptr& ctx,
+-                             const std::string& buttonPath,
+-                             const std::string& buttonIntf, bool enable)
++static bool setButtonEnabled(const std::string& buttonPath, const bool disabled)
+ {
++    try
++    {
++        auto service = ipmi::getService(*getSdBus(), buttonIntf, buttonPath);
++        ipmi::setDbusProperty(*getSdBus(), service, buttonPath, buttonIntf,
++                              "ButtonMasked", disabled);
++    }
++    catch (const std::exception& e)
++    {
++        log<level::ERR>("Failed to set button disabled",
++                        entry("EXCEPTION=%s, REQUEST=%x", e.what(), disabled));
++        return -1;
++    }
++
++    return 0;
++}
++
++/*
++ * getRestartCause
++ * helper function for Get Host restart cause Command
++ * return - optional value for RestartCause (no value on error)
++ */
++static bool getRestartCause(ipmi::Context::ptr& ctx, std::string& restartCause)
++{
++    constexpr const char* restartCausePath =
++        "/xyz/openbmc_project/control/host0/restart_cause";
++    constexpr const char* restartCauseIntf =
++        "xyz.openbmc_project.Control.Host.RestartCause";
++
+     std::string service;
+-    boost::system::error_code ec;
+-    ec = ipmi::getService(ctx, buttonIntf, buttonPath, service);
++    boost::system::error_code ec =
++        ipmi::getService(ctx, restartCauseIntf, restartCausePath, service);
++
+     if (!ec)
+     {
+-        ec = ipmi::setDbusProperty(ctx, service, buttonPath, buttonIntf,
+-                                   "Enabled", enable);
++        ec = ipmi::getDbusProperty(ctx, service, restartCausePath,
++                                   restartCauseIntf, "RestartCause",
++                                   restartCause);
+     }
+     if (ec)
+     {
+-        log<level::ERR>("Fail to set button Enabled property",
+-                        entry("SERVICE=%s", service.c_str()),
+-                        entry("PATH=%s", buttonPath.c_str()),
+-                        entry("ERROR=%s", ec.message().c_str()));
++        log<level::ERR>("Failed to fetch RestartCause property",
++                        entry("ERROR=%s", ec.message().c_str()),
++                        entry("PATH=%s", restartCausePath),
++                        entry("INTERFACE=%s", restartCauseIntf));
+         return false;
+     }
+     return true;
+ }
+ 
++static bool checkIPMIRestartCause(ipmi::Context::ptr& ctx,
++                                  bool& ipmiRestartCause)
++{
++    std::string restartCause;
++    if (!getRestartCause(ctx, restartCause))
++    {
++        return false;
++    }
++    ipmiRestartCause =
++        (restartCause ==
++         "xyz.openbmc_project.State.Host.RestartCause.IpmiCommand");
++    return true;
++}
++
+ //----------------------------------------------------------------------
+ // Get Chassis Status commands
+ //----------------------------------------------------------------------
+@@ -1130,9 +1172,8 @@ ipmi::RspType<bool,    // Power is on
+               bool, // Diagnostic Interrupt button disable allowed
+               bool  // Standby (sleep) button disable allowed
+               >
+-    ipmiGetChassisStatus()
++    ipmiGetChassisStatus(ipmi::Context::ptr ctx)
+ {
+-    using namespace chassis::internal;
+     std::optional<uint2_t> restorePolicy =
+         power_policy::getPowerRestorePolicy();
+     std::optional<bool> powerGood = power_policy::getPowerStatus();
+@@ -1142,8 +1183,7 @@ ipmi::RspType<bool,    // Power is on
+     }
+ 
+     //  Front Panel Button Capabilities and disable/enable status(Optional)
+-    std::optional<bool> powerButtonReading =
+-        getButtonEnabled(powerButtonPath, powerButtonIntf);
++    std::optional<bool> powerButtonReading = getButtonEnabled(powerButtonPath);
+     // allow disable if the interface is present
+     bool powerButtonDisableAllow = static_cast<bool>(powerButtonReading);
+     // default return the button is enabled (not disabled)
+@@ -1154,8 +1194,7 @@ ipmi::RspType<bool,    // Power is on
+         powerButtonDisabled = *powerButtonReading;
+     }
+ 
+-    std::optional<bool> resetButtonReading =
+-        getButtonEnabled(resetButtonPath, resetButtonIntf);
++    std::optional<bool> resetButtonReading = getButtonEnabled(resetButtonPath);
+     // allow disable if the interface is present
+     bool resetButtonDisableAllow = static_cast<bool>(resetButtonReading);
+     // default return the button is enabled (not disabled)
+@@ -1166,8 +1205,27 @@ ipmi::RspType<bool,    // Power is on
+         resetButtonDisabled = *resetButtonReading;
+     }
+ 
++    std::optional<bool> interruptButtonReading =
++        getButtonEnabled(interruptButtonPath);
++    // allow disable if the interface is present
++    bool interruptButtonDisableAllow =
++        static_cast<bool>(interruptButtonReading);
++    // default return the button is enabled (not disabled)
++    bool interruptButtonDisabled = false;
++    if (interruptButtonDisableAllow)
++    {
++        // return the real value of the button status, if present
++        interruptButtonDisabled = *interruptButtonReading;
++    }
++
+     bool powerDownAcFailed = power_policy::getACFailStatus();
+ 
++    bool powerStatusIPMI = false;
++    if (!checkIPMIRestartCause(ctx, powerStatusIPMI))
++    {
++        return ipmi::responseUnspecifiedError();
++    }
++
+     // This response has a lot of hard-coded, unsupported fields
+     // They are set to false or 0
+     constexpr bool powerOverload = false;
+@@ -1177,7 +1235,6 @@ ipmi::RspType<bool,    // Power is on
+     constexpr bool powerDownOverload = false;
+     constexpr bool powerDownInterlock = false;
+     constexpr bool powerDownPowerFault = false;
+-    constexpr bool powerStatusIPMI = false;
+     constexpr bool chassisIntrusionActive = false;
+     constexpr bool frontPanelLockoutActive = false;
+     constexpr bool driveFault = false;
+@@ -1185,9 +1242,7 @@ ipmi::RspType<bool,    // Power is on
+     // chassisIdentifySupport set because this command is implemented
+     constexpr bool chassisIdentifySupport = true;
+     uint2_t chassisIdentifyState = types::enum_cast<uint2_t>(chassisIDState);
+-    constexpr bool diagButtonDisabled = false;
+     constexpr bool sleepButtonDisabled = false;
+-    constexpr bool diagButtonDisableAllow = false;
+     constexpr bool sleepButtonDisableAllow = false;
+ 
+     return ipmi::responseSuccess(
+@@ -1203,120 +1258,86 @@ ipmi::RspType<bool,    // Power is on
+         coolingFanFault, chassisIdentifyState, chassisIdentifySupport,
+         false, // reserved
+ 
+-        powerButtonDisabled, resetButtonDisabled, diagButtonDisabled,
++        powerButtonDisabled, resetButtonDisabled, interruptButtonDisabled,
+         sleepButtonDisabled, powerButtonDisableAllow, resetButtonDisableAllow,
+-        diagButtonDisableAllow, sleepButtonDisableAllow);
++        interruptButtonDisableAllow, sleepButtonDisableAllow);
+ }
+ 
+-enum class IpmiRestartCause
+-{
+-    Unknown = 0x0,
+-    RemoteCommand = 0x1,
+-    ResetButton = 0x2,
+-    PowerButton = 0x3,
+-    WatchdogTimer = 0x4,
+-    PowerPolicyAlwaysOn = 0x6,
+-    PowerPolicyPreviousState = 0x7,
+-    SoftReset = 0xa,
+-};
+-
+-static IpmiRestartCause
+-    restartCauseToIpmiRestartCause(State::Host::RestartCause cause)
++static uint4_t getRestartCauseValue(const std::string& cause)
+ {
+-    switch (cause)
++    uint4_t restartCauseValue = 0;
++    if (cause == "xyz.openbmc_project.State.Host.RestartCause.Unknown")
+     {
+-        case State::Host::RestartCause::Unknown:
+-        {
+-            return IpmiRestartCause::Unknown;
+-        }
+-        case State::Host::RestartCause::RemoteCommand:
+-        {
+-            return IpmiRestartCause::RemoteCommand;
+-        }
+-        case State::Host::RestartCause::ResetButton:
+-        {
+-            return IpmiRestartCause::ResetButton;
+-        }
+-        case State::Host::RestartCause::PowerButton:
+-        {
+-            return IpmiRestartCause::PowerButton;
+-        }
+-        case State::Host::RestartCause::WatchdogTimer:
+-        {
+-            return IpmiRestartCause::WatchdogTimer;
+-        }
+-        case State::Host::RestartCause::PowerPolicyAlwaysOn:
+-        {
+-            return IpmiRestartCause::PowerPolicyAlwaysOn;
+-        }
+-        case State::Host::RestartCause::PowerPolicyPreviousState:
+-        {
+-            return IpmiRestartCause::PowerPolicyPreviousState;
+-        }
+-        case State::Host::RestartCause::SoftReset:
+-        {
+-            return IpmiRestartCause::SoftReset;
+-        }
+-        default:
+-        {
+-            return IpmiRestartCause::Unknown;
+-        }
++        restartCauseValue = 0x0;
+     }
+-}
+-
+-/*
+- * getRestartCause
+- * helper function for Get Host restart cause Command
+- * return - optional value for RestartCause (no value on error)
+- */
+-static std::optional<uint4_t> getRestartCause(ipmi::Context::ptr ctx)
+-{
+-    constexpr const char* restartCausePath =
+-        "/xyz/openbmc_project/control/host0/restart_cause";
+-    constexpr const char* restartCauseIntf =
+-        "xyz.openbmc_project.Control.Host.RestartCause";
+-
+-    std::string service;
+-    boost::system::error_code ec =
+-        ipmi::getService(ctx, restartCauseIntf, restartCausePath, service);
+-    if (!ec)
++    else if (cause == "xyz.openbmc_project.State.Host.RestartCause.IpmiCommand")
+     {
+-        std::string restartCauseStr;
+-        ec = ipmi::getDbusProperty<std::string>(
+-            ctx, service, restartCausePath, restartCauseIntf, "RestartCause",
+-            restartCauseStr);
+-        if (!ec)
+-        {
+-            auto cause =
+-                State::Host::convertRestartCauseFromString(restartCauseStr);
+-            return types::enum_cast<uint4_t>(
+-                restartCauseToIpmiRestartCause(cause));
+-        }
++        restartCauseValue = 0x1;
+     }
+-
+-    log<level::ERR>("Failed to fetch RestartCause property",
+-                    entry("ERROR=%s", ec.message().c_str()),
+-                    entry("PATH=%s", restartCausePath),
+-                    entry("INTERFACE=%s", restartCauseIntf));
+-    return std::nullopt;
++    else if (cause == "xyz.openbmc_project.State.Host.RestartCause.ResetButton")
++    {
++        restartCauseValue = 0x2;
++    }
++    else if (cause == "xyz.openbmc_project.State.Host.RestartCause.PowerButton")
++    {
++        restartCauseValue = 0x3;
++    }
++    else if (cause ==
++             "xyz.openbmc_project.State.Host.RestartCause.WatchdogTimer")
++    {
++        restartCauseValue = 0x4;
++    }
++    else if (cause == "xyz.openbmc_project.State.Host.RestartCause.OEM")
++    {
++        restartCauseValue = 0x5;
++    }
++    else if (cause ==
++             "xyz.openbmc_project.State.Host.RestartCause.PowerPolicyAlwaysOn")
++    {
++        restartCauseValue = 0x6;
++    }
++    else if (cause == "xyz.openbmc_project.State.Host.RestartCause."
++                      "PowerPolicyPreviousState")
++    {
++        restartCauseValue = 0x7;
++    }
++    else if (cause == "xyz.openbmc_project.State.Host.RestartCause.PEFReset")
++    {
++        restartCauseValue = 0x8;
++    }
++    else if (cause ==
++             "xyz.openbmc_project.State.Host.RestartCause.PEFPowerCycle")
++    {
++        restartCauseValue = 0x9;
++    }
++    else if (cause == "xyz.openbmc_project.State.Host.RestartCause.SoftReset")
++    {
++        restartCauseValue = 0xa;
++    }
++    else if (cause == "xyz.openbmc_project.State.Host.RestartCause.RTCWakeup")
++    {
++        restartCauseValue = 0xb;
++    }
++    return restartCauseValue;
+ }
+ 
+ ipmi::RspType<uint4_t, // Restart Cause
+               uint4_t, // reserved
+-              uint8_t  // channel number (not supported)
++              uint8_t  // channel number
+               >
+     ipmiGetSystemRestartCause(ipmi::Context::ptr ctx)
+ {
+-    std::optional<uint4_t> cause = getRestartCause(ctx);
+-    if (!cause)
++    std::string restartCauseStr;
++    if (!getRestartCause(ctx, restartCauseStr))
+     {
+         return ipmi::responseUnspecifiedError();
+     }
+-
+     constexpr uint4_t reserved = 0;
+     auto channel = static_cast<uint8_t>(ctx->channel);
+-    return ipmi::responseSuccess(cause.value(), reserved, channel);
++    return ipmi::responseSuccess(getRestartCauseValue(restartCauseStr),
++                                 reserved, channel);
+ }
++
+ /** @brief Implementation of chassis control command
+  *
+  *  @param - chassisControl command byte
+@@ -2322,25 +2343,27 @@ ipmi::RspType<uint3_t, // policy support
+     return ipmi::responseSuccess(power_policy::allSupport, reserved);
+ }
+ 
+-ipmi::RspType<> ipmiSetFrontPanelButtonEnables(
+-    ipmi::Context::ptr ctx, bool disablePowerButton, bool disableResetButton,
+-    bool disableDiagButton, bool disableSleepButton, uint4_t reserved)
++ipmi::RspType<> ipmiSetFrontPanelButtonEnables(bool disablePowerButton,
++                                               bool disableResetButton,
++                                               bool disableInterruptButton,
++                                               bool disableSleepButton,
++                                               uint4_t reserved)
+ {
+-    using namespace chassis::internal;
+-
+-    // set power button Enabled property
+-    bool success = setButtonEnabled(ctx, powerButtonPath, powerButtonIntf,
+-                                    !disablePowerButton);
++    if (reserved)
++    {
++        return ipmi::responseInvalidFieldRequest();
++    }
++    bool error = false;
+ 
+-    // set reset button Enabled property
+-    success &= setButtonEnabled(ctx, resetButtonPath, resetButtonIntf,
+-                                !disableResetButton);
++    error |= setButtonEnabled(powerButtonPath, disablePowerButton);
++    error |= setButtonEnabled(resetButtonPath, disableResetButton);
++    error |= setButtonEnabled(interruptButtonPath, disableInterruptButton);
+ 
+-    if (!success)
++    if (error)
+     {
+-        // not all buttons were successfully set
+         return ipmi::responseUnspecifiedError();
+     }
++
+     return ipmi::responseSuccess();
+ }
+ 
+-- 
+2.34.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0025-save-no-supported-boot-options.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0025-save-no-supported-boot-options.patch
@@ -1,0 +1,111 @@
+diff --git a/chassishandler.cpp b/chassishandler.cpp
+index de4bafa2..a198e899 100644
+--- a/chassishandler.cpp
++++ b/chassishandler.cpp
+@@ -120,6 +120,8 @@ static constexpr const char* resetButtonPath =
+     "/xyz/openbmc_project/chassis/buttons/reset";
+ static constexpr const char* interruptButtonPath =
+     "/xyz/openbmc_project/chassis/buttons/nmi";
++static constexpr const char* deviceInstanceFile = "/var/lib/ipmi/dev_instance";
++
+ // Phosphor Host State manager
+ namespace State = sdbusplus::xyz::openbmc_project::State::server;
+ 
+@@ -1826,6 +1828,64 @@ static ipmi::Cc setBootOneTime(ipmi::Context::ptr& ctx, const bool& onetime)
+     return ipmi::ccUnspecifiedError;
+ }
+ 
++static ipmi::Cc getBootDevInstance(uint8_t& data3, uint8_t& data4,
++                                   uint8_t& data5)
++{
++    char msg[3] = {0};
++    std::fstream dev_file(deviceInstanceFile, dev_file.in | dev_file.binary);
++    if (!dev_file.is_open())
++    {
++        // file may not be created
++        log<level::INFO>("Cannot open boot device instance file");
++    }
++    else
++    {
++        try
++        {
++            dev_file.read(msg, 3);
++        }
++        catch (const std::exception& e)
++        {
++            log<level::ERR>("Cannot read boot device instance file");
++            dev_file.close();
++            return ipmi::ccUnspecifiedError;
++        }
++        dev_file.close();
++    }
++    data3 = msg[0];
++    data4 = msg[1];
++    data5 = msg[2];
++    return ipmi::ccSuccess;
++}
++
++static ipmi::Cc setBootDevInstance(const uint8_t& data3, const uint8_t& data4,
++                                   const uint8_t& data5)
++{
++    std::fstream dev_file(deviceInstanceFile, dev_file.out | dev_file.binary);
++    if (!dev_file.is_open())
++    {
++        log<level::ERR>("Cannot open boot device instance file");
++        return ipmi::ccUnspecifiedError;
++    }
++    else
++    {
++        unsigned char msg[3] = {data3, data4, data5};
++        try
++        {
++            dev_file.write((char*)msg, 3);
++        }
++        catch (const std::exception& e)
++        {
++            log<level::ERR>("Cannot write boot device instance file",
++                            entry("ERROR=%s", e.what()));
++            dev_file.close();
++            return ipmi::ccUnspecifiedError;
++        }
++        dev_file.close();
++    }
++    return ipmi::ccSuccess;
++}
++
+ static constexpr uint8_t setComplete = 0x0;
+ static constexpr uint8_t setInProgress = 0x1;
+ static uint8_t transferStatus = setComplete;
+@@ -1957,12 +2017,17 @@ ipmi::RspType<ipmi::message::Payload>
+             }
+ 
+             uint1_t validFlag = valid ? 1 : 0;
++            uint8_t data3, data4, data5;
++            rc = getBootDevInstance(data3, data4, data5);
++            if (rc != ipmi::ccSuccess)
++            {
++                return ipmi::response(rc);
++            }
+ 
+             response.pack(bootOptionParameter, reserved1, uint5_t{},
+                           uint1_t{biosBootType}, uint1_t{permanent},
+                           uint1_t{validFlag}, uint2_t{}, uint4_t{bootOption},
+-                          uint1_t{}, cmosClear, uint8_t{}, uint8_t{},
+-                          uint8_t{});
++                          uint1_t{}, cmosClear, data3, data4, data5);
+             return ipmi::responseSuccess(std::move(response));
+         }
+         catch (const InternalFailure& e)
+@@ -2161,6 +2226,12 @@ ipmi::RspType<> ipmiChassisSetSysBootOptions(ipmi::Context::ptr ctx,
+                     "ipmiChassisSetSysBootOptions: Boot option not supported");
+                 return ipmi::responseInvalidFieldRequest();
+             }
++            rc = setBootDevInstance(data3, static_cast<uint8_t>(biosInfo),
++                                    static_cast<uint8_t>(deviceInstance));
++            if (rc != ipmi::ccSuccess)
++            {
++                return ipmi::response(rc);
++            }
+         }
+         catch (const sdbusplus::exception_t& e)
+         {

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -28,6 +28,8 @@ SRC_URI:append:evb-npcm845 = " file://0020-fix-percentage-type-show.patch"
 SRC_URI:append:evb-npcm845 = " file://0021-sensor-reading-optional-zero.patch"
 SRC_URI:append:evb-npcm845 = " file://0022-add-sensor-reading-factory-support.patch"
 SRC_URI:append:evb-npcm845 = " file://0023-add-oem-sel-support.patch"
+SRC_URI:append:evb-npcm845 = " file://0024-update-chassishandler-from-intel-oem-ipmi.patch"
+SRC_URI:append:evb-npcm845 = " file://0025-save-no-supported-boot-options.patch"
 
 # Add send/get message support
 # ipmid <-> ipmb <-> i2c

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0025-save-no-supported-boot-options.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0025-save-no-supported-boot-options.patch
@@ -1,0 +1,111 @@
+diff --git a/chassishandler.cpp b/chassishandler.cpp
+index de4bafa2..a198e899 100644
+--- a/chassishandler.cpp
++++ b/chassishandler.cpp
+@@ -120,6 +120,8 @@ static constexpr const char* resetButtonPath =
+     "/xyz/openbmc_project/chassis/buttons/reset";
+ static constexpr const char* interruptButtonPath =
+     "/xyz/openbmc_project/chassis/buttons/nmi";
++static constexpr const char* deviceInstanceFile = "/var/lib/ipmi/dev_instance";
++
+ // Phosphor Host State manager
+ namespace State = sdbusplus::xyz::openbmc_project::State::server;
+ 
+@@ -1826,6 +1828,64 @@ static ipmi::Cc setBootOneTime(ipmi::Context::ptr& ctx, const bool& onetime)
+     return ipmi::ccUnspecifiedError;
+ }
+ 
++static ipmi::Cc getBootDevInstance(uint8_t& data3, uint8_t& data4,
++                                   uint8_t& data5)
++{
++    char msg[3] = {0};
++    std::fstream dev_file(deviceInstanceFile, dev_file.in | dev_file.binary);
++    if (!dev_file.is_open())
++    {
++        // file may not be created
++        log<level::INFO>("Cannot open boot device instance file");
++    }
++    else
++    {
++        try
++        {
++            dev_file.read(msg, 3);
++        }
++        catch (const std::exception& e)
++        {
++            log<level::ERR>("Cannot read boot device instance file");
++            dev_file.close();
++            return ipmi::ccUnspecifiedError;
++        }
++        dev_file.close();
++    }
++    data3 = msg[0];
++    data4 = msg[1];
++    data5 = msg[2];
++    return ipmi::ccSuccess;
++}
++
++static ipmi::Cc setBootDevInstance(const uint8_t& data3, const uint8_t& data4,
++                                   const uint8_t& data5)
++{
++    std::fstream dev_file(deviceInstanceFile, dev_file.out | dev_file.binary);
++    if (!dev_file.is_open())
++    {
++        log<level::ERR>("Cannot open boot device instance file");
++        return ipmi::ccUnspecifiedError;
++    }
++    else
++    {
++        unsigned char msg[3] = {data3, data4, data5};
++        try
++        {
++            dev_file.write((char*)msg, 3);
++        }
++        catch (const std::exception& e)
++        {
++            log<level::ERR>("Cannot write boot device instance file",
++                            entry("ERROR=%s", e.what()));
++            dev_file.close();
++            return ipmi::ccUnspecifiedError;
++        }
++        dev_file.close();
++    }
++    return ipmi::ccSuccess;
++}
++
+ static constexpr uint8_t setComplete = 0x0;
+ static constexpr uint8_t setInProgress = 0x1;
+ static uint8_t transferStatus = setComplete;
+@@ -1957,12 +2017,17 @@ ipmi::RspType<ipmi::message::Payload>
+             }
+ 
+             uint1_t validFlag = valid ? 1 : 0;
++            uint8_t data3, data4, data5;
++            rc = getBootDevInstance(data3, data4, data5);
++            if (rc != ipmi::ccSuccess)
++            {
++                return ipmi::response(rc);
++            }
+ 
+             response.pack(bootOptionParameter, reserved1, uint5_t{},
+                           uint1_t{biosBootType}, uint1_t{permanent},
+                           uint1_t{validFlag}, uint2_t{}, uint4_t{bootOption},
+-                          uint1_t{}, cmosClear, uint8_t{}, uint8_t{},
+-                          uint8_t{});
++                          uint1_t{}, cmosClear, data3, data4, data5);
+             return ipmi::responseSuccess(std::move(response));
+         }
+         catch (const InternalFailure& e)
+@@ -2161,6 +2226,12 @@ ipmi::RspType<> ipmiChassisSetSysBootOptions(ipmi::Context::ptr ctx,
+                     "ipmiChassisSetSysBootOptions: Boot option not supported");
+                 return ipmi::responseInvalidFieldRequest();
+             }
++            rc = setBootDevInstance(data3, static_cast<uint8_t>(biosInfo),
++                                    static_cast<uint8_t>(deviceInstance));
++            if (rc != ipmi::ccSuccess)
++            {
++                return ipmi::response(rc);
++            }
+         }
+         catch (const sdbusplus::exception_t& e)
+         {

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -31,6 +31,7 @@ SRC_URI:append:scm-npcm845 = " file://0021-sensor-reading-optional-zero.patch"
 SRC_URI:append:scm-npcm845 = " file://0022-add-sensor-reading-factory-support.patch"
 SRC_URI:append:scm-npcm845 = " file://0023-add-oem-sel-support.patch"
 SRC_URI:append:scm-npcm845 = " file://0024-update-chassishandler-from-intel-oem-ipmi.patch"
+SRC_URI:append:scm-npcm845 = " file://0025-save-no-supported-boot-options.patch"
 
 # Add send/get message support
 # ipmid <-> ipmb <-> i2c


### PR DESCRIPTION
Save the boot options which Openbmc is not supported, and load the saved
data when execute IPMI command get system boot options.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
