### PR TITLE
meta-scm-npcm845: update dbus sensor patches

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/dbus/phosphor-dbus-interfaces/0024-Add-the-pre-timeout-interrupt-defined-in-IPMI-spec.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/dbus/phosphor-dbus-interfaces/0024-Add-the-pre-timeout-interrupt-defined-in-IPMI-spec.patch
@@ -1,0 +1,57 @@
+From cf396e70f5d29a625bcfc10355a301c5e1ea4e14 Mon Sep 17 00:00:00 2001
+From: Ren Yu <yux.ren@intel.com>
+Date: Fri, 24 May 2019 14:55:10 +0800
+Subject: [PATCH] Add the pre-timeout interrupt defined in IPMI spec
+
+The IPMI watchdog pre-timeout interrupt is used to set the different
+pre-timeout interrupt source. Add them as a dbus property,
+IPMI set/get watchdog commands will use it.
+
+Signed-off-by: Ren Yu <yux.ren@intel.com>
+---
+ .../State/Watchdog.interface.yaml             | 22 +++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/yaml/xyz/openbmc_project/State/Watchdog.interface.yaml b/yaml/xyz/openbmc_project/State/Watchdog.interface.yaml
+index 7f79c7c8..d8075646 100644
+--- a/yaml/xyz/openbmc_project/State/Watchdog.interface.yaml
++++ b/yaml/xyz/openbmc_project/State/Watchdog.interface.yaml
+@@ -33,6 +33,11 @@ properties:
+       description: >
+           The action the watchdog should perform when it expires.
+       default: "HardReset"
++    - name: PreTimeoutInterrupt
++      type: enum[self.PreTimeoutInterruptAction]
++      description: >
++          The BMC generates the selected interrupt before the timer expires.
++      default: 'None'
+     - name: Interval
+       type: uint64
+       description: >
+@@ -73,6 +78,23 @@ enumerations:
+             description: >
+                 Perform a power cycle of the system.
+ 
++    - name: PreTimeoutInterruptAction
++      description: >
++        The type of PreTimeout Interrupt.
++      values:
++          - name: 'None'
++            description: >
++                Do nothing.
++          - name: 'SMI'
++            description: >
++                SMI.
++          - name: 'NMI'
++            description: >
++                NMI / Diagnostic Interrupt.
++          - name: 'MI'
++            description: >
++                Messaging Interrupt.
++
+     - name: TimerUse
+       description: >
+           The type of timer use.
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/dbus/phosphor-dbus-interfaces/0025-Add-PreInterruptFlag-properity-in-DBUS.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/dbus/phosphor-dbus-interfaces/0025-Add-PreInterruptFlag-properity-in-DBUS.patch
@@ -1,0 +1,39 @@
+From 727c272eb37709e07b32dd796cc09280d9534069 Mon Sep 17 00:00:00 2001
+From: Ren Yu <yux.ren@intel.com>
+Date: Mon, 29 Jul 2019 10:51:12 +0800
+Subject: [PATCH] Add PreInterruptFlag properity in DBUS.
+
+PreTimeoutInterruptOccurFlag in DBUS would be set 'true'
+when watchdog pre-timeout interrupt occurred.
+
+Tested:
+Enable command(raw 0x06 0x31) that get message flag
+can set right bit about watchdog,
+need record PreTimeoutInterruptOccurFlag
+at xyz.openbmmc_project.State.Watchdog when watchdog
+pre-timeout interrupt occurred.
+
+Signed-off-by: Ren Yu <yux.ren@intel.com>
+---
+ yaml/xyz/openbmc_project/State/Watchdog.interface.yaml | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/yaml/xyz/openbmc_project/State/Watchdog.interface.yaml b/yaml/xyz/openbmc_project/State/Watchdog.interface.yaml
+index d8075646..7d3206f3 100644
+--- a/yaml/xyz/openbmc_project/State/Watchdog.interface.yaml
++++ b/yaml/xyz/openbmc_project/State/Watchdog.interface.yaml
+@@ -59,6 +59,11 @@ properties:
+       description: >
+           The timer user at the time of expiration.
+       default: "Reserved"
++    - name: PreTimeoutInterruptOccurFlag
++      type: boolean
++      description: >
++          PreTimeoutInterruptOccurFlag that preTimeoutInterrupt action occurred.
++      default: false
+ 
+ enumerations:
+     - name: Action
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/dbus/phosphor-dbus-interfaces_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/dbus/phosphor-dbus-interfaces_%.bbappend
@@ -1,3 +1,6 @@
 FILESEXTRAPATHS:prepend:scm-npcm845 := "${THISDIR}/${PN}:"
 
-SRC_URI:append:scm-npcm845 = " file://0001-update-NMISource-interface-from-intel-dbus-interface.patch"
+SRC_URI:append:scm-npcm845 = " \
+    file://0024-Add-the-pre-timeout-interrupt-defined-in-IPMI-spec.patch \
+    file://0025-Add-PreInterruptFlag-properity-in-DBUS.patch \
+"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config.bbappend
@@ -4,10 +4,22 @@ inherit image_version
 
 SRC_URI:append:scm-npcm845 = " file://channel_config.json"
 SRC_URI:append:scm-npcm845 = " file://dev_id.json"
