### PR TITLE
meta-nuvoton: linux-nuvoton: srcrev bump e705947..d37182b

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_git.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_git.bb
@@ -5,7 +5,7 @@
 
 KBRANCH ?= "NPCM-5.10-OpenBMC"
 LINUX_VERSION ?= "5.10.67"
-SRCREV = "e70594746e6f1048537f4188a23c05aa9b0c3685"
+SRCREV = "d37182b55c65daa74fc42fc0efff77417ae07a62"
 
 require linux-nuvoton.inc
 


### PR DESCRIPTION
Marvin Lin (8):
      dts: Reduce reserved video memory from 32M to 24M
      driver: edac: Support error injection via debugfs
      driver: edac: Remove sysfs error injection
      dts: npcm845-evb: Move video memory to 0x33400000
      driver: media: platform: Increase polling timeout to 300ms
      driver: edac: Code refactoring
      driver: media: Sync with upstream refinements
      Revert "dts: npcm845-evb: Move video memory to 0x33400000"

Mia Lin (4):
      RTC: nuvoton: Add nuvoton real time clock driver
      dt-bindings: rtc: nuvoton: add NCT3018Y Real Time Clock
      driver: rtc: add intrusion event detection
      driver: rtc: Add record intrusion and vcc drop timestamps when bmc boots up.

Stanley Chu (1):
      i3c: master: svc: adjust clock duty cycle

Tomer Maimon (4):
      arm64: nuvoton: remove unused timer GIC_SPI IRQs
      spi: npcm-fiu: handle SPI-X configuration in FIUX
      Revert "spi: npcm-fiu: handle SPI-X configuration in FIUX"
      spi: npcm-fiu: handle SPI-X configuration in FIUX

Tyrone Ting (2):
      i2c: npcm: Modify timeout evaluation mechanism
      i2c: npcm: Modify the client address assignment

jhkang (1):
      dts: buv-runbmc: spi: fix spix pin group does not be set and enable spix dual mode

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
