### PR TITLE
meta-scm-npcm845: Add BMC health SEL rollover

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-extended/rsyslog/rsyslog/bmc-health-sel-rollover.sh
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-extended/rsyslog/rsyslog/bmc-health-sel-rollover.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+# get and increase rollover count script
+
+# handle rollover count first
+SEL_FILE="/var/log/ipmi_sel_rollover"
+num=0
+if [ ! -f ${SEL_FILE} ]; then
+  num=1
+else
+  num=$(expr `cat ${SEL_FILE}` + 1)
+fi
+echo ${num} > ${SEL_FILE}
+
+# write SEL rollover
+busctl call `mapper get-service /xyz/openbmc_project/Logging/IPMI` /xyz/openbmc_project/Logging/IPMI xyz.openbmc_project.Logging.IPMI IpmiSelAdd ssaybq "OEM BMC health SEL rollover" "/xyz/openbmc_project/sensors/oem_health/sel_rollover" 3 171 ${num} 0 true 0x2000

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-extended/rsyslog/rsyslog/rsyslog.logrotate
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-extended/rsyslog/rsyslog/rsyslog.logrotate
@@ -8,6 +8,7 @@
     missingok
     postrotate
         systemctl reload rsyslog 2> /dev/null || true
+        /bin/sh /usr/bin/bmc-health-sel-rollover.sh
     endscript
 }
 # Keep up to four 64k files for redfish (256k total)

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-extended/rsyslog/rsyslog_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-extended/rsyslog/rsyslog_%.bbappend
@@ -7,6 +7,8 @@ SRC_URI += "file://rsyslog.conf \
            file://rsyslog-override.conf \
 "
 
+SRC_URI:append:scm-npcm845 = " file://bmc-health-sel-rollover.sh"
+
 FILES:${PN} += "${systemd_system_unitdir}/rsyslog.service.d/rsyslog-override.conf"
 
 PACKAGECONFIG:append = " imjournal"
@@ -18,6 +20,8 @@ do_install:append() {
                         ${D}${systemd_system_unitdir}/rsyslog.service.d/rsyslog-override.conf
         install -d ${D}${bindir}
         install -m 0755 ${WORKDIR}/rotate-event-logs.sh ${D}/${bindir}/rotate-event-logs.sh
+
+        install -m 0755 ${WORKDIR}/bmc-health-sel-rollover.sh ${D}${bindir}/bmc-health-sel-rollover.sh
 }
 
 SYSTEMD_SERVICE:${PN} += " rotate-event-logs.service"


### PR DESCRIPTION
Add a script write SEL rollover when SEL log rotate.

Test:
root@scm-npcm845:~# dd if=/dev/zero of=/var/log/ipmi_sel bs=1024 count=64
root@scm-npcm845:~# journalctl -n 10
...
Jan 08 18:47:12 scm-npcm845 systemd[1]: Reloaded System Logging Service.
Jan 08 18:47:12 scm-npcm845 sel-logger[664]: OEM BMC health SEL rollover
Jan 08 18:47:12 scm-npcm845 rotate-event-logs.sh[960]: q 6

root@scm-npcm845:~# cat /var/log/ipmi_sel
2000-01-08T18:47:12.280447+00:00 6,2,AB0500,2000,/xyz/openbmc_project/sensors/oem_health/sel_rollover,1

Signed-off-by: Brian_Ma <chma0@nuvoton.com>

