### PR TITLE
meta-nuvoton: Correct EDAC config name

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton/npcm8xx_defconfig
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton/npcm8xx_defconfig
@@ -171,7 +171,7 @@ CONFIG_DEBUG_FS=y
 # Enable EDAC support
 CONFIG_EDAC_SUPPORT=y
 CONFIG_EDAC=y
-CONFIG_EDAC_NPCM8XX=y
+CONFIG_EDAC_NPCM=y
 CONFIG_RAS=y
 
 # Enable RemotePorc driver support


### PR DESCRIPTION
EDAC config name was unexpectedly changed in commit 494e423. Just correct it back.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
