### PR TITLE
meta-evb-nuvoton: meta-buv-runbmc: layer.conf: add langdale compatibi…

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/layer.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/layer.conf
@@ -7,4 +7,4 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "buv-runbmc-layer"
 BBFILE_PATTERN_buv-runbmc-layer := "^${LAYERDIR}/"
-LAYERSERIES_COMPAT_buv-runbmc-layer = "honister kirkstone"
+LAYERSERIES_COMPAT_buv-runbmc-layer = "kirkstone langdale"


### PR DESCRIPTION
…lity

Fix ERROR: Layer buv-runbmc-layer is not compatible with the core layer which only supports these series: langdale (layer is compatible with kirkstone honister)

Signed-off-by: yhyang2 <yhyang2@nuvoton.com>

