### PR TITLE
meta-nuvoton: fix bootblock build warning

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.2.2.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.2.2.bb
@@ -10,7 +10,7 @@ S = "${WORKDIR}"
 
 SRCREV = "4002b2f086f6d2177ec36bed507241386d604f6b"
 SRC_URI = " \
-    https://github.com/Nuvoton-Israel/npcm8xx-bootblock/${SRCREV}/LICENSE;name=lic \
+    https://github.com/Nuvoton-Israel/npcm8xx-bootblock/blob/${SRCREV}/LICENSE;name=lic \
     https://github.com/Nuvoton-Israel/npcm8xx-bootblock/releases/download/A35_BootBlock_${PV}/arbel_a35_bootblock.bin;downloadfilename=${FILENAME};name=bin \
 "
 


### PR DESCRIPTION
Update the correct license URL on Github.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
