### PR TITLE
[Workaround] Remove trace event tool

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-scm-npcm845/packagegroups/packagegroup-obmc-apps.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-scm-npcm845/packagegroups/packagegroup-obmc-apps.bbappend
@@ -1,0 +1,2 @@
+# this patch is used to avoid access uboot envoronment
+RDEPENDS:${PN}-devtools:remove:scm-npcm845 = "trace-enable"


### PR DESCRIPTION
Remove trace event tool to avoid OS access U-Boot environment. This patch should be removed when dynmaic U-Boot feature done.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

