### PR TITLE
meta-scm-npcm845: update MAX16550 power parameter

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/0013-Add-pmbus-driver-for-MAX16550.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/0013-Add-pmbus-driver-for-MAX16550.patch
@@ -150,7 +150,7 @@ index 000000000000..72c4256c49ef
 +	.R[PSC_POWER] = -3,
 +
 +	.format[PSC_POWER] = direct,
-+	.m[PSC_POWER] = 8055,
++	.m[PSC_POWER] = 13425,
 +	.b[PSC_POWER] = -9100,
 +	.R[PSC_POWER] = -2,
 +


### PR DESCRIPTION
Update the kernel driver MAX16550 power parameter with real Rload.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
