### PR TITLE
meta-scm-npcm845: extend U-Boot size to 4MB

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/conf/machine/scm-npcm845.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/conf/machine/scm-npcm845.conf
@@ -16,9 +16,9 @@ IMAGE_CLASSES:append = " image_types_phosphor_scm_npcm8xx"
 
 FLASH_SIZE = "65536"
 FLASH_UBOOT_OFFSET:flash-65536 = "0"
-FLASH_KERNEL_OFFSET:flash-65536 = "2048"
-FLASH_ROFS_OFFSET:flash-65536 = "10240"
-FLASH_RWFS_OFFSET:flash-65536 = "46080"
+FLASH_KERNEL_OFFSET:flash-65536 = "4096"
+FLASH_ROFS_OFFSET:flash-65536 = "12288"
+FLASH_RWFS_OFFSET:flash-65536 = "61440"
 
 # Don't generate MTD flash images until we're able to include the primary
 # bootloader and the Linux MTD driver is ready.

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/0001-dts-scm-flash-partition-mtd0-only.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/0001-dts-scm-flash-partition-mtd0-only.patch
@@ -18,23 +18,23 @@ index c924ae76e3fa..40c26e2d979d 100644
  					};
 -					u-boot@0 {
 -						label = "u-boot";
--						reg = <0x00000000 0x001C0000>;
+-						reg = <0x00000000 0x003C0000>;
 -					};
--					u-boot-env@1c0000{
+-					u-boot-env@3c0000{
 -						label = "u-boot-env";
--						reg = <0x001C0000 0x00040000>;
+-						reg = <0x003C0000 0x00040000>;
 -					};
--					kernel@200000 {
+-					kernel@400000 {
 -						label = "kernel";
--						reg = <0x00200000 0x00800000>;
+-						reg = <0x00400000 0x00800000>;
 -					};
--					rofs@a00000 {
+-					rofs@c00000 {
 -						label = "rofs";
--						reg = <0x00a00000 0x02600000>;
+-						reg = <0x00C00000 0x03000000>;
 -					};
--					rwfs@3000000 {
+-					rwfs@3c00000 {
 -						label = "rwfs";
--						reg = <0x3000000 0x400000>;
+-						reg = <0x3C00000 0x400000>;
 -					};
  				};
  			};

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/0004-kernel-scm-dts.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/0004-kernel-scm-dts.patch
@@ -213,23 +213,23 @@ index 000000000000..c4455dd4d2fe
 +					};
 +					u-boot@0 {
 +						label = "u-boot";
-+						reg = <0x00000000 0x001C0000>;
++						reg = <0x00000000 0x003C0000>;
 +					};
-+					u-boot-env@1c0000{
++					u-boot-env@3c0000{
 +						label = "u-boot-env";
-+						reg = <0x001C0000 0x00040000>;
++						reg = <0x003C0000 0x00040000>;
 +					};
-+					kernel@200000 {
++					kernel@400000 {
 +						label = "kernel";
-+						reg = <0x00200000 0x00800000>;
++						reg = <0x00400000 0x00800000>;
 +					};
-+					rofs@a00000 {
++					rofs@c00000 {
 +						label = "rofs";
-+						reg = <0x00a00000 0x02600000>;
++						reg = <0x00C00000 0x03000000>;
 +					};
-+					rwfs@3000000 {
++					rwfs@3c00000 {
 +						label = "rwfs";
-+						reg = <0x3000000 0x400000>;
++						reg = <0x3C00000 0x400000>;
 +					};
 +				};
 +			};


### PR DESCRIPTION
Update partition layout and DTS to extend U-Boot size.

Signed-off-by: Brian Ma <chma0@nuvoton.com>

