### PR TITLE
bmcweb: bump srcrev f5e29f33e...e1cc4828

### DIFF
--- a/meta-phosphor/recipes-phosphor/interfaces/bmcweb_git.bb
+++ b/meta-phosphor/recipes-phosphor/interfaces/bmcweb_git.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 SRC_URI = "git://github.com/openbmc/bmcweb.git;branch=master;protocol=https"
 
 PV = "1.0+git${SRCPV}"
-SRCREV = "f5e29f33e61be81ece4b2f78d7d1750d357f7ff3"
+SRCREV = "e1cc482880d7b47dcf19609cedba7df80368ae3c"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Update bmcweb version to fix update service fwUpdateErrorMatcher cannot
work issue.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