+SRC_URI:append:scm-npcm845 = " file://fw.json"
+SRC_URI:append:scm-npcm845 = " file://system_guid.json"
+SRC_URI:append:scm-npcm845 = " file://power_reading.json"
+
+FILES:${PN}:append:scm-npcm845 = " ${datadir}/ipmi-providers/fw.json"
+FILES:${PN}:append:scm-npcm845 = " ${datadir}/ipmi-providers/system_guid.json"
 
 do_install:append:scm-npcm845() {
     install -m 0644 -D ${WORKDIR}/channel_config.json \
         ${D}${datadir}/ipmi-providers/channel_config.json
     install -m 0644 -D ${WORKDIR}/dev_id.json \
         ${D}${datadir}/ipmi-providers/dev_id.json
+    install -m 0644 -D ${WORKDIR}/fw.json \
+        ${D}${datadir}/ipmi-providers/fw.json
+    install -m 0644 -D ${WORKDIR}/system_guid.json \
+        ${D}${datadir}/ipmi-providers/system_guid.json
+    install -m 0644 -D ${WORKDIR}/power_reading.json \
+        ${D}${datadir}/ipmi-providers/power_reading.json
 }

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config/dev_id.json
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config/dev_id.json
@@ -1,2 +1,2 @@
-{"id": 0, "revision": 1, "addn_dev_support": 141,
-    "manuf_id": 0, "prod_id": 1, "aux": 0}
+{"id": 32, "revision": 1, "addn_dev_support": 191,
+    "manuf_id": 40092, "prod_id": 0, "aux": 0}

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config/fw.json
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config/fw.json
@@ -1,0 +1,32 @@
+{
+  "PSU": {
+    "bus": "7",
+    "address": "0x58"
+  },
+  "CPLD": {
+    "bus": "5",
+    "address": "0x40",
+    "write_length": 4,
+    "read_lngth": 4,
+    "//": "[0xc0, 0x0, 0x0, 0x0]",
+    "command": [
+      192,
+      0,
+      0,
+      0
+    ]
+  },
+  "DC-SCM CPLD": {
+    "bus": "19",
+    "address": "0x40",
+    "write_length": 4,
+    "read_lngth": 4,
+    "//": "[0xc0, 0x0, 0x0, 0x0]",
+    "command": [
+      192,
+      0,
+      0,
+      0
+    ]
+  }
+}

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config/power_reading.json
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config/power_reading.json
@@ -1,0 +1,3 @@
+{
+  "path": "/xyz/openbmc_project/sensors/power/HSC0_Input_Power"
+}

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config/system_guid.json
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config/system_guid.json
@@ -1,0 +1,1 @@
+{"system_uuid": "ed5a61af-53b5-47f7-ae91-99c4267278df" }

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0001-add-TMP100-support.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0001-add-TMP100-support.patch
@@ -1,0 +1,25 @@
+From 28dd66e5b49dff037534de5f0e88624a49ff3adb Mon Sep 17 00:00:00 2001
+From: Stanley Chu <yschu@nuvoton.com>
+Date: Mon, 15 Aug 2022 14:15:09 +0800
+Subject: [PATCH 1/8] add TMP100 support
+
+Signed-off-by: Stanley Chu <yschu@nuvoton.com>
+---
+ src/HwmonTempMain.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/HwmonTempMain.cpp b/src/HwmonTempMain.cpp
+index 9ebdfcdf..0b8cfa69 100644
+--- a/src/HwmonTempMain.cpp
++++ b/src/HwmonTempMain.cpp
+@@ -67,6 +67,7 @@ static const I2CDeviceTypeMap sensorTypes{
+     {"NCT7802", I2CDeviceType{"nct7802", true}},
+     {"SBTSI", I2CDeviceType{"sbtsi", true}},
+     {"SI7020", I2CDeviceType{"si7020", false}},
++    {"TMP100", I2CDeviceType{"tmp100", true}},
+     {"TMP112", I2CDeviceType{"tmp112", true}},
+     {"TMP175", I2CDeviceType{"tmp175", true}},
+     {"TMP421", I2CDeviceType{"tmp421", true}},
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0002-psu-sensor-add-fan3-support.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0002-psu-sensor-add-fan3-support.patch
@@ -1,0 +1,40 @@
+From abab7c5040adbed268707a7161e22eeb6458689e Mon Sep 17 00:00:00 2001
+From: Joseph Liu <kwliu@nuvoton.com>
+Date: Fri, 24 Jun 2022 18:36:29 +0800
+Subject: [PATCH 2/8] psu sensor: add fan3 support
+
+Signed-off-by: Joseph Liu <kwliu@nuvoton.com>
+---
+ src/PSUSensorMain.cpp | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/src/PSUSensorMain.cpp b/src/PSUSensorMain.cpp
+index 918b9c6c..2851564c 100644
+--- a/src/PSUSensorMain.cpp
++++ b/src/PSUSensorMain.cpp
+@@ -1020,9 +1020,10 @@ void propertyInitialize(void)
+         {"temp6", PSUProperty("Temperature", 127, -128, 3, 0)},
+         {"maxtemp1", PSUProperty("Max Temperature", 127, -128, 3, 0)},
+         {"fan1", PSUProperty("Fan Speed 1", 30000, 0, 0, 0)},
+-        {"fan2", PSUProperty("Fan Speed 2", 30000, 0, 0, 0)}};
++        {"fan2", PSUProperty("Fan Speed 2", 30000, 0, 0, 0)},
++        {"fan3", PSUProperty("Fan Speed 3", 30000, 0, 0, 0)}};
+ 
+-    pwmTable = {{"fan1", "Fan_1"}, {"fan2", "Fan_2"}};
++    pwmTable = {{"fan1", "1"}};
+ 
+     limitEventMatch = {{"PredictiveFailure", {"max_alarm", "min_alarm"}},
+                        {"Failure", {"crit_alarm", "lcrit_alarm"}}};
+@@ -1034,7 +1035,8 @@ void propertyInitialize(void)
+ 
+     groupEventMatch = {{"FanFault",
+                         {{"fan1", {"fan1_alarm", "fan1_fault"}},
+-                         {"fan2", {"fan2_alarm", "fan2_fault"}}}}};
++                         {"fan2", {"fan2_alarm", "fan2_fault"}},
++                         {"fan3", {"fan3_alarm", "fan3_fault"}}}}};
+ }
+ 
+ int main()
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0003-psu-sensor-support-p2011-psu.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0003-psu-sensor-support-p2011-psu.patch
@@ -1,0 +1,36 @@
+From 56fc5d6f66726f0318798e50e34c150beb030e8f Mon Sep 17 00:00:00 2001
+From: Stanley Chu <yschu@nuvoton.com>
+Date: Mon, 15 Aug 2022 14:24:40 +0800
+Subject: [PATCH 3/8] psu sensor: support p2011 psu
+
+Signed-off-by: Stanley Chu <yschu@nuvoton.com>
+---
+ src/PSUSensorMain.cpp | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/PSUSensorMain.cpp b/src/PSUSensorMain.cpp
+index 2851564c..21a777dc 100644
+--- a/src/PSUSensorMain.cpp
++++ b/src/PSUSensorMain.cpp
+@@ -47,7 +47,7 @@ static constexpr auto sensorTypes{std::to_array<const char*>(
+      "MAX20730",  "MAX20734",  "MAX20796",  "MAX34451",  "MP2971",
+      "MP2973",    "MP5023",    "pmbus",     "PXE1610",   "RAA228000",
+      "RAA228228", "RAA228620", "RAA229001", "RAA229004", "RAA229126",
+-     "TPS546D24", "XDPE12284"})};
++     "TPS546D24", "XDPE12284", "p2011"})};
+ 
+ // clang-format off
+ static constexpr auto pmbusNames{std::to_array<const char*>({
+@@ -87,7 +87,8 @@ static constexpr auto pmbusNames{std::to_array<const char*>({
+     "raa229004",
+     "raa229126",
+     "tps546d24",
+-    "xdpe12284"
++    "xdpe12284",
++    "p2011"
+ })};
+ //clang-format on
+ 
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0004-add-NIC-temp-sensor.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0004-add-NIC-temp-sensor.patch
@@ -1,0 +1,207 @@
+From fad9634567f027ccf6c52b7ee04667d3de744256 Mon Sep 17 00:00:00 2001
+From: Stanley Chu <yschu@nuvoton.com>
+Date: Mon, 15 Aug 2022 14:42:20 +0800
+Subject: [PATCH 4/8] add NIC temp sensor
+
+Signed-off-by: Stanley Chu <yschu@nuvoton.com>
+---
+ include/MCUTempSensor.hpp |   6 +-
+ src/MCUTempSensor.cpp     | 121 ++++++++++++++++++++++++++++++++------
+ 2 files changed, 108 insertions(+), 19 deletions(-)
+
+diff --git a/include/MCUTempSensor.hpp b/include/MCUTempSensor.hpp
+index c4c2406f..46bab19a 100644
+--- a/include/MCUTempSensor.hpp
++++ b/include/MCUTempSensor.hpp
+@@ -16,7 +16,8 @@ struct MCUTempSensor : public Sensor
+                   const std::string& sensorConfiguration,
+                   sdbusplus::asio::object_server& objectServer,
+                   std::vector<thresholds::Threshold>&& thresholdData,
+-                  uint8_t busId, uint8_t mcuAddress, uint8_t tempReg);
++                  uint8_t busId, uint8_t mcuAddress, uint8_t tempReg,
++                  uint8_t tempRegWidth, uint16_t scale);
+     ~MCUTempSensor() override;
+ 
+     void checkThresholds(void) override;
+@@ -26,9 +27,12 @@ struct MCUTempSensor : public Sensor
+     uint8_t busId;
+     uint8_t mcuAddress;
+     uint8_t tempReg;
++    uint8_t tempRegWidth;
++    uint16_t scale;
+ 
+   private:
+     int getMCURegsInfoWord(uint8_t regs, int16_t* pu16data) const;
++    int getMCURegsInfoByte(uint8_t regs, uint8_t* pu8data);
+     sdbusplus::asio::object_server& objectServer;
+     boost::asio::steady_timer waitTimer;
+ };
+diff --git a/src/MCUTempSensor.cpp b/src/MCUTempSensor.cpp
+index ba68bedb..d2b2535d 100644
+--- a/src/MCUTempSensor.cpp
++++ b/src/MCUTempSensor.cpp
+@@ -52,12 +52,12 @@ MCUTempSensor::MCUTempSensor(std::shared_ptr<sdbusplus::asio::connection>& conn,
+                              sdbusplus::asio::object_server& objectServer,
+                              std::vector<thresholds::Threshold>&& thresholdData,
+                              uint8_t busId, uint8_t mcuAddress,
+-                             uint8_t tempReg) :
++                             uint8_t tempReg, uint8_t tempRegWidth, uint16_t scale) :
+     Sensor(escapeName(sensorName), std::move(thresholdData),
+            sensorConfiguration, "MCUTempSensor", false, false,
+            mcuTempMaxReading, mcuTempMinReading, conn),
+-    busId(busId), mcuAddress(mcuAddress), tempReg(tempReg),
+-    objectServer(objectServer), waitTimer(io)
++    busId(busId), mcuAddress(mcuAddress), tempReg(tempReg), tempRegWidth(tempRegWidth),
++    scale(scale), objectServer(objectServer), waitTimer(io)
+ {
+     sensorInterface = objectServer.add_interface(
+         "/xyz/openbmc_project/sensors/temperature/" + name,
+@@ -97,6 +97,55 @@ void MCUTempSensor::checkThresholds(void)
+     thresholds::checkThresholds(this);
+ }
+ 
++int MCUTempSensor::getMCURegsInfoByte(uint8_t regs, uint8_t* pu8data)
++{
++    std::string i2cBus = "/dev/i2c-" + std::to_string(busId);
++    int fd = open(i2cBus.c_str(), O_RDWR);
++    int ret;
++
++    if (fd < 0)
++    {
++        std::cerr << " unable to open i2c device" << i2cBus << "  err=" << fd
++                  << "\n";
++        return -1;
++    }
++
++    if (ioctl(fd, I2C_SLAVE_FORCE, mcuAddress) < 0)
++    {
++        std::cerr << " unable to set device address\n";
++        close(fd);
++        return -1;
++    }
++
++    unsigned long funcs = 0;
++    if (ioctl(fd, I2C_FUNCS, &funcs) < 0)
++    {
++        std::cerr << " not support I2C_FUNCS\n";
++        close(fd);
++        return -1;
++    }
++
++    if (!(funcs & I2C_FUNC_SMBUS_READ_BYTE_DATA))
++    {
++        std::cerr << " not support I2C_FUNC_SMBUS_READ_BYTE_DATA\n";
++        close(fd);
++        return -1;
++    }
++
++    ret = i2c_smbus_read_byte_data(fd, regs);
++    close(fd);
++
++    if (ret < 0)
++    {
++        std::cerr << " read word data failed at " << static_cast<int>(regs)
++                  << "\n";
++        return -1;
++    }
++    *pu8data = (uint8_t)ret;
++
++    return 0;
++}
++
+ int MCUTempSensor::getMCURegsInfoWord(uint8_t regs, int16_t* pu16data) const
+ {
+     std::string i2cBus = "/dev/i2c-" + std::to_string(busId);
+@@ -163,23 +212,46 @@ void MCUTempSensor::read(void)
+             std::cerr << "timer error\n";
+             return;
+         }
+-        int16_t temp = 0;
+-        int ret = getMCURegsInfoWord(tempReg, &temp);
+-        if (ret >= 0)
+-        {
+-            double v = static_cast<double>(temp) / 1000;
+-            if constexpr (debug)
++	if (tempRegWidth == 1)
++	{
++            uint8_t temp;
++            int ret = getMCURegsInfoByte(tempReg, &temp);
++            if (ret >= 0)
+             {
+-                std::cerr << "Value update to " << v << "raw reading "
++                double v = static_cast<double>(temp) / scale;
++                if constexpr (debug)
++                {
++                    std::cerr << "Value update to " << v << "raw reading "
+                           << static_cast<int>(temp) << "\n";
++                }
++                updateValue(v);
+             }
+-            updateValue(v);
+-        }
+-        else
+-        {
+-            std::cerr << "Invalid read getMCURegsInfoWord\n";
+-            incrementError();
+-        }
++            else
++            {
++                std::cerr << "Invalid read getMCURegsInfoByte\n";
++                incrementError();
++            }
++	}
++	else
++	{
++            int16_t temp;
++            int ret = getMCURegsInfoWord(tempReg, &temp);
++            if (ret >= 0)
++            {
++                double v = static_cast<double>(temp) / scale;
++                if constexpr (debug)
++                {
++                    std::cerr << "Value update to " << v << "raw reading "
++                          << static_cast<int>(temp) << "\n";
++                }
++                updateValue(v);
++            }
++            else
++            {
++                std::cerr << "Invalid read getMCURegsInfoWord\n";
++                incrementError();
++            }
++	}
+         read();
+     });
+ }
+@@ -224,6 +296,18 @@ void createSensors(
+                 uint8_t busId = loadVariant<uint8_t>(cfg, "Bus");
+                 uint8_t mcuAddress = loadVariant<uint8_t>(cfg, "Address");
+                 uint8_t tempReg = loadVariant<uint8_t>(cfg, "Reg");
++                uint8_t tempRegWidth = 2;
++                uint16_t scale = 1000;
++                auto findType1 = cfg.find("RegWidth");
++                if (findType1 != cfg.end())
++                {
++                    tempRegWidth = loadVariant<uint8_t>(cfg, "RegWidth");
++                }
++                auto findType2 = cfg.find("Scale");
++                if (findType2 != cfg.end())
++                {
++                    scale = loadVariant<uint16_t>(cfg, "Scale");
++                }
+ 
+                 std::string sensorClass =
+                     loadVariant<std::string>(cfg, "Class");
+@@ -244,7 +328,8 @@ void createSensors(
+ 
+                 sensor = std::make_unique<MCUTempSensor>(
+                     dbusConnection, io, name, path, objectServer,
+-                    std::move(sensorThresholds), busId, mcuAddress, tempReg);
++                    std::move(sensorThresholds), busId, mcuAddress, tempReg,
++                    tempRegWidth, scale);
+ 
+                 sensor->init();
+             }
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0005-increase-adc-max-reading.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0005-increase-adc-max-reading.patch
@@ -1,0 +1,26 @@
+From 8b7c4cbbee268dd8c44041b9972e8fad376100e2 Mon Sep 17 00:00:00 2001
+From: Stanley Chu <yschu@nuvoton.com>
+Date: Mon, 15 Aug 2022 14:46:11 +0800
+Subject: [PATCH 5/8] increase adc max reading
+
+Signed-off-by: Stanley Chu <yschu@nuvoton.com>
+---
+ src/ADCSensor.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ADCSensor.cpp b/src/ADCSensor.cpp
+index fe2c8a79..e7e0942a 100644
+--- a/src/ADCSensor.cpp
++++ b/src/ADCSensor.cpp
+@@ -35,7 +35,7 @@
+ static constexpr unsigned int sensorScaleFactor = 1000;
+ 
+ static constexpr double roundFactor = 10000;     // 3 decimal places
+-static constexpr double maxVoltageReading = 1.8; // pre sensor scaling
++static constexpr double maxVoltageReading = 2.0; // pre sensor scaling
+ static constexpr double minVoltageReading = 0;
+ 
+ ADCSensor::ADCSensor(const std::string& path,
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0006-change-PSU-sensor-name-to-meet-customer-requirement.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0006-change-PSU-sensor-name-to-meet-customer-requirement.patch
@@ -1,0 +1,25 @@
+From a725add51c780ec04f9483eed544bee4b3850e64 Mon Sep 17 00:00:00 2001
+From: Stanley Chu <yschu@nuvoton.com>
+Date: Mon, 15 Aug 2022 14:53:06 +0800
+Subject: [PATCH 6/8] change PSU sensor name to meet customer requirement
+
+Signed-off-by: Stanley Chu <yschu@nuvoton.com>
+---
+ src/PSUSensorMain.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/PSUSensorMain.cpp b/src/PSUSensorMain.cpp
+index 21a777dc..4f8fab0a 100644
+--- a/src/PSUSensorMain.cpp
++++ b/src/PSUSensorMain.cpp
+@@ -263,6 +263,7 @@ static void
+         name += psuName;
+         name += "_";
+         name += pwmName;
++	name = psuName + "_PWM_" + pwmName; // change PSU sensor name
+ 
+         std::string objPath = interfacePath;
+         objPath += "_";
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0006-change-psu-sensor-name.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0006-change-psu-sensor-name.patch
@@ -1,0 +1,25 @@
+From d5e10eba40176ba5e81e573057782cea271bebca Mon Sep 17 00:00:00 2001
+From: Stanley Chu <yschu@nuvoton.com>
+Date: Mon, 15 Aug 2022 14:53:06 +0800
+Subject: [PATCH 6/6] change PSU sensor name to meet customer requirement
+
+Signed-off-by: Stanley Chu <yschu@nuvoton.com>
+---
+ src/PSUSensorMain.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/PSUSensorMain.cpp b/src/PSUSensorMain.cpp
+index 21a777dc..4f8fab0a 100644
+--- a/src/PSUSensorMain.cpp
++++ b/src/PSUSensorMain.cpp
+@@ -263,6 +263,7 @@ static void
+         name += psuName;
+         name += "_";
+         name += pwmName;
++	name = psuName + "_PWM_" + pwmName; // change PSU sensor name
+ 
+         std::string objPath = interfacePath;
+         objPath += "_";
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0007-add-sesnor-max16550.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0007-add-sesnor-max16550.patch
@@ -1,0 +1,36 @@
+From 843c8480e70e4a9f948916c76a3234a54833b53f Mon Sep 17 00:00:00 2001
+From: Stanley Chu <yschu@nuvoton.com>
+Date: Mon, 15 Aug 2022 14:58:46 +0800
+Subject: [PATCH 7/8] add sesnor max16550
+
+Signed-off-by: Stanley Chu <yschu@nuvoton.com>
+---
+ src/PSUSensorMain.cpp | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/PSUSensorMain.cpp b/src/PSUSensorMain.cpp
+index 4f8fab0a..8f1dcd11 100644
+--- a/src/PSUSensorMain.cpp
++++ b/src/PSUSensorMain.cpp
+@@ -47,7 +47,7 @@ static constexpr auto sensorTypes{std::to_array<const char*>(
+      "MAX20730",  "MAX20734",  "MAX20796",  "MAX34451",  "MP2971",
+      "MP2973",    "MP5023",    "pmbus",     "PXE1610",   "RAA228000",
+      "RAA228228", "RAA228620", "RAA229001", "RAA229004", "RAA229126",
+-     "TPS546D24", "XDPE12284", "p2011"})};
++     "TPS546D24", "XDPE12284", "p2011", "MAX1655"})};
+ 
+ // clang-format off
+ static constexpr auto pmbusNames{std::to_array<const char*>({
+@@ -88,7 +88,8 @@ static constexpr auto pmbusNames{std::to_array<const char*>({
+     "raa229126",
+     "tps546d24",
+     "xdpe12284",
+-    "p2011"
++    "p2011",
++    "max16550"
+ })};
+ //clang-format on
+ 
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0008-add-dimm-sensor.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0008-add-dimm-sensor.patch
@@ -1,0 +1,818 @@
+From f66c982439ed39f8cb026f4fecf7f84d5331132d Mon Sep 17 00:00:00 2001
+From: Stanley Chu <yschu@nuvoton.com>
+Date: Mon, 15 Aug 2022 16:13:12 +0800
+Subject: [PATCH 8/8] add dimm sensor
+
+Signed-off-by: Stanley Chu <yschu@nuvoton.com>
+---
+ include/DIMMSensor.hpp |  51 ++++
+ include/amd-apml.h     |  74 ++++++
+ include/i3cdev.h       |  39 +++
+ meson_options.txt      |   1 +
+ src/DIMMSensor.cpp     | 576 +++++++++++++++++++++++++++++++++++++++++
+ src/meson.build        |  15 ++
+ 6 files changed, 756 insertions(+)
+ create mode 100644 include/DIMMSensor.hpp
+ create mode 100644 include/amd-apml.h
+ create mode 100644 include/i3cdev.h
+ create mode 100644 src/DIMMSensor.cpp
+
+diff --git a/include/DIMMSensor.hpp b/include/DIMMSensor.hpp
+new file mode 100644
+index 00000000..91f2ce6a
+--- /dev/null
++++ b/include/DIMMSensor.hpp
+@@ -0,0 +1,51 @@
++#pragma once
++#include <boost/asio/deadline_timer.hpp>
++#include <boost/container/flat_map.hpp>
++#include <sensor.hpp>
++
++#include <chrono>
++#include <limits>
++#include <memory>
++#include <string>
++#include <vector>
++
++struct DIMMSensor : public Sensor
++{
++    DIMMSensor(std::shared_ptr<sdbusplus::asio::connection>& conn,
++                  boost::asio::io_service& io, const std::string& name,
++                  const std::string& sensorType,
++                  const std::string& interface,
++                  const std::string& sensorConfiguration,
++                  sdbusplus::asio::object_server& objectServer,
++                  std::vector<thresholds::Threshold>&& thresholds,
++                  uint8_t busId, uint8_t addr, const std::string& pid,
++                  uint8_t tempReg, double max, double min, uint8_t adcSel);
++    ~DIMMSensor() override;
++
++    void checkThresholds(void) override;
++    void read(void);
++    void init(void);
++    void work_thread(void);
++
++    uint8_t busId;
++    uint8_t addr;
++    std::string pid;
++    uint8_t tempReg;
++    std::string sensorName;
++    std::string sensorType;
++    std::string interface;
++    uint8_t adcSel;
++    double adcScal;
++    double sensorVal;
++
++  private:
++    int get_sensor_val(double *val);
++    int get_temp_i3c(double *temp);
++    int get_volt_i3c(double *volt);
++    int get_reg_i3c(uint8_t reg, uint8_t *data, uint8_t len);
++    int get_temp_sbrmi(double *temp);
++    int get_power_sbrmi(double *power);
++    int enableADC(void);
++    sdbusplus::asio::object_server& objectServer;
++    boost::asio::deadline_timer waitTimer;
++};
+diff --git a/include/amd-apml.h b/include/amd-apml.h
+new file mode 100644
+index 00000000..04161092
+--- /dev/null
++++ b/include/amd-apml.h
+@@ -0,0 +1,74 @@
++/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
++/*
++ * Copyright (C) 2021-2022 Advanced Micro Devices, Inc.
++ */
++#ifndef _AMD_APML_H_
++#define _AMD_APML_H_
++
++#include <linux/types.h>
++
++enum apml_protocol {
++	APML_CPUID	= 0x1000,
++	APML_MCA_MSR,
++	APML_REG,
++};
++
++/* These are byte indexes into data_in and data_out arrays */
++#define RD_WR_DATA_INDEX	0
++#define REG_OFF_INDEX		0
++#define REG_VAL_INDEX		4
++#define THREAD_LOW_INDEX	4
++#define THREAD_HI_INDEX		5
++#define EXT_FUNC_INDEX		6
++#define RD_FLAG_INDEX		7
++
++#define MB_DATA_SIZE		4
++
++struct apml_message {
++	/* message ids:
++	 * Mailbox Messages:	0x0 ... 0x999
++	 * APML_CPUID:		0x1000
++	 * APML_MCA_MSR:	0x1001
++	 * APML_REG:		0x1002 (RMI & TSI reg access)
++	 */
++	__u32 cmd;
++
++	/*
++	 * 8 bit data for reg read,
++	 * 32 bit data in case of mailbox,
++	 * upto 64 bit in case of cpuid and mca msr
++	 */
++	union {
++		__u64 cpu_msr_out;
++		__u32 mb_out[2];
++		__u8 reg_out[8];
++	} data_out;
++
++	/*
++	 * [0]...[3] mailbox 32bit input
++	 *	     cpuid & mca msr,
++	 *	     rmi rd/wr: reg_offset
++	 * [4][5] cpuid & mca msr: thread
++	 * [4] rmi reg wr: value
++	 * [6] cpuid: ext function & read eax/ebx or ecx/edx
++	 *	[7:0] -> bits [7:4] -> ext function &
++	 *	bit [0] read eax/ebx or ecx/edx
++	 * [7] read/write functionality
++	 */
++	union {
++		__u64 cpu_msr_in;
++		__u32 mb_in[2];
++		__u8 reg_in[8];
++	} data_in;
++	/*
++	 * Status code is returned in case of CPUID/MCA access
++	 * Error code is returned in case of soft mailbox
++	 */
++	__u32 fw_ret_code;
++} __attribute__((packed));
++
++/* ioctl command for mailbox msgs using generic _IOWR */
++#define SBRMI_BASE_IOCTL_NR      0xF9
++#define SBRMI_IOCTL_CMD          _IOWR(SBRMI_BASE_IOCTL_NR, 0, struct apml_message)
++
++#endif /*_AMD_APML_H_*/
+diff --git a/include/i3cdev.h b/include/i3cdev.h
+new file mode 100644
+index 00000000..7b8d429a
+--- /dev/null
++++ b/include/i3cdev.h
+@@ -0,0 +1,39 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright (C) 2019 Synopsys, Inc. and/or its affiliates.
++ *
++ * Author: Vitor Soares <vitor.soares@synopsys.com>
++ */
++
++#ifndef _UAPI_I3C_DEV_H_
++#define _UAPI_I3C_DEV_H_
++
++#include <linux/types.h>
++#include <linux/ioctl.h>
++
++#define VERSION "0.1"
++
++/* IOCTL commands */
++#define I3C_DEV_IOC_MAGIC	0x07
++
++/**
++ * struct i3c_ioc_priv_xfer - I3C SDR ioctl private transfer
++ * @data: Holds pointer to userspace buffer with transmit data.
++ * @len: Length of data buffer buffers, in bytes.
++ * @rnw: encodes the transfer direction. true for a read, false for a write
++ */
++struct i3c_ioc_priv_xfer {
++	__u64 data;
++	__u16 len;
++	__u8 rnw;
++	__u8 pad[5];
++};
++
++#define I3C_PRIV_XFER_SIZE(N)	\
++	((((sizeof(struct i3c_ioc_priv_xfer)) * (N)) < (1 << _IOC_SIZEBITS)) \
++	? ((sizeof(struct i3c_ioc_priv_xfer)) * (N)) : 0)
++
++#define I3C_IOC_PRIV_XFER(N)	\
++	_IOC(_IOC_READ|_IOC_WRITE, I3C_DEV_IOC_MAGIC, 30, I3C_PRIV_XFER_SIZE(N))
++
++#endif
+diff --git a/meson_options.txt b/meson_options.txt
+index d6a8b966..c0ec6454 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -12,3 +12,4 @@ option('external', type: 'feature', value: 'enabled', description: 'Enable Exter
+ option('tests', type: 'feature', value: 'enabled', description: 'Build tests.',)
+ option('validate-unsecure-feature', type : 'feature', value : 'disabled', description : 'Enables unsecure features required by validation. Note: mustbe turned off for production images.',)
+ option('insecure-sensor-override', type : 'feature', value : 'disabled', description : 'Enables Sensor override feature without any check.',)
++option('dimm', type: 'feature', value: 'enabled', description: 'Enable DIMM sensor.',)
+diff --git a/src/DIMMSensor.cpp b/src/DIMMSensor.cpp
+new file mode 100644
+index 00000000..87adc43f
+--- /dev/null
++++ b/src/DIMMSensor.cpp
+@@ -0,0 +1,576 @@
++#include <DIMMSensor.hpp>
++#include <Utils.hpp>
++#include <VariantVisitors.hpp>
++#include <boost/algorithm/string/predicate.hpp>
++#include <boost/container/flat_map.hpp>
++#include <sdbusplus/asio/connection.hpp>
++#include <sdbusplus/asio/object_server.hpp>
++#include <sdbusplus/bus/match.hpp>
++
++#include <chrono>
++#include <cmath>
++#include <functional>
++#include <iostream>
++#include <limits>
++#include <memory>
++#include <numeric>
++#include <string>
++#include <vector>
++#include <thread>
++
++extern "C"
++{
++#include <i3cdev.h>
++#include <amd-apml.h>
++}
++
++constexpr const bool debug = false;
++bool thread_exist = false;
++
++constexpr const char* configInterface =
++    "xyz.openbmc_project.Configuration.dimm";
++
++boost::container::flat_map<std::string, std::unique_ptr<DIMMSensor>> sensors;
++
++int sbrmi_read_mailbox(uint32_t cmd, uint32_t input, uint32_t *output)
++{
++	struct apml_message msg;
++	int fd = 0, ret = 0;
++
++	memset((char *)&msg, 0, sizeof(msg));
++	fd = open("/dev/sbrmi0", O_RDWR);
++	if (fd < 0)
++		return -1;
++
++	msg.cmd = cmd;
++	msg.data_in.mb_in[0] = input & 0xFF;
++	msg.data_in.mb_in[1] = (uint32_t)(1 << 24); // READ_MODE
++	if (ioctl(fd, SBRMI_IOCTL_CMD, &msg) < 0) {
++	    ret = -1;
++	}
++	*output = msg.data_out.mb_out[0];
++
++	close(fd);
++
++	return ret;
++}
++
++DIMMSensor::DIMMSensor(std::shared_ptr<sdbusplus::asio::connection>& conn,
++                             boost::asio::io_service& io,
++                             const std::string& sensorName,
++                             const std::string& sensorType,
++                             const std::string& interface,
++                             const std::string& sensorConfiguration,
++                             sdbusplus::asio::object_server& objectServer,
++                             std::vector<thresholds::Threshold>&& thresholdData,
++                             uint8_t busId, uint8_t addr, const std::string& pid,
++                             uint8_t tempReg, double max, double min, uint8_t adcSel) :
++    Sensor(escapeName(sensorName), std::move(thresholdData),
++           sensorConfiguration, sensorType,
++           false, false, max, min, conn, PowerState::biosPost),
++    busId(busId), addr(addr), pid(pid), tempReg(tempReg), sensorName(sensorName), sensorType(sensorType),
++    interface(interface), adcSel(adcSel), objectServer(objectServer), waitTimer(io)
++{
++    std::string dbusPath = "/xyz/openbmc_project/sensors/" + sensorType + "/" + name;
++
++    sensorInterface = objectServer.add_interface(
++        dbusPath,
++        "xyz.openbmc_project.Sensor.Value");
++
++    for (const auto& threshold : thresholds)
++    {
++        std::string interface = thresholds::getInterface(threshold.level);
++        thresholdInterfaces[static_cast<size_t>(threshold.level)] =
++            objectServer.add_interface(dbusPath, interface);
++    }
++    association = objectServer.add_interface(
++        dbusPath,
++        association::interface);
++}
++
++DIMMSensor::~DIMMSensor()
++{
++    waitTimer.cancel();
++    thread_exist = true;
++    for (const auto& iface : thresholdInterfaces)
++    {
++        objectServer.remove_interface(iface);
++    }
++    objectServer.remove_interface(sensorInterface);
++    objectServer.remove_interface(association);
++}
++
++void DIMMSensor::init(void)
++{
++    if (sensorType == "temperature")
++    {
++        setInitialProperties(sensor_paths::unitDegreesC);
++    } else if (sensorType == "power") {
++        setInitialProperties(sensor_paths::unitWatts);
++    } else if (sensorType == "voltage") {
++        setInitialProperties(sensor_paths::unitVolts);
++        if (interface == "i3c")
++        {
++	    enableADC();
++        }
++    } else {
++        std::cerr << "delete:" << sensorName << "\n";
++        sensors.erase(sensorName);
++        return;
++    }
++    std::thread thread([this]() {
++        work_thread();
++    });
++    thread.detach();
++    sensorVal = std::numeric_limits<double>::quiet_NaN();
++    read();
++}
++
++void DIMMSensor::checkThresholds(void)
++{
++    thresholds::checkThresholds(this);
++}
++#if 0
++int DIMMSensor::probe(uint8_t reg)
++{
++    uint8_t val = 0;
++
++    int ret = getDIMMRegsInfo(reg, &val, 1);
++    if ((ret < 0) || (0 == (int)val))
++    {
++        std::cerr << sensorName << " is not present" << "\n";
++        return -1;
++    }
++
++    return 0;
++}
++#endif
++int DIMMSensor::enableADC(void)
++{
++    std::string i3cBus = "/dev/i3c-" + std::to_string(busId) + "-" + pid;
++    i3c_ioc_priv_xfer xfer;
++    uint8_t buf[2];
++    uint8_t val;
++
++    if (adcSel == 5) {
++        adcScal = 0.07;
++    } else if (adcSel == 7) {
++        adcScal = 0.025;
++    } else if (adcSel == 0 || adcSel == 1 || adcSel == 2 || adcSel == 3
++             || adcSel == 6 || adcSel == 8 || adcSel == 9) {
++        adcScal = 0.015;
++    } else {
++        adcSel = 0;
++        adcScal = 0.015;
++    }
++    std::cerr << sensorName << ": adc Select = " << (int)adcSel << "\n";
++    std::cerr << sensorName << ": adc Read scale = " << adcScal << "\n";
++
++    val = 0x80 | (adcSel << 3);
++
++    int fd = open(i3cBus.c_str(), O_RDWR);
++    if (fd < 0)
++    {
++        std::cerr << " unable to open i3c device" << i3cBus << "  err=" << fd
++                  << "\n";
++        return -1;
++    }
++
++    buf[0] = 0x30;
++    buf[1] = val | 0x80;
++    xfer.len = 2;
++    xfer.rnw = 0;
++    xfer.data = (__u64)buf;
++    if (ioctl(fd, I3C_IOC_PRIV_XFER(1), &xfer) < 0) {
++        std::cerr << "Error: transfer failed: " << i3cBus << "\n";
++        close(fd);
++        return -1;
++    }
++
++    close(fd);
++
++    return 0;
++}
++
++int DIMMSensor::get_reg_i3c(uint8_t regs, uint8_t *data, uint8_t len)
++{
++    std::string i3cBus = "/dev/i3c-" + std::to_string(busId) + "-" + pid;
++    i3c_ioc_priv_xfer xfers[2];
++    uint8_t wbuf[2];
++    uint8_t rbuf[32];
++    int ret;
++
++    if (len > 32)
++        return -1;
++
++    int fd = open(i3cBus.c_str(), O_RDWR);
++    if (fd < 0)
++    {
++        if constexpr (debug)
++	{
++            std::cerr << "unable to open i3c bus " << i3cBus << "  err=" << fd
++                  << "\n";
++        }
++        return -1;
++    }
++
++    wbuf[0] = regs;
++    for (int i = 0; i < len; i++)
++    {
++        rbuf[i] = 0;
++    }
++    xfers[0].len = 1;
++    xfers[0].rnw = 0;
++    xfers[0].data = (__u64)wbuf;
++    xfers[1].len = len;
++    xfers[1].rnw = 1;
++    xfers[1].data = (__u64)rbuf;
++    ret = ioctl(fd, I3C_IOC_PRIV_XFER(2), xfers);
++    if (ret != 0) {
++        if constexpr (debug)
++        {
++            std::cerr << i3cBus << ": transfer failed: " << ret << "\n";
++        }
++        close(fd);
++        return -1;
++    }
++
++    int i;
++    for (i = 0; i < len; i++)
++    {
++        if constexpr (debug)
++        {
++            std::cerr << "Raw reading: "  << static_cast<int>(rbuf[i]) << "\n";
++        }
++        *data = rbuf[i];
++        data++;
++    }
++
++    close(fd);
++
++    return 0;
++}
++
++int DIMMSensor::get_temp_sbrmi(double *temp)
++{
++    uint32_t output;
++    uint16_t raw;
++    int ret;
++
++    ret = sbrmi_read_mailbox(0x48, addr, &output); // READ_DIMM_THERMAL_SENSOR
++    if (ret < 0) {
++        if constexpr (debug)
++        {
++            std::cerr << sensorName << ": read mailbox failed\n";
++        }
++        return ret;
++    }
++
++    raw = output >> 21;
++    //std::cerr << sensorName << ": temp raw=" << raw << "\n";
++    //std::cerr << sensorName << ": addr=" << static_cast<int>(addr) << "\n";
++    //std::cerr << sensorName << ": mbox output=" << output << "\n";
++    if (raw <= 0x3FF)
++        *temp = raw * 0.25;
++    else
++        *temp = (raw - 0x800) * 0.25;
++
++    return 0;
++}
++
++int DIMMSensor::get_power_sbrmi(double *power)
++{
++    uint32_t output;
++    int ret;
++
++    ret = sbrmi_read_mailbox(0x47, addr, &output); // READ_DIMM_POWER_CONSUMPTION
++    if (ret < 0) {
++        if constexpr (debug)
++        {
++            std::cerr << sensorName << ": read mailbox failed\n";
++        }
++        return ret;
++    }
++    //std::cerr << sensorName << ": addr=" << static_cast<int>(addr) << "\n";
++    //std::cerr << sensorName << ": mbox output=" << output << "\n";
++
++    *power = (double)(output >> 17) / 1000;
++
++    return 0;
++}
++
++int DIMMSensor::get_temp_i3c(double *temp)
++{
++    uint8_t raw[2];
++    int ret;
++
++    ret = get_reg_i3c(0x31, raw, 2);
++    if (ret == 0)
++    {
++        double v = static_cast<double>(raw[0] >> 2) * 0.25;
++        v += static_cast<double>(raw[1] & 0x0F) * 16;
++        if (raw[1] & 0x10) v = v * -1;
++	*temp = v;
++    }
++    return ret;
++}
++
++int DIMMSensor::get_volt_i3c(double *volt)
++{
++    uint8_t raw;
++    int ret;
++
++    ret = get_reg_i3c(0x31, &raw, 1);
++    if (ret == 0)
++    {
++        *volt = static_cast<double>(raw) * adcScal;
++    }
++    return ret;
++}
++
++int DIMMSensor::get_sensor_val(double *val)
++{
++    if (interface == "i3c")
++    {
++        if (sensorType == "temperature")
++            return get_temp_i3c(val);
++        if (sensorType == "voltage")
++            return get_volt_i3c(val);
++    }
++    if (interface == "sbrmi")
++    {
++        if (sensorType == "temperature")
++            return get_temp_sbrmi(val);
++        if (sensorType == "power")
++            return get_power_sbrmi(val);
++    }
++    return -1;
++}
++
++void DIMMSensor::work_thread(void)
++{
++    double v;
++    int pollTime = 1;
++    int failCount = 0;
++    while (!thread_exist) {
++        if (!readingStateGood())
++        {
++            sensorVal = std::numeric_limits<double>::quiet_NaN();
++            std::this_thread::sleep_for(std::chrono::seconds(1));
++            continue;
++        }
++        if (failCount > 10)
++        {
++            std::cerr << sensorName << " is not detected, stop reading\n";
++            return;
++        }
++        int ret = get_sensor_val(&v);
++        if (ret == 0)
++        {
++            sensorVal = v;
++            pollTime = 1;
++            failCount = 0;
++        } else {
++            #if 0
++            if (readingStateGood())
++            {
++                std::cerr << "remove sensor " << sensorName << "\n";
++                sensors.erase(sensorName);
++                return;
++            }
++            #endif
++            failCount++;
++            if (pollTime < 10) {
++                pollTime++;
++            }
++            sensorVal = std::numeric_limits<double>::quiet_NaN();
++        }
++        std::this_thread::sleep_for(std::chrono::seconds(pollTime));
++    }
++}
++
++void DIMMSensor::read(void)
++{
++    static constexpr size_t pollTime = 1; // in seconds
++
++    waitTimer.expires_from_now(boost::posix_time::seconds(pollTime));
++    waitTimer.async_wait([this](const boost::system::error_code& ec) {
++        if (ec == boost::asio::error::operation_aborted)
++        {
++            return; // we're being cancelled
++        }
++        // read timer error
++        if (ec)
++        {
++            std::cerr << "timer error\n";
++            return;
++        }
++        if constexpr (debug)
++        {
++            std::cerr << sensorName << ":update sensor value to " << sensorVal << "\n";
++        }
++        updateValue(sensorVal);
++        read();
++    });
++}
++
++void createSensors(
++    boost::asio::io_service& io, sdbusplus::asio::object_server& objectServer,
++    boost::container::flat_map<std::string, std::unique_ptr<DIMMSensor>>&
++        sensors,
++    std::shared_ptr<sdbusplus::asio::connection>& dbusConnection)
++{
++    if (!dbusConnection)
++    {
++        std::cerr << "Connection not created\n";
++        return;
++    }
++
++    dbusConnection->async_method_call(
++        [&io, &objectServer, &dbusConnection, &sensors](
++            boost::system::error_code ec, const ManagedObjectType& resp) {
++            if (ec)
++            {
++                std::cerr << "Error contacting entity manager\n";
++                return;
++            }
++            for (const auto& pathPair : resp)
++            {
++                for (const auto& entry : pathPair.second)
++                {
++                    if (entry.first != configInterface)
++                    {
++                        continue;
++                    }
++                    std::string name =
++                        loadVariant<std::string>(entry.second, "Name");
++
++                    std::vector<thresholds::Threshold> sensorThresholds;
++                    if (!parseThresholdsFromConfig(pathPair.second,
++                                                   sensorThresholds))
++                    {
++                        std::cerr << "error populating thresholds for " << name
++                                  << "\n";
++                    }
++
++                    std::string interface =
++                        loadVariant<std::string>(entry.second, "Interface");
++
++                    uint8_t busId = 0;
++                    uint8_t addr = 0;
++		    uint8_t tempReg = 0;
++		    std::string pid = "0";
++                    double max, min;
++		    uint8_t adcSel = 0;
++
++                    if (interface == "i3c")
++		    {
++                        busId = loadVariant<uint8_t>(entry.second, "Bus");
++                        pid = loadVariant<std::string>(entry.second, "Pid");
++                        tempReg = loadVariant<uint8_t>(entry.second, "Reg");
++		    } else if (interface == "sbrmi") {
++                        addr = loadVariant<uint8_t>(entry.second, "Addr");
++		    }
++
++                    std::string sensorType =
++                        loadVariant<std::string>(entry.second, "Class");
++                    if (sensorType == "temperature") {
++                        max = 255;
++                        min = -127;
++                    } else if (sensorType == "voltage") {
++                        max = 15;
++                        min = 0;
++                        auto findType = entry.second.find("Adc");
++                        if (findType != entry.second.end())
++                        {
++                            adcSel = loadVariant<uint8_t>(entry.second, "Adc");
++                        }
++                    } else if (sensorType == "power") {
++                        max = 64;
++                        min = 0;
++                    } else {
++                        std::cerr << "error sensor type: " << sensorType
++                                  << "\n";
++                        continue;
++                    }
++
++                    if constexpr (debug)
++                    {
++                        std::cerr
++                            << "Configuration parsed for \n\t" << entry.first
++                            << "\n"
++                            << "with\n"
++                            << "\tName: " << name << "\n"
++                            << "\tInterface: " << interface << "\n"
++                            << "\tBus: " << static_cast<int>(busId) << "\n"
++                            << "\tAddr: " << static_cast<int>(addr) << "\n"
++                            << "\tPid: " << pid << "\n"
++                            << "\n"
++                            << "\tReg: " << static_cast<int>(tempReg) << "\n"
++                            << "\tClass: " << sensorType << "\n";
++                    }
++
++                    auto& sensor = sensors[name];
++
++                    sensor = std::make_unique<DIMMSensor>(
++                        dbusConnection, io, name, sensorType, interface,
++                        pathPair.first, objectServer,
++                        std::move(sensorThresholds), busId, addr, pid,
++                        tempReg, max, min, adcSel);
++
++                    sensor->init();
++                }
++            }
++        },
++        entityManagerName, "/", "org.freedesktop.DBus.ObjectManager",
++        "GetManagedObjects");
++}
++
++int main()
++{
++    boost::asio::io_service io;
++    auto systemBus = std::make_shared<sdbusplus::asio::connection>(io);
++    systemBus->request_name("xyz.openbmc_project.DIMMSensor");
++    sdbusplus::asio::object_server objectServer(systemBus);
++
++    io.post([&]() { createSensors(io, objectServer, sensors, systemBus); });
++
++    boost::asio::deadline_timer configTimer(io);
++
++    std::function<void(sdbusplus::message::message&)> eventHandler =
++        [&](sdbusplus::message::message&) {
++            configTimer.expires_from_now(boost::posix_time::seconds(1));
++            // create a timer because normally multiple properties change
++            configTimer.async_wait([&](const boost::system::error_code& ec) {
++                if (ec == boost::asio::error::operation_aborted)
++                {
++                    return; // we're being canceled
++                }
++                // config timer error
++                if (ec)
++                {
++                    std::cerr << "timer error\n";
++                    return;
++                }
++                createSensors(io, objectServer, sensors, systemBus);
++                if (sensors.empty())
++                {
++                    std::cout << "Configuration not detected\n";
++                }
++            });
++        };
++
++    sdbusplus::bus::match::match configMatch(
++        static_cast<sdbusplus::bus::bus&>(*systemBus),
++        "type='signal',member='PropertiesChanged',"
++        "path_namespace='" +
++            std::string(inventoryPath) +
++            "',"
++            "arg0namespace='" +
++            configInterface + "'",
++        eventHandler);
++
++    setupManufacturingModeMatch(*systemBus);
++    io.run();
++    return 0;
++}
+diff --git a/src/meson.build b/src/meson.build
+index e420b278..945a6a98 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -195,3 +195,18 @@ if get_option('external').enabled()
+         install: true,
+     )
+ endif
++
++if get_option('dimm').enabled()
++    executable(
++        'dimmsensor',
++        'DIMMSensor.cpp',
++        dependencies: [
++            default_deps,
++            thresholds_dep,
++            utils_dep,
++        ],
++        implicit_include_directories: false,
++        include_directories: '../include',
++        install: true,
++    )
++endif
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/xyz.openbmc_project.dimmsensor.service
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/xyz.openbmc_project.dimmsensor.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=DIMM Sensor
+StopWhenUnneeded=false
+Requires=xyz.openbmc_project.EntityManager.service
+After=xyz.openbmc_project.EntityManager.service
+
+[Service]
+Restart=always
+RestartSec=5
+ExecStart=/usr/bin/dimmsensor
+
+[Install]
+WantedBy=multi-user.target
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors_%.bbappend
@@ -1,1 +1,35 @@
 FILESEXTRAPATHS:prepend:scm-npcm845 := "${THISDIR}/${PN}:"
+
+SRC_URI:append:scm-npcm845 = " \
+    file://0001-add-TMP100-support.patch \
+    file://0002-psu-sensor-add-fan3-support.patch \
+    file://0003-psu-sensor-support-p2011-psu.patch \
+    file://0004-add-NIC-temp-sensor.patch \
+    file://0005-increase-adc-max-reading.patch \
+    file://0006-change-psu-sensor-name.patch \
+    file://0007-add-sesnor-max16550.patch \
+    file://0008-add-dimm-sensor.patch \
+    file://xyz.openbmc_project.dimmsensor.service \
+    "
+
+PACKAGECONFIG:scm-npcm845 = "\
+    hwmontempsensor \
+    fansensor \
+    psusensor \
+    adcsensor \
+    intrusionsensor \
+    nvmesensor \
+    dimmsensor \
+    mcutempsensor \
+    "
+
+PACKAGECONFIG[dimmsensor] = "-Ddimm=enabled, -Ddimm=disabled"
+SYSTEMD_SERVICE:${PN}:append:scm-npcm845 = "${@bb.utils.contains('PACKAGECONFIG', 'dimmsensor', \
+                                               ' xyz.openbmc_project.dimmsensor.service', \
+                                               '', d)}"
+
+do_install:append:scm-npcm845() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/xyz.openbmc_project.dimmsensor.service \
+        ${D}${systemd_system_unitdir}
+}

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/settings/phosphor-settings-manager/chassis-nmisource.override.yml
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/settings/phosphor-settings-manager/chassis-nmisource.override.yml
@@ -1,7 +1,0 @@
-/xyz/openbmc_project/Chassis/Control/NMISource:
-    - Interface: xyz.openbmc_project.Chassis.Control.NMISource
-      Properties:
-          BMCSource:
-              Default: NMISource::BMCSourceSignal::None
-          Enabled:
-              Default: 'false'

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/settings/phosphor-settings-manager_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/settings/phosphor-settings-manager_%.bbappend
@@ -1,4 +1,3 @@
 FILESEXTRAPATHS:prepend:scm-npcm845 := "${THISDIR}/${PN}:"
 
-SRC_URI:append:scm-npcm845 = " file://chassis-nmisource.override.yml"
 SRC_URI:append:scm-npcm845 = " file://sol-default.override.yml"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/watchdog/phosphor-watchdog/0001-Customize-phosphor-watchdog-for-Intel-platforms.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/watchdog/phosphor-watchdog/0001-Customize-phosphor-watchdog-for-Intel-platforms.patch
@@ -1,0 +1,348 @@
+From a2a8b080f73a32c86a4eed4f483d60e293eb7753 Mon Sep 17 00:00:00 2001
+From: James Feist <james.feist@linux.intel.com>
+Date: Mon, 17 Jun 2019 12:00:58 -0700
+Subject: [PATCH 1/2] Customize phosphor-watchdog for Intel platforms
+
+This patch adds various changes to phosphor-watchdog that are
+required for compatibility with Intel platforms.
+
+   1. Add Redfish messages for watchdog timeout and pre-interrupt
+   2. Use dbus properties for power control insted of service files
+   3. Use host status to enable/disable watchdog
+   4. Set preTimeoutInterruptOccurFlag
+   5. Assign watchdog cause for correct reset cause reporting
+   6. Add NMI Pre-Interrupt support for IPMI watchdog timer.
+
+Signed-off-by: James Feist <james.feist@linux.intel.com>
+Signed-off-by: Ren Yu <yux.ren@intel.com>
+Signed-off-by: Yong Li <yong.b.li@linux.intel.com>
+Signed-off-by: Jason M. Bills <jason.m.bills@linux.intel.com>
+Signed-off-by: Johnathan Mantey <johnathanx.mantey@intel.com>
+Signed-off-by: Sunita Kumari <sunitax.kumari@intel.com>
+
+%% original patch: 0001-Customize-phosphor-watchdog-for-Intel-platforms.patch
+---
+ src/watchdog.cpp | 229 ++++++++++++++++++++++++++++++++++++++++++++---
+ src/watchdog.hpp |  22 ++++-
+ 2 files changed, 240 insertions(+), 11 deletions(-)
+
+diff --git a/src/watchdog.cpp b/src/watchdog.cpp
+index 918a372..6eab537 100644
+--- a/src/watchdog.cpp
++++ b/src/watchdog.cpp
+@@ -5,8 +5,10 @@
+ #include <phosphor-logging/elog.hpp>
+ #include <phosphor-logging/log.hpp>
+ #include <sdbusplus/exception.hpp>
++#include <systemd/sd-journal.h>
+ #include <string_view>
+ #include <xyz/openbmc_project/Common/error.hpp>
++#include <xyz/openbmc_project/State/Host/server.hpp>
+ 
+ namespace phosphor
+ {
+@@ -18,10 +20,86 @@ using namespace phosphor::logging;
+ 
+ using sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+ 
+-// systemd service to kick start a target.
+-constexpr auto SYSTEMD_SERVICE = "org.freedesktop.systemd1";
+-constexpr auto SYSTEMD_ROOT = "/org/freedesktop/systemd1";
+-constexpr auto SYSTEMD_INTERFACE = "org.freedesktop.systemd1.Manager";
++const static constexpr char* currentHostState = "CurrentHostState";
++const static constexpr char* hostStatusOff =
++    "xyz.openbmc_project.State.Host.HostState.Off";
++
++const static constexpr char* actionDescription = " due to Watchdog timeout";
++const static constexpr char* hardResetDescription = "Hard Reset - System reset";
++const static constexpr char* powerOffDescription =
++    "Power Down - System power down";
++const static constexpr char* powerCycleDescription =
++    "Power Cycle - System power cycle";
++const static constexpr char* timerExpiredDescription = "Timer expired";
++
++const static constexpr char* preInterruptActionNone =
++    "xyz.openbmc_project.State.Watchdog.PreTimeoutInterruptAction.None";
++
++const static constexpr char* preInterruptDescriptionSMI = "SMI";
++const static constexpr char* preInterruptDescriptionNMI = "NMI";
++const static constexpr char* preInterruptDescriptionMI = "Messaging Interrupt";
++
++const static constexpr char* reservedDescription = "Reserved";
++
++const static constexpr char* timerUseDescriptionBIOSFRB2 = "BIOS FRB2";
++const static constexpr char* timerUseDescriptionBIOSPOST = "BIOS/POST";
++const static constexpr char* timerUseDescriptionOSLoad = "OSLoad";
++const static constexpr char* timerUseDescriptionSMSOS = "SMS/OS";
++const static constexpr char* timerUseDescriptionOEM = "OEM";
++
++namespace restart
++{
++static constexpr const char* busName =
++    "xyz.openbmc_project.Control.Host.RestartCause";
++static constexpr const char* path =
++    "/xyz/openbmc_project/control/host0/restart_cause";
++static constexpr const char* interface =
++    "xyz.openbmc_project.Control.Host.RestartCause";
++static constexpr const char* property = "RequestedRestartCause";
++} // namespace restart
++
++// chassis state manager service
++namespace chassis
++{
++static constexpr const char* busName = "xyz.openbmc_project.State.Chassis";
++static constexpr const char* path = "/xyz/openbmc_project/state/chassis0";
++static constexpr const char* interface = "xyz.openbmc_project.State.Chassis";
++static constexpr const char* request = "RequestedPowerTransition";
++} // namespace chassis
++
++namespace host
++{
++static constexpr const char* busName = "xyz.openbmc_project.State.Host";
++static constexpr const char* path = "/xyz/openbmc_project/state/host0";
++static constexpr const char* interface = "xyz.openbmc_project.State.Host";
++static constexpr const char* request = "RequestedHostTransition";
++} // namespace host
++
++namespace nmi
++{
++static constexpr const char* busName = "xyz.openbmc_project.Control.Host.NMI";
++static constexpr const char* path = "/xyz/openbmc_project/control/host0/nmi";
++static constexpr const char* interface = "xyz.openbmc_project.Control.Host.NMI";
++static constexpr const char* request = "NMI";
++
++} // namespace nmi
++
++void Watchdog::powerStateChangedHandler(
++    const std::map<std::string, std::variant<std::string>>& props)
++{
++    const auto iter = props.find(currentHostState);
++    if (iter != props.end())
++    {
++        const std::string* powerState = std::get_if<std::string>(&iter->second);
++        if (powerState && (*powerState == hostStatusOff))
++        {
++            if (timerEnabled())
++            {
++                enabled(false);
++            }
++        }
++    }
++}
+ 
+ void Watchdog::resetTimeRemaining(bool enableWatchdog)
+ {
+@@ -107,13 +185,111 @@ uint64_t Watchdog::interval(uint64_t value)
+ // Optional callback function on timer expiration
+ void Watchdog::timeOutHandler()
+ {
++    PreTimeoutInterruptAction preTimeoutInterruptAction = preTimeoutInterrupt();
++    std::string preInterruptActionMessageArgs{};
++
+     Action action = expireAction();
++    std::string actionMessageArgs{};
++
++    expiredTimerUse(currentTimerUse());
++
++    TimerUse timeUser = expiredTimerUse();
++    std::string timeUserMessage{};
++
+     if (!this->enabled())
+     {
+         action = fallback->action;
+     }
+ 
+-    expiredTimerUse(currentTimerUse());
++    switch (timeUser)
++    {
++        case Watchdog::TimerUse::BIOSFRB2:
++            timeUserMessage = timerUseDescriptionBIOSFRB2;
++            break;
++        case Watchdog::TimerUse::BIOSPOST:
++            timeUserMessage = timerUseDescriptionBIOSPOST;
++            break;
++        case Watchdog::TimerUse::OSLoad:
++            timeUserMessage = timerUseDescriptionOSLoad;
++            break;
++        case Watchdog::TimerUse::SMSOS:
++            timeUserMessage = timerUseDescriptionSMSOS;
++            break;
++        case Watchdog::TimerUse::OEM:
++            timeUserMessage = timerUseDescriptionOEM;
++            break;
++        default:
++            timeUserMessage = reservedDescription;
++            break;
++    }
++
++    switch (action)
++    {
++        case Watchdog::Action::HardReset:
++            actionMessageArgs = std::string(hardResetDescription) +
++                                std::string(actionDescription);
++            break;
++        case Watchdog::Action::PowerOff:
++            actionMessageArgs = std::string(powerOffDescription) +
++                                std::string(actionDescription);
++            break;
++        case Watchdog::Action::PowerCycle:
++            actionMessageArgs = std::string(powerCycleDescription) +
++                                std::string(actionDescription);
++            break;
++        case Watchdog::Action::None:
++            actionMessageArgs = timerExpiredDescription;
++            break;
++        default:
++            actionMessageArgs = reservedDescription;
++            break;
++    }
++
++    // Log into redfish event log
++    sd_journal_send("MESSAGE=IPMIWatchdog: Timed out ACTION=%s",
++                    convertForMessage(action).c_str(), "PRIORITY=%i", LOG_INFO,
++                    "REDFISH_MESSAGE_ID=%s", "OpenBMC.0.1.IPMIWatchdog",
++                    "REDFISH_MESSAGE_ARGS=%s. timer use: %s",
++                    actionMessageArgs.c_str(), timeUserMessage.c_str(), NULL);
++
++    switch (preTimeoutInterruptAction)
++    {
++        case Watchdog::PreTimeoutInterruptAction::SMI:
++            preInterruptActionMessageArgs = preInterruptDescriptionSMI;
++            break;
++        case Watchdog::PreTimeoutInterruptAction::NMI:
++            preInterruptActionMessageArgs = preInterruptDescriptionNMI;
++            break;
++        case Watchdog::PreTimeoutInterruptAction::MI:
++            preInterruptActionMessageArgs = preInterruptDescriptionMI;
++            break;
++        default:
++            preInterruptActionMessageArgs = reservedDescription;
++            break;
++    }
++
++    if (preInterruptActionNone != convertForMessage(preTimeoutInterruptAction))
++    {
++        preTimeoutInterruptOccurFlag(true);
++
++        sd_journal_send("MESSAGE=IPMIWatchdog: Pre Timed out Interrupt=%s",
++                        convertForMessage(preTimeoutInterruptAction).c_str(),
++                        "PRIORITY=%i", LOG_INFO, "REDFISH_MESSAGE_ID=%s",
++                        "OpenBMC.0.1.IPMIWatchdog",
++                        "REDFISH_MESSAGE_ARGS=Timer interrupt - %s due to "
++                        "Watchdog timeout. timer use: %s",
++                        preInterruptActionMessageArgs.c_str(),
++                        timeUserMessage.c_str(), NULL);
++
++        if (preTimeoutInterruptAction ==
++            Watchdog::PreTimeoutInterruptAction::NMI)
++        {
++            sdbusplus::message::message preTimeoutInterruptHandler;
++            preTimeoutInterruptHandler = bus.new_method_call(
++                nmi::busName, nmi::path, nmi::interface, nmi::request);
++            bus.call_noreply(preTimeoutInterruptHandler);
++        }
++    }
+ 
+     auto target = actionTargetMap.find(action);
+     if (target == actionTargetMap.end())
+@@ -146,12 +322,45 @@ void Watchdog::timeOutHandler()
+ 
+         try
+         {
+-            auto method = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_ROOT,
+-                                              SYSTEMD_INTERFACE, "StartUnit");
+-            method.append(target->second);
+-            method.append("replace");
++            sdbusplus::message::message method;
++            if (action == Watchdog::Action::HardReset)
++            {
++                auto method = bus.new_method_call(
++                    restart::busName, restart::path,
++                    "org.freedesktop.DBus.Properties", "Set");
++                method.append(
++                    restart::interface, restart::property,
++                    std::variant<std::string>("xyz.openbmc_project.State.Host."
++                                              "RestartCause.WatchdogTimer"));
++                bus.call_noreply(method);
+ 
+-            bus.call_noreply(method);
++                method = bus.new_method_call(host::busName, host::path,
++                                             "org.freedesktop.DBus.Properties",
++                                             "Set");
++                method.append(host::interface, host::request,
++                              std::variant<std::string>(target->second));
++                bus.call_noreply(method);
++            }
++            else
++            {
++                if (action == Watchdog::Action::PowerCycle)
++                {
++                    auto method = bus.new_method_call(
++                        restart::busName, restart::path,
++                        "org.freedesktop.DBus.Properties", "Set");
++                    method.append(restart::interface, restart::property,
++                                  std::variant<std::string>(
++                                      "xyz.openbmc_project.State.Host."
++                                      "RestartCause.WatchdogTimer"));
++                    bus.call_noreply(method);
++                }
++                method = bus.new_method_call(chassis::busName, chassis::path,
++                                             "org.freedesktop.DBus.Properties",
++                                             "Set");
++                method.append(chassis::interface, chassis::request,
++                              std::variant<std::string>(target->second));
++                bus.call_noreply(method);
++            }
+         }
+         catch (const sdbusplus::exception_t& e)
+         {
+diff --git a/src/watchdog.hpp b/src/watchdog.hpp
+index 16f05f1..822c422 100644
+--- a/src/watchdog.hpp
++++ b/src/watchdog.hpp
+@@ -73,7 +73,17 @@ class Watchdog : public WatchdogInherits
+         bus(bus), actionTargetMap(std::move(actionTargetMap)),
+         fallback(fallback), minInterval(minInterval),
+         timer(event, std::bind(&Watchdog::timeOutHandler, this)),
+-        objPath(objPath)
++        objPath(objPath), powerStateChangedSignal(
++            bus,
++            sdbusplus::bus::match::rules::propertiesChanged(
++                "/xyz/openbmc_project/state/host0",
++                "xyz.openbmc_project.State.Host"),
++            [this](sdbusplus::message::message& msg) {
++                std::string objectName;
++                std::map<std::string, std::variant<std::string>> props;
++                msg.read(objectName, props);
++                powerStateChangedHandler(props);
++            })
+     {
+         // Use default if passed in otherwise just use default that comes
+         // with object
+@@ -90,6 +100,12 @@ class Watchdog : public WatchdogInherits
+         tryFallbackOrDisable();
+     }
+ 
++    /** @brief Disable watchdog when power status change meet
++     *         the specific requirement
++     */
++    void powerStateChangedHandler(
++        const std::map<std::string, std::variant<std::string>>& props);
++
+     /** @brief Resets the TimeRemaining to the configured Interval
+      *         Optionally enables the watchdog.
+      *
+@@ -178,6 +194,10 @@ class Watchdog : public WatchdogInherits
+     /** @brief Contained timer object */
+     sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> timer;
+ 
++    /** @brief Optional Callback handler when power status change meet
++     * the specific requirement */
++    sdbusplus::bus::match_t powerStateChangedSignal;
++
+     /** @brief Optional Callback handler on timer expirartion */
+     void timeOutHandler();
+ 
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/watchdog/phosphor-watchdog/0002-Customize-phosphor-watchdog-for-Nuvoton-platform.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/watchdog/phosphor-watchdog/0002-Customize-phosphor-watchdog-for-Nuvoton-platform.patch
@@ -1,0 +1,45 @@
+From d5175a063d1292dd0d7a1df74658eacaf0e2d6d1 Mon Sep 17 00:00:00 2001
+From: Tim Lee <timlee660101@gmail.com>
+Date: Fri, 18 Feb 2022 14:55:06 +0800
+Subject: [PATCH 2/2] Customize phosphor-watchdog for Nuvoton platform
+
+Signed-off-by: Tim Lee <timlee660101@gmail.com>
+---
+ src/watchdog.cpp | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/src/watchdog.cpp b/src/watchdog.cpp
+index ea94082..6c5246b 100644
+--- a/src/watchdog.cpp
++++ b/src/watchdog.cpp
+@@ -20,6 +20,11 @@ using namespace phosphor::logging;
+ 
+ using sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+ 
++// systemd service to kick start a target.
++constexpr auto SYSTEMD_SERVICE = "org.freedesktop.systemd1";
++constexpr auto SYSTEMD_ROOT = "/org/freedesktop/systemd1";
++constexpr auto SYSTEMD_INTERFACE = "org.freedesktop.systemd1.Manager";
++
+ const static constexpr char* currentHostState = "CurrentHostState";
+ const static constexpr char* hostStatusOff =
+     "xyz.openbmc_project.State.Host.HostState.Off";
+@@ -354,11 +359,10 @@ void Watchdog::timeOutHandler()
+                                       "RestartCause.WatchdogTimer"));
+                     bus.call_noreply(method);
+                 }
+-                method = bus.new_method_call(chassis::busName, chassis::path,
+-                                             "org.freedesktop.DBus.Properties",
+-                                             "Set");
+-                method.append(chassis::interface, chassis::request,
+-                              std::variant<std::string>(target->second));
++                method = bus.new_method_call(SYSTEMD_SERVICE, SYSTEMD_ROOT,
++                                              SYSTEMD_INTERFACE, "StartUnit");
++                method.append(target->second);
++                method.append("replace");
+                 bus.call_noreply(method);
+             }
+         }
+-- 
+2.17.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/watchdog/phosphor-watchdog/phosphor-watchdog.service
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/watchdog/phosphor-watchdog/phosphor-watchdog.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Phosphor Watchdog
+
+[Service]
+ExecStart=/usr/bin/phosphor-watchdog --continue --service=xyz.openbmc_project.Watchdog \
+         --path=/xyz/openbmc_project/watchdog/host0 \
+         --action_target=xyz.openbmc_project.State.Watchdog.Action.HardReset=xyz.openbmc_project.State.Host.Transition.ForceWarmReboot \
+         --action_target=xyz.openbmc_project.State.Watchdog.Action.PowerOff=xyz.openbmc_project.State.Chassis.Transition.Off \
+         --action_target=xyz.openbmc_project.State.Watchdog.Action.PowerCycle=xyz.openbmc_project.State.Chassis.Transition.PowerCycle
+
+BusName=xyz.openbmc_project.Watchdog
+Type=dbus
+
+[Install]
+WantedBy=basic.target

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/watchdog/phosphor-watchdog_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/watchdog/phosphor-watchdog_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:scm-npcm845 = " \
+    file://0001-Customize-phosphor-watchdog-for-Intel-platforms.patch \
+    file://0002-Customize-phosphor-watchdog-for-Nuvoton-platform.patch \
+    "
+
+# Remove the override to keep service running after DC cycle
+SYSTEMD_OVERRIDE:${PN}:remove:scm-npcm845 = "poweron.conf:phosphor-watchdog@poweron.service.d/poweron.conf"
+SYSTEMD_SERVICE:${PN}:scm-npcm845 = "phosphor-watchdog.service"


### PR DESCRIPTION
Porting dbus-sensor patches from branch npcm-v2.12

Update SCM packages:
phosphor-dbus-interfaces, phosphor-ipmi-config,
phosphor-settings-manager, phosphor-watchdog

Signed-off-by: Brian Ma <chma0@nuvoton.com>
