### PR TITLE
meta-scm-npcm845: Use fixed U-Boot env offset

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/conf/machine/scm-npcm845.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/conf/machine/scm-npcm845.conf
@@ -1,7 +1,7 @@
 KMACHINE = "nuvoton"
 KERNEL_DEVICETREE = "nuvoton/${KMACHINE}-npcm845-scm.dtb"
 
-UBOOT_MACHINE = "ArbelEVB_ubootptr_defconfig"
+UBOOT_MACHINE = "ArbelEVB_defconfig"
 UBOOT_DEVICETREE = "nuvoton-npcm845-scm"
 
 IGPS_MACHINE = "EB"
@@ -9,10 +9,6 @@ DEVICE_GEN = "A1"
 
 require conf/machine/include/npcm8xx.inc
 require conf/machine/include/obmc-bsp-common.inc
-
-IMAGE_CLASSES:remove = " image_types_phosphor_nuvoton_npcm8xx"
-IMAGE_CLASSES:append = " image_types_phosphor_scm_npcm8xx"
-
 
 FLASH_SIZE = "65536"
 FLASH_UBOOT_OFFSET:flash-65536 = "0"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton/0008-uboot-env-fixed-offset-update.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton/0008-uboot-env-fixed-offset-update.patch
@@ -1,0 +1,47 @@
+diff --git a/configs/ArbelEVB_defconfig b/configs/ArbelEVB_defconfig
+index c8752b45ce..53a9beaa43 100644
+--- a/configs/ArbelEVB_defconfig
++++ b/configs/ArbelEVB_defconfig
+@@ -6,12 +6,12 @@ CONFIG_SYS_TEXT_BASE=0x8000
+ CONFIG_DEFAULT_DEVICE_TREE="nuvoton-npcm845-evb"
+ CONFIG_ENV_IS_IN_SPI_FLASH=y
+ CONFIG_ENV_SIZE=0x40000
+-CONFIG_ENV_OFFSET=0x1C0000
++CONFIG_ENV_OFFSET=0x3C0000
+ CONFIG_ENV_SECT_SIZE=0x1000
+ CONFIG_CMD_MEMTEST=y
+ CONFIG_SYS_MEMTEST_START=0
+ CONFIG_SYS_MEMTEST_END=0x08000000
+-CONFIG_ENV_ADDR=0x801C0000
++CONFIG_ENV_ADDR=0x803C0000
+ CONFIG_SF_DEFAULT_BUS=0
+ CONFIG_SF_DEFAULT_CS=0
+ CONFIG_NR_DRAM_BANKS=1
+diff --git a/include/configs/arbel.h b/include/configs/arbel.h
+index b4ebc54641..40535d5c36 100644
+--- a/include/configs/arbel.h
++++ b/include/configs/arbel.h
+@@ -37,8 +37,8 @@
+ #define SPI3_END_ADDR			0xBFFFFFFF
+ 
+ /* Default environemnt variables */
+-#define CONFIG_BOOTCOMMAND "run common_bootargs; run romboot"
+-#define CONFIG_EXTRA_ENV_SETTINGS   "uimage_flash_addr=80200000\0"   \
++#define CONFIG_BOOTCOMMAND "run emmc_bootargs; run emmcboot"
++#define CONFIG_EXTRA_ENV_SETTINGS   "uimage_flash_addr=80400000\0"   \
+ 		"stdin=serial\0"   \
+ 		"stdout=serial\0"   \
+ 		"stderr=serial\0"    \
+@@ -59,6 +59,12 @@
+ 		"console=ttyS0,115200n8\0" \
+ 		"common_bootargs=setenv bootargs earlycon=${earlycon} root=/dev/ram " \
+ 		"console=${console} mem=${mem} ramdisk_size=48000 oops=panic panic=20\0" \
++		"emmc_bootargs=setenv bootargs earlycon=${earlycon} console=${console} " \
++		"rootwait root=PARTLABEL=rofs-a\0" \
++		"emmcboot=echo Booting Kernel from eMMC; echo Using bootargs: ${bootargs};" \
++		"setenv loadaddr 0x10000000; setenv bootpart 2; " \
++		"ext4load mmc 0:${bootpart} ${loadaddr} fitImage && bootm; " \
++		"echo Error loading kernel FIT image\0" \
+ 		"ftp_prog=setenv ethact eth${eth_num}; dhcp; tftp 10000000 image-bmc; cp.b 10000000 80000000 ${filesize}\0"   \
+ 		"ftp_run=setenv ethact eth${eth_num}; dhcp; tftp 10000000 image-bmc; bootm 10200000\0"   \
+ 		"usb_prog=usb start; fatload usb 0 10000000 image-bmc; cp.b 10000000 80000000 ${filesize}\0"    \

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton_%.bbappend
@@ -10,5 +10,6 @@ SRC_URI:append:scm-npcm845 = " file://0004-net-designware-do-phy_config-before-s
 SRC_URI:append:scm-npcm845 = " file://0005-net-phy-realtek-rtl8211f-introduce-phy_reset.patch"
 SRC_URI:append:scm-npcm845 = " file://0006-set-clock-divisor-for-uart456.patch"
 SRC_URI:append:scm-npcm845 = " file://0007-set-fiu0-drd_cfg-4-byte-addr.patch"
+SRC_URI:append:scm-npcm845 = " file://0008-uboot-env-fixed-offset-update.patch"
 SRC_URI:append:scm-npcm845 = " \
 	${@emmc_enabled(d, 'file://1111-boot-openbmc-form-emmc.patch')}"

--- a/meta-phosphor/classes/image_types_phosphor_nuvoton_npcm8xx.bbclass
+++ b/meta-phosphor/classes/image_types_phosphor_nuvoton_npcm8xx.bbclass
@@ -9,6 +9,7 @@ KMT_TIPFW_BB_BL31_TEE_BINARY = "Kmt_TipFw_BootBlock_BL31_Tee.bin"
 KMT_TIPFW_BB_UBOOT_BINARY = "u-boot.bin.merged"
 FULL_SUFFIX = "full"
 MERGED_SUFFIX = "merged"
+UBOOT_SUFFIX:append = ".${MERGED_SUFFIX}"
 
 IGPS_DIR = "${STAGING_DIR_NATIVE}/${datadir}/npcm8xx-igps"
 inherit logging
@@ -98,6 +99,7 @@ prepare_secureos = "${@ "arm-trusted-firmware:do_deploy optee-os:do_deploy" if b
 do_prepare_bootloaders[depends] += " \
     npcm8xx-tip-fw:do_deploy \
     npcm8xx-bootblock:do_deploy \
+    u-boot-nuvoton:do_deploy \
     ${prepare_secureos} \
     npcm7xx-bingo-native:do_populate_sysroot \
     npcm8xx-igps-native:do_populate_sysroot \


### PR DESCRIPTION
We can use fixed U-Boot environment offset after update SPI flash layout. The fixed environment offset can make Openbmc feature work.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
