### PR TITLE
meta-scm-npcm845: update chassis AC fail status

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/0004-kernel-scm-dts.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/0004-kernel-scm-dts.patch
@@ -412,7 +412,7 @@ index 000000000000..c4455dd4d2fe
 +				nuvoton,reset-priority = <155>;
 +				nuvoton,card-reset-type = "porst";
 +				nuvoton,ext1-reset-type = "wd1";
-+				nuvoton,ext2-reset-type = "sw2";
++				nuvoton,ext2-reset-type = "sw1";
 +				status = "okay";
 +			};
 +

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/0016-WA-fix-watchdog-bootstatus-incorrect.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/0016-WA-fix-watchdog-bootstatus-incorrect.patch
@@ -1,0 +1,24 @@
+From 417f21995597d60854b8b0c1434bbaae19e4e9fd Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Mon, 22 Aug 2022 10:09:41 +0800
+Subject: [PATCH] [WA] fix watchdog bootstatus incorrect
+
+---
+ drivers/watchdog/npcm_wdt.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/watchdog/npcm_wdt.c b/drivers/watchdog/npcm_wdt.c
+index 2656ba278178..8013e4d46010 100644
+--- a/drivers/watchdog/npcm_wdt.c
++++ b/drivers/watchdog/npcm_wdt.c
+@@ -210,7 +210,6 @@ static void npcm_get_reset_status(struct npcm_wdt *wdt, struct device *dev)
+ 	regmap_read(gcr_regmap, NPCM7XX_RESSR_OFFSET, &rstval);
+ 	if (!rstval) {
+ 		regmap_read(gcr_regmap, NPCM7XX_INTCR2_OFFSET, &rstval);
+-		rstval = ~rstval;
+ 	}
+ 
+ 	if (rstval & wdt->card_reset)
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton_%.bbappend
@@ -15,6 +15,7 @@ SRC_URI:append:scm-npcm845 = " file://0012-rtl8211f-customized-led.patch"
 SRC_URI:append:scm-npcm845 = " file://0013-Add-pmbus-driver-for-MAX16550.patch"
 SRC_URI:append:scm-npcm845 = " file://0014-driver-i2c-npcm7xx-don-t-check-sda-scl-status-in-dri.patch"
 SRC_URI:append:scm-npcm845 = " file://0015-device-tree-optee-enable.patch"
+SRC_URI:append:scm-npcm845 = " file://0016-WA-fix-watchdog-bootstatus-incorrect.patch"
 
 SRC_URI:append:scm-npcm845 = " file://enable-legacy-kvm.cfg"
 SRC_URI:append:scm-npcm845 = " file://1111-dts-enable-legacy-kvm.patch"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0027-implement-chassis-acfail-status.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0027-implement-chassis-acfail-status.patch
@@ -1,0 +1,57 @@
+From 1d73bdc1b2bfc84f81eb84e660b1d90f3abb7037 Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Mon, 22 Aug 2022 13:50:48 +0800
+Subject: [PATCH] Use BMC state is POR to get ACfail status
+
+---
+ chassishandler.cpp | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/chassishandler.cpp b/chassishandler.cpp
+index a198e899..b699b57f 100644
+--- a/chassishandler.cpp
++++ b/chassishandler.cpp
+@@ -1029,6 +1029,7 @@ std::optional<bool> getPowerStatus()
+  */
+ bool getACFailStatus()
+ {
++    /* Intel ACboot is not in Openbmc dbus interface, settings may not work.
+     constexpr const char* acBootObj =
+         "/xyz/openbmc_project/control/host0/ac_boot";
+     constexpr const char* acBootIntf = "xyz.openbmc_project.Common.ACBoot";
+@@ -1049,6 +1050,32 @@ bool getACFailStatus()
+             entry("PATH=%s", acBootObj), entry("INTERFACE=%s", acBootIntf));
+     }
+     return acFail == "True";
++    */
++    constexpr const char* bmcStateObj = "/xyz/openbmc_project/state/bmc0";
++    constexpr const char* bmcStateIntf = "xyz.openbmc_project.State.BMC";
++    std::string rebootCause;
++    bool acFail = false;
++    std::shared_ptr<sdbusplus::asio::connection> bus = getSdBus();
++    try
++    {
++        auto service = ipmi::getService(*bus, bmcStateIntf, bmcStateObj);
++
++        ipmi::Value variant = ipmi::getDbusProperty(
++            *bus, service, bmcStateObj, bmcStateIntf, "LastRebootCause");
++        rebootCause = std::get<std::string>(variant);
++        if (rebootCause == "xyz.openbmc_project.State.BMC.RebootCause.POR")
++        {
++            acFail = true;
++        }
++    }
++    catch (const std::exception& e)
++    {
++        log<level::ERR>("Failed to fetch LastRebootCause property",
++                        entry("ERROR=%s", e.what()),
++                        entry("PATH=%s", bmcStateObj),
++                        entry("INTERFACE=%s", bmcStateIntf));
++    }
++    return acFail;
+ }
+ } // namespace power_policy
+ 
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -33,6 +33,7 @@ SRC_URI:append:scm-npcm845 = " file://0023-add-oem-sel-support.patch"
 SRC_URI:append:scm-npcm845 = " file://0024-update-chassishandler-from-intel-oem-ipmi.patch"
 SRC_URI:append:scm-npcm845 = " file://0025-save-no-supported-boot-options.patch"
 SRC_URI:append:scm-npcm845 = " file://0026-set-channel-security-keys.patch"
+SRC_URI:append:scm-npcm845 = " file://0027-implement-chassis-acfail-status.patch"
 
 # Add send/get message support
 # ipmid <-> ipmb <-> i2c


### PR DESCRIPTION
Use BMC status LastRebootCause is POR to set chassis AC fail status.
In normal reset case we use soft reset or watchdog reset, once we get
POR, it should be AC fail or first time boot.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
