### PR TITLE
meta-nuvoton: npcm8xx: add no-warn-rwx-segments

### DIFF
--- a/meta-nuvoton/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware.inc
+++ b/meta-nuvoton/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware.inc
@@ -33,6 +33,8 @@ LDFLAGS[unexport] = "1"
 AS[unexport] = "1"
 LD[unexport] = "1"
 
+EXTRA_OEMAKE = "LDFLAGS='--no-warn-rwx-segments'"
+
 do_configure() {
 	oe_runmake clean -C ${S} PLAT=${PLATFORM}
 }

--- a/meta-nuvoton/recipes-security/optee/optee-os.bb
+++ b/meta-nuvoton/recipes-security/optee/optee-os.bb
@@ -33,7 +33,7 @@ EXTRA_OEMAKE = "PLATFORM=${OPTEEMACHINE} CFG_ARM64_core=y \
                 CROSS_COMPILE_ta_arm64=${HOST_PREFIX} \
                 NOWERROR=1 \
                 ta-targets=ta_arm64 \
-                LDFLAGS= \
+                LDFLAGS='--no-warn-rwx-segments' \
                 LIBGCC_LOCATE_CFLAGS=--sysroot=${STAGING_DIR_HOST} \
         "
 


### PR DESCRIPTION
Similar fix is added in https://github.com/OP-TEE/optee_os/pull/5474

Due to the changes in binutils, when there is any warning during the linking,
it would be treated as a fatal error, breaking the compilation.

Signed-off-by: Anthony <anthonyhkf@google.com>