### PR TITLE
[Workaround] Fix dynamic U-Boot env image crash

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -3,6 +3,7 @@ inherit entity-utils
 FILESEXTRAPATHS:append:evb-npcm845 := "${THISDIR}/${PN}:"
 
 DEPENDS:append:evb-npcm845 = " ${@entity_enabled(d, '', ' evb-npcm845-yaml-config')}"
+RDEPENDS:${PN}:remove:evb-npcm845 = "clear-once"
 EXTRA_OECONF:append:evb-npcm845 = " ${@entity_enabled(d, '', 'SENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/evb-npcm845-yaml-config/ipmi-sensors.yaml')}"
 EXTRA_OECONF:append:evb-npcm845 = " ${@entity_enabled(d, '', 'FRU_YAML_GEN=${STAGING_DIR_HOST}${datadir}/evb-npcm845-yaml-config/ipmi-fru-read.yaml')}"
 EXTRA_OECONF:append:evb-npcm845 = " ${@entity_enabled(d, '', 'INVSENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/evb-npcm845-yaml-config/ipmi-inventory-sensors.yaml')}"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -3,6 +3,7 @@ inherit entity-utils
 FILESEXTRAPATHS:append:scm-npcm845 := "${THISDIR}/${PN}:"
 
 DEPENDS:append:scm-npcm845 = " ${@entity_enabled(d, '', ' scm-npcm845-yaml-config')}"
+RDEPENDS:${PN}:remove:scm-npcm845 = "clear-once"
 EXTRA_OECONF:append:scm-npcm845 = " ${@entity_enabled(d, '', 'SENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/scm-npcm845-yaml-config/ipmi-sensors.yaml')}"
 EXTRA_OECONF:append:scm-npcm845 = " ${@entity_enabled(d, '', 'FRU_YAML_GEN=${STAGING_DIR_HOST}${datadir}/scm-npcm845-yaml-config/ipmi-fru-read.yaml')}"
 EXTRA_OECONF:append:scm-npcm845 = " ${@entity_enabled(d, '', 'INVSENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/scm-npcm845-yaml-config/ipmi-inventory-sensors.yaml')}"


### PR DESCRIPTION
The U-Boot dynamic enviroment feature is not fully implemented, if enable it may cause other image crash. Remove the clear once service to avoid write U-Boot enviroment after get into OS.

Note. This patch may casue openbmc some feature not work well like factor-reset.

