### PR TITLE
meta-quanta: meta-olympus-nuvoton: fix Olympus layer build error for …

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dbus/phosphor-dbus-interfaces-mapper-config-native.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dbus/phosphor-dbus-interfaces-mapper-config-native.bbappend
@@ -1,2 +1,0 @@
-PHOSPHOR_MAPPER_SERVICE:append:olympus-nuvoton = " com.intel.crashdump"
-PHOSPHOR_MAPPER_INTERFACE:append:olympus-nuvoton = " com.intel.crashdump"

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dbus/phosphor-dbus-interfaces/0001-support-type-uint8-uint16-uint64-for-inventory-manag.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/dbus/phosphor-dbus-interfaces/0001-support-type-uint8-uint16-uint64-for-inventory-manag.patch
@@ -15,8 +15,8 @@ index 6c791eec..1442e0ee 100644
            state managed.
        parameters:
            - name: object
--            type: dict[path,dict[string,dict[string,variant[boolean,size,int64,string,array[byte]]]]]
-+            type: dict[path,dict[string,dict[string,variant[boolean,size,int64,string,uint64,uint16,byte,array[byte]]]]]
+-            type: dict[object_path,dict[string,dict[string,variant[boolean,size,int64,string,array[byte]]]]]
++            type: dict[object_path,dict[string,dict[string,variant[boolean,size,int64,string,uint64,uint16,byte,array[byte]]]]]
              description: >
                  A dictionary of fully enumerated items to be managed.
 -- 

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -4,7 +4,7 @@ SRC_URI:append:olympus-nuvoton = " file://0001-Handle-now-allow-execption-in-acc
 SRC_URI:append:olympus-nuvoton = " file://0002-Redfish-Add-power-metrics-support.patch"
 SRC_URI:append:olympus-nuvoton = " file://0003-Create-new-user-without-SSH-group.patch"
 #SRC_URI:append:olympus-nuvoton = " file://0004-bmcweb-chassis-add-indicatorLED-support.patch"
-SRC_URI:append:olympus-nuvoton = " file://0005-redfish-log_services-fix-createDump-functionality.patch"
+#SRC_URI:append:olympus-nuvoton = " file://0005-redfish-log_services-fix-createDump-functionality.patch"
 
 # Enable CPU Log support
 EXTRA_OEMESON:append:olympus-nuvoton = " -Dredfish-cpu-log=enabled"

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/users/phosphor-user-manager_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/users/phosphor-user-manager_%.bbappend
@@ -2,6 +2,5 @@
 FILESEXTRAPATHS:append := "${THISDIR}/${PN}:"
 
 SRC_URI:append:olympus-nuvoton = " \
-    file://0001-meta-quanta-meta-olympus-nuvoton-phosphor-user-manag.patch \
     file://0001-Throw-NotAllowed-when-delete-or-disable-root.patch \
     "


### PR DESCRIPTION
…OpenBmc updating

Remove/modify patches whcih will casuse build error.

If meet another build error of phosphor-inventory-manager, key words are: "notify marked 'override', but does not override" Do clean build could fix it.

Test done: build OK, boot OK, login OK

TODO: Run full test-automation to see if there is side effect.

Signed-off-by: Allen Kang <jhkang@nuvoton.com>
