### PR TITLE
meta-scm-npcm845: Add BMC health utilization SEL

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/files/0001-change-the-cpu-sensor-name-from-CPU-to-CPU_Utilizati.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/files/0001-change-the-cpu-sensor-name-from-CPU-to-CPU_Utilizati.patch
@@ -1,26 +1,31 @@
-From 0c66a7f348692507b5e4e0683a557c768fca1f67 Mon Sep 17 00:00:00 2001
+From c0ac6d275cc7322047ad22d26b85fbea0d41ccab Mon Sep 17 00:00:00 2001
 From: Joseph Liu <kwliu@nuvoton.com>
 Date: Tue, 12 Jul 2022 15:17:49 +0800
 Subject: [PATCH] change the cpu sensor name from CPU to CPU_Utilization
 
 Signed-off-by: Joseph Liu <kwliu@nuvoton.com>
 ---
- healthMonitor.cpp | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ healthMonitor.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/healthMonitor.cpp b/healthMonitor.cpp
-index be62c3a..9d56e1d 100644
+index aaa27ee..9a92b58 100644
 --- a/healthMonitor.cpp
 +++ b/healthMonitor.cpp
-@@ -235,7 +235,7 @@ constexpr auto storage = "Storage";
- constexpr auto inode = "Inode";
- /** Map of read function for each health sensors supported */
- const std::map<std::string, std::function<double(std::string path)>>
--    readSensors = {{"CPU", readCPUUtilization},
-+    readSensors = {{"CPU_Utilization", readCPUUtilization},
-                    {"Memory", readMemoryUtilization},
-                    {storage, readStorageUtilization},
-                    {inode, readInodeUtilization}};
+@@ -481,11 +481,12 @@ void printConfig(HealthConfig& cfg)
+ }
+ 
+ /* Create dbus utilization sensor object for each configured sensors */
++constexpr auto util_path = "_Utilization";
+ void HealthMon::createHealthSensors(const std::vector<std::string>& chassisIds)
+ {
+     for (auto& cfg : sensorConfigs)
+     {
+-        std::string objPath = std::string(HEALTH_SENSOR_PATH) + cfg.name;
++        std::string objPath = std::string(HEALTH_SENSOR_PATH) + cfg.name + util_path;
+         auto healthSensor = std::make_shared<HealthSensor>(bus, objPath.c_str(),
+                                                            cfg, chassisIds);
+         healthSensors.emplace(cfg.name, healthSensor);
 -- 
-2.34.1
+2.17.1
 

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/files/0002-Add-support-health-SEL-service.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/files/0002-Add-support-health-SEL-service.patch
@@ -1,0 +1,89 @@
+From b2cee74741050926f7381d0b94fea9e996cf5b24 Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Fri, 30 Sep 2022 15:31:58 +0800
+Subject: [PATCH] Add support health SEL service
+
+---
+ healthMonitor.cpp | 35 ++++++++++++++++++++++++++++++++++-
+ healthMonitor.hpp |  2 ++
+ 2 files changed, 36 insertions(+), 1 deletion(-)
+
+diff --git a/healthMonitor.cpp b/healthMonitor.cpp
+index 9a92b58..49a9207 100644
+--- a/healthMonitor.cpp
++++ b/healthMonitor.cpp
+@@ -336,7 +336,7 @@ void HealthSensor::checkSensorThreshold(const double value)
+                 error(
+                     "ASSERT: sensor {SENSOR} is above the upper threshold warning high",
+                     "SENSOR", sensorConfig.name);
+-                startUnit(sensorConfig.warningTgt);
++                startUnit(getUnitInfo(sensorConfig.warningTgt, true));
+             }
+         }
+         return;
+@@ -346,9 +346,12 @@ void HealthSensor::checkSensorThreshold(const double value)
+     {
+         WarningInterface::warningAlarmHigh(false);
+         if (sensorConfig.warningLog)
++        {
+             info(
+                 "DEASSERT: sensor {SENSOR} is under the upper threshold warning high",
+                 "SENSOR", sensorConfig.name);
++            startUnit(getUnitInfo(sensorConfig.warningTgt, false));
++        }
+     }
+ }
+ 
+@@ -416,6 +419,36 @@ void HealthSensor::startUnit(const std::string& sysdUnit)
+     bus.call_noreply(msg);
+ }
+ 
++std::string HealthSensor::getUnitInfo(const std::string& sysdUnit, bool asserted)
++{
++    // Only handle service can set info and
++    // do nothing for deassert case for normal unit
++    size_t index = sysdUnit.find('@');
++    if (index == std::string::npos)
++        return asserted ? sysdUnit : "";
++
++    // Get service name with @
++    std::string service = sysdUnit.substr(0, index + 1);
++
++    // Get alarm event information string
++    std::string boolstr =  asserted ? "true" : "false";
++    char event[32] = {0};
++    int rc = sprintf(event, "%s_%s_%.0f", sensorConfig.name.c_str(),
++                     boolstr.c_str(), ValueIface::value());
++    if (rc <= 0)
++    {
++        error("Cannot generate service infomation: {SENSOR}", "SENSOR",
++              sensorConfig.name);
++        return "";
++    }
++    if (DEBUG)
++    {
++        info("unit event: {INFO}", "INFO", std::string(event));
++    }
++
++    return service + std::string(event) + ".service";
++}
++
+ void HealthMon::recreateSensors()
+ {
+     PHOSPHOR_LOG2_USING;
+diff --git a/healthMonitor.hpp b/healthMonitor.hpp
+index b86563e..dba9a85 100644
+--- a/healthMonitor.hpp
++++ b/healthMonitor.hpp
+@@ -126,6 +126,8 @@ class HealthSensor : public healthIfaces
+     void readHealthSensor();
+     /** @brief Start configured threshold systemd unit */
+     void startUnit(const std::string& sysdUnit);
++    /** @brief Get sensor infomation for set SEL */
++    std::string getUnitInfo(const std::string& sysdUnit, bool asserted);
+ };
+ 
+ class HealthMon
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/files/bmc_health_config.json
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/files/bmc_health_config.json
@@ -1,20 +1,27 @@
 {
-  "CPU_Utilization" : {
+  "CPU" : {
     "Frequency" : 1,
     "Window_size": 120,
     "Threshold":
     {
-        "Critical":
-        {
-            "Value": 90.0,
-            "Log": true,
-            "Target": "reboot.target"
-        },
         "Warning":
         {
-          "Value": 80.0,
-          "Log": false,
-          "Target": "systemd unit file"
+          "Value": 70.0,
+          "Log": true,
+          "Target": "utilization-health-sel@.service"
+        }
+    }
+  },
+  "Memory" : {
+    "Frequency" : 1,
+    "Window_size": 120,
+    "Threshold":
+    {
+        "Warning":
+        {
+          "Value": 70.0,
+          "Log": true,
+          "Target": "utilization-health-sel@.service"
         }
     }
   }

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/files/utilization-health-sel.sh
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/files/utilization-health-sel.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# input string should be like: CPU_true_90 or MEMORY_false_50
+if [ -z "$1" ]; then
+  echo "invalid information for utilization"
+  exit 1
+fi
+
+
+# get utilization type
+util="${1%%_*}"
+un=255 # 0xff invalid event data
+if [ "$util" = "CPU" ]; then
+  #0xA6
+  un=166
+elif [ "$util" = "Memory" ]; then
+  #0xA7
+  un=167
+fi
+params="${1#*_}"
+
+# get assert/de-assert
+assert_m=assert
+assert="${params%%_*}"
+if [ "$assert" != "true" ]; then
+  assert_m=deassert
+fi
+params="${params#*_}"
+
+# get usage
+usage="${params%%_*}"
+
+# get ipmid memory usage
+ipmid_mem=0 # do not set value when set CPU health SEL
+if [ "$util" = "Memory" ]; then
+  data=`top -n 1 |grep ipmid$` # get mem info like: 432 1 root S 16816 4% 0 0% ipmid
+  data="${data%%%*}" # remove info after mem usage(right of %): 432 1 root S 16816 4
+  ipmid_mem="${data##* }" # remove data left of space
+fi
+
+# IpmiSelAdd format ssaybq
+# - message
+# - object path
+# - array length, fixed 3
+# - array data (event data 1~3)
+# - assert (as true, de-assert as false)
+# - generator ID
+
+# write SEL
+busctl call `mapper get-service /xyz/openbmc_project/Logging/IPMI` /xyz/openbmc_project/Logging/IPMI xyz.openbmc_project.Logging.IPMI IpmiSelAdd ssaybq "OEM BMC health utilization ${assert_m}" "/xyz/openbmc_project/sensors/oem_health/utilization" 3 ${un} ${usage} ${ipmid_mem} ${assert} 0x2000
+
+# DEBUG print
+echo "type: ${util}, code: ${un}, assert: ${assert}, usage: ${usage}, ipmi mem usage: ${ipmid_mem}"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/files/utilization-health-sel@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/files/utilization-health-sel@.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=BMC health CPU/Memory utilization SEL add service
+Requires=xyz.openbmc_project.Logging.IPMI.service
+Wants=mapper-wait@-xyz-openbmc_project-Logging-IPMI.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Restart=no
+ExecStart=/bin/bash /usr/bin/utilization-health-sel.sh %I

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/phosphor-health-monitor_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/phosphor-health-monitor_%.bbappend
@@ -1,11 +1,20 @@
 FILESEXTRAPATHS:prepend:scm-npcm845  := "${THISDIR}/files:"
 
+inherit obmc-phosphor-systemd
+RDEPENDS:${PN}:append:scm-npcm845 = "bash"
 SRC_URI:append:scm-npcm845 = " file://bmc_health_config.json"
 SRC_URI:append:scm-npcm845 = " file://0001-change-the-cpu-sensor-name-from-CPU-to-CPU_Utilizati.patch"
-
-SRCREV:scm-npcm845 = "f8d797372088ec0a9b2356de21496b0bc7fce95d"
+SRC_URI:append:scm-npcm845 = " \
+  file://utilization-health-sel.sh \
+  file://utilization-health-sel@.service \
+  file://0002-Add-support-health-SEL-service.patch \
+"
+FILES:${PN}:append:scm-npcm845 = " ${systemd_system_unitdir}/utilization-health-sel@.service"
+SRCREV:scm-npcm845 = "b7d7bd5a384ea501766b15e4613eb9b14fe71e7f"
 
 do_install:append:scm-npcm845() {
     install -d ${D}/${sysconfdir}/healthMon/
     install -m 0644 ${WORKDIR}/bmc_health_config.json ${D}/${sysconfdir}/healthMon/
+    install -D -m 0644 ${WORKDIR}/utilization-health-sel@.service ${D}${systemd_system_unitdir}
+    install -D -m 0755 ${WORKDIR}/utilization-health-sel.sh ${D}/${bindir}/utilization-health-sel.sh
 }


### PR DESCRIPTION
Write SEL when BMC CPU/Memory utilization large then 70%, and also write SEL once the event de-asserted.

Update the health monitor to support start service unit feature.
Update sensor dbus name instead of change sensor name directly.
Add utils service and script to support start a service to write SEL.
Update configuration file to match spec.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
