### PR TITLE
meta-scm-npcm845: support eMMC image update U-Boot.

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/flash/phosphor-software-manager/support_update_uboot_with_emmc_image.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/flash/phosphor-software-manager/support_update_uboot_with_emmc_image.patch
@@ -1,0 +1,111 @@
+diff --git a/obmc-flash-bmc b/obmc-flash-bmc
+index 4b29bb3..8a310fb 100644
+--- a/obmc-flash-bmc
++++ b/obmc-flash-bmc
+@@ -1,6 +1,8 @@
+ #!/bin/bash
+ set -eo pipefail
+ 
++ulog="/var/log/update.log"
++
+ # Get the root mtd device number (mtdX) from "/dev/ubiblockX_Y on /"
+ findrootmtd() {
+   rootmatch=" on / "
+@@ -349,7 +351,7 @@ ubi_setenv() {
+ mtd_write() {
+   flashmtd="$(findmtd "${reqmtd}")"
+   img="/tmp/images/${version}/${imgfile}"
+-  flashcp -v ${img} /dev/${flashmtd}
++  flashcp -v ${img} /dev/${flashmtd} >> "${ulog}"
+ }
+ 
+ backup_env_vars() {
+@@ -453,6 +455,12 @@ cmp_uboot() {
+   device="$1"
+   image="$2"
+ 
++  # if no uboot image need to update
++  if [ ! -f "${image}" ];then
++    echo "no uboot file for update" >> "${ulog}"
++    echo 0
++    return
++  fi
+   # Since the image file can be smaller than the device, copy the device to a
+   # tmp file and write the image file on top, then compare the sum of each.
+   # Use cat / redirection since busybox does not have the conv=notrunc option.
+@@ -463,6 +471,8 @@ cmp_uboot() {
+   imgSum="$(sha256sum ${tmpFile})"
+   rm -f "${tmpFile}"
+ 
++  echo "image checksum: ${imgSum}" >> "${ulog}"
++  echo "mtd device checksum: ${devSum}" >> "${ulog}"
+   if [ "${imgSum}" == "${devSum}" ]; then
+     echo "0";
+   else
+@@ -502,14 +512,16 @@ mmc_get_secondary_label() {
+ }
+ 
+ mmc_update() {
++  echo "start mmc update, version: ${version}" >> "${ulog}"
++  echo $(date) >> "${ulog}"
+   # Update u-boot if needed
+-  bootPartition="mmcblk0boot0"
+-  devUBoot="/dev/${bootPartition}"
++  devUBoot="/dev/$(findmtd u-boot)"
+   imgUBoot="${imgpath}/${version}/image-u-boot"
+   if [ "$(cmp_uboot "${devUBoot}" "${imgUBoot}")" != "0" ]; then
+-    echo 0 > "/sys/block/${bootPartition}/force_ro"
+-    dd if="${imgUBoot}" of="${devUBoot}"
+-    echo 1 > "/sys/block/${bootPartition}/force_ro"
++    echo "uboot need update" >> "${ulog}"
++    imgfile=image-u-boot
++    reqmtd=u-boot
++    mtd_write
+   fi
+ 
+   # Update the secondary (non-running) boot and rofs partitions.
+@@ -517,20 +529,25 @@ mmc_update() {
+ 
+   # Update the boot and rootfs partitions, restore their labels after the update
+   # by getting the partition number mmcblk0pX from their label.
++  echo "start update kernel: boot-${label}" >> "${ulog}"
+   zstd -d -c ${imgpath}/${version}/image-kernel | dd of="/dev/disk/by-partlabel/boot-${label}"
+   number="$(readlink -f /dev/disk/by-partlabel/boot-${label})"
+   number="${number##*mmcblk0p}"
+   sgdisk --change-name=${number}:boot-${label} /dev/mmcblk0 1>/dev/null
+ 
++  echo "start update rofs: rofs-${label}" >> "${ulog}"
+   zstd -d -c ${imgpath}/${version}/image-rofs | dd of="/dev/disk/by-partlabel/rofs-${label}"
+   number="$(readlink -f /dev/disk/by-partlabel/rofs-${label})"
+   number="${number##*mmcblk0p}"
+   sgdisk --change-name=${number}:rofs-${label} /dev/mmcblk0 1>/dev/null
+ 
+   # Run this after sgdisk for labels to take effect.
+-  partprobe
++  echo "start partprobe" >> "${ulog}"
++  # fix some mtd device get Invalid partition table
++  partprobe /dev/mmcblk0
+ 
+   # Update hostfw
++  echo "start try to update hostfw" >> "${ulog}"
+   if [ -f ${imgpath}/${version}/image-hostfw ]; then
+     # Remove patches
+     patchdir="/usr/local/share/hostfw/alternate"
+@@ -546,10 +563,17 @@ mmc_update() {
+   # Store the label where the other properties like purpose and priority are
+   # preserved via the storePriority() function in the serialize files, so that
+   # it can be used for the remove function.
++  echo "store partlabel..." >> "${ulog}"
+   label_dir="/var/lib/phosphor-bmc-code-mgmt/${version}"
+   label_file="${label_dir}/partlabel"
+   mkdir -p "${label_dir}"
+   echo "${label}" > "${label_file}"
++  # handle the ipmi flash bmc update
++  if [ "${version}" == "bmc-image" ]; then
++      echo "directly update bootside for ipmi flash bmc" >> "${ulog}"
++      fw_setenv bootside "${label}"
++  fi
++  echo "end of mmc update" >> "${ulog}"
+ }
+ 
+ mmc_remove() {

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -3,5 +3,6 @@ FILESEXTRAPATHS:prepend:scm-npcm845 := "${THISDIR}/${PN}:"
 PACKAGECONFIG:append:scm-npcm845 = " verify_signature flash_bios"
 
 SRC_URI:append:scm-npcm845 = " file://restore_verify_bios.patch"
+SRC_URI:append:scm-npcm845 = " file://support_update_uboot_with_emmc_image.patch"
 
 EXTRA_OEMESON:append:scm-npcm845 = " -Doptional-images=image-bios"


### PR DESCRIPTION
Update software manager update script to support update eMMC image to
flash U-Boot image on SPI flash.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
