### PR TITLE
meta-nuvoton: npcm8xx: change inherit to IMAGE_CLASSES

### DIFF
--- a/meta-phosphor/classes/image_types_phosphor_nuvoton_npcm8xx.bbclass
+++ b/meta-phosphor/classes/image_types_phosphor_nuvoton_npcm8xx.bbclass
@@ -12,7 +12,8 @@ MERGED_SUFFIX = "merged"
 UBOOT_SUFFIX:append = ".${MERGED_SUFFIX}"
 
 IGPS_DIR = "${STAGING_DIR_NATIVE}/${datadir}/npcm8xx-igps"
-inherit logging
+
+IMAGE_CLASSES += "logging"
 
 # Prepare the Bootblock and U-Boot images using npcm8xx-bingo
 do_prepare_bootloaders() {


### PR DESCRIPTION
In https://gerrit.openbmc.org/c/openbmc/openbmc/+/56708,
logging.bbclass was moved from `classes` to `classes-global`.

Refer to:
https://github.com/openembedded/bitbake/commit/f33ce7e742f46635658c400b82558cf822690b5e

Signed-off-by: Anthony <anthonyhkf@google.com>