### PR TITLE
Nuvoton: prepare_bootloaders: move Bootblock align

### DIFF
--- a/meta-phosphor/classes/image_types_phosphor_nuvoton_npcm8xx.bbclass
+++ b/meta-phosphor/classes/image_types_phosphor_nuvoton_npcm8xx.bbclass
@@ -63,7 +63,7 @@ python do_merge_bootloaders() {
     Merge_bin_files_and_pad(os.path.join(d.getVar('DEPLOY_DIR_IMAGE', True), '%s' % d.getVar('KMT_TIPFW_BINARY',True)),
         os.path.join(d.getVar('DEPLOY_DIR_IMAGE', True), '%s' % d.getVar('BOOTBLOCK',True)),
         os.path.join(d.getVar('DEPLOY_DIR_IMAGE', True), '%s' % d.getVar('KMT_TIPFW_BB_BINARY',True)),
-        0x1000, 0x20)
+        0x80000, 0x20)
 
     Merge_bin_files_and_pad(os.path.join(d.getVar('DEPLOY_DIR_IMAGE', True), '%s' % d.getVar('KMT_TIPFW_BB_BINARY',True)),
         os.path.join(d.getVar('DEPLOY_DIR_IMAGE', True), '%s' % d.getVar('ATF_BINARY',True)),


### PR DESCRIPTION
Move Bootblock align to 0x80000.

Signed-off-by: Brian_Ma <chma0@nuvoton.com>
