### PR TITLE
meta-nuvoton: linux-nuvoton: srcrev bump cc7e2206...0ba165da

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_git.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_git.bb
@@ -9,7 +9,7 @@
 
 KBRANCH ?= "NPCM-5.15-OpenBMC"
 LINUX_VERSION ?= "5.15.50"
-SRCREV = "7870b74768b6a37a5ba60231b14b3bafd85d78e4"
+SRCREV = "cc7e2206d6d2cc8bdc193f00aa9d7c7f0ba165da"
 
 require linux-nuvoton.inc
 


### PR DESCRIPTION
Marvin Lin (1):
      driver: edac: Sync with upstream changes

Allen Kang (1):
      arm: dts: Modify runbmc-olympus dts and pincfg.dtsi for kernel 5.15 grading

Joel Stanley (1):
      net: npcm: Remove superfluous logging

Tomer Maimon (1):
      net: emc: version 3.9.4

Jim Liu (3):
      driver: gpio: nuvoton: add sgpio driver
      drivers: gpio: add NPCM8xx SGPIO dts node
      arm64: dts: nuvoton: fix build error for video dts node

Signed-off-by: Allen Kang <jhkang@nuvoton.com>

