### PR TITLE
meta-scm-npcm845: update patches to fix build break

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/flash/phosphor-software-manager/0002-Support-ignore-update-uboot-with-eMMC-image.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/flash/phosphor-software-manager/0002-Support-ignore-update-uboot-with-eMMC-image.patch
@@ -1,4 +1,4 @@
-From 57fcbef2b50e8373c504fa8f2570aded34960dd7 Mon Sep 17 00:00:00 2001
+From 2e0b0534569bf84f17cc5c705706599c59a60d44 Mon Sep 17 00:00:00 2001
 From: Brian Ma <chma0@nuvoton.com>
 Date: Thu, 17 Feb 2022 08:50:52 +0800
 Subject: [PATCH 2/2] Support ignore update uboot with eMMC image
@@ -9,7 +9,7 @@ Signed-off-by: Brian Ma <chma0@nuvoton.com>
  1 file changed, 29 insertions(+), 12 deletions(-)
 
 diff --git a/obmc-flash-bmc b/obmc-flash-bmc
-index 67e3a88..a024c8a 100644
+index b76ad62..bd4506c 100644
 --- a/obmc-flash-bmc
 +++ b/obmc-flash-bmc
 @@ -1,6 +1,8 @@
@@ -19,101 +19,101 @@ index 67e3a88..a024c8a 100644
 +ulog="/var/log/update.log"
 +
  # Get the root mtd device number (mtdX) from "/dev/ubiblockX_Y on /"
- findrootmtd() {
-   rootmatch=" on / "
-@@ -387,7 +389,7 @@ ubi_setenv() {
- mtd_write() {
-   flashmtd="$(findmtd "${reqmtd}")"
-   img="/tmp/images/${version}/${imgfile}"
--  flashcp -v "${img}" /dev/"${flashmtd}"
-+  flashcp -v "${img}" /dev/"${flashmtd}" >> "${ulog}"
+ function findrootmtd() {
+     rootmatch=" on / "
+@@ -387,7 +389,7 @@ function ubi_setenv() {
+ function mtd_write() {
+     flashmtd="$(findmtd "${reqmtd}")"
+     img="/tmp/images/${version}/${imgfile}"
+-    flashcp -v "${img}" /dev/"${flashmtd}"
++    flashcp -v "${img}" /dev/"${flashmtd}" >> "${ulog}"
  }
  
- backup_env_vars() {
-@@ -491,6 +493,13 @@ cmp_uboot() {
-   device="$1"
-   image="$2"
+ function backup_env_vars() {
+@@ -491,6 +493,13 @@ function cmp_uboot() {
+     device="$1"
+     image="$2"
  
-+  # if no uboot image need to update
-+  if [ ! -f "${image}" ];then
-+    echo "no uboot file for update" >> "${ulog}"
-+    echo 0
-+    return
-+  fi
++    # if no uboot image need to update
++    if [ ! -f "${image}" ];then
++      echo "no uboot file for update" >> "${ulog}"
++      echo 0
++      return
++    fi
 +
-   # Since the image file can be smaller than the device, copy the device to a
-   # tmp file and write the image file on top, then compare the sum of each.
-   # Use cat / redirection since busybox does not have the conv=notrunc option.
-@@ -501,6 +510,9 @@ cmp_uboot() {
-   imgSum="$(sha256sum "${tmpFile}")"
-   rm -f "${tmpFile}"
+     # Since the image file can be smaller than the device, copy the device to a
+     # tmp file and write the image file on top, then compare the sum of each.
+     # Use cat / redirection since busybox does not have the conv=notrunc option.
+@@ -501,6 +510,9 @@ function cmp_uboot() {
+     imgSum="$(sha256sum "${tmpFile}")"
+     rm -f "${tmpFile}"
  
-+  echo "image checksum: ${imgSum}" >> "${ulog}"
-+  echo "mtd device checksum: ${devSum}" >> "${ulog}"
++    echo "image checksum: ${imgSum}" >> "${ulog}"
++    echo "mtd device checksum: ${devSum}" >> "${ulog}"
 +
-   if [ "${imgSum}" == "${devSum}" ]; then
-     echo "0";
-   else
-@@ -555,35 +567,33 @@ mmc_mount() {
+     if [ "${imgSum}" == "${devSum}" ]; then
+         echo "0";
+     else
+@@ -555,35 +567,33 @@ function mmc_mount() {
  }
  
- mmc_update() {
--  # Update u-boot if needed
--  bootPartition="mmcblk0boot0"
--  devUBoot="/dev/${bootPartition}"
--  imgUBoot="${imgpath}/${version}/image-u-boot"
--  if [ "$(cmp_uboot "${devUBoot}" "${imgUBoot}")" != "0" ]; then
--    echo 0 > "/sys/block/${bootPartition}/force_ro"
--    dd if="${imgUBoot}" of="${devUBoot}"
--    echo 1 > "/sys/block/${bootPartition}/force_ro"
--  fi
-+  echo "start mmc update, version: ${version}" >> "${ulog}"
-+  echo $(date) >> "${ulog}"
+ function mmc_update() {
+-    # Update u-boot if needed
+-    bootPartition="mmcblk0boot0"
+-    devUBoot="/dev/${bootPartition}"
+-    imgUBoot="${imgpath}/${version}/image-u-boot"
+-    if [ "$(cmp_uboot "${devUBoot}" "${imgUBoot}")" != "0" ]; then
+-        echo 0 > "/sys/block/${bootPartition}/force_ro"
+-        dd if="${imgUBoot}" of="${devUBoot}"
+-        echo 1 > "/sys/block/${bootPartition}/force_ro"
+-    fi
++    echo "start mmc update, version: ${version}" >> "${ulog}"
++    echo $(date) >> "${ulog}"
  
-   # Update the secondary (non-running) boot and rofs partitions.
-   label="$(mmc_get_secondary_label)"
+     # Update the secondary (non-running) boot and rofs partitions.
+     label="$(mmc_get_secondary_label)"
  
-   # Update the boot and rootfs partitions, restore their labels after the update
-   # by getting the partition number mmcblk0pX from their label.
-+  echo "start update kernel: boot-${label}" >> "${ulog}"
-   zstd -d -c "${imgpath}"/"${version}"/image-kernel | dd of="/dev/disk/by-partlabel/boot-${label}"
-   number="$(readlink -f /dev/disk/by-partlabel/boot-"${label}")"
-   number="${number##*mmcblk0p}"
-   sgdisk --change-name="${number}":boot-"${label}" /dev/mmcblk0 1>/dev/null
+     # Update the boot and rootfs partitions, restore their labels after the update
+     # by getting the partition number mmcblk0pX from their label.
++    echo "start update kernel: boot-${label}" >> "${ulog}"
+     zstd -d -c "${imgpath}"/"${version}"/image-kernel | dd of="/dev/disk/by-partlabel/boot-${label}"
+     number="$(readlink -f /dev/disk/by-partlabel/boot-"${label}")"
+     number="${number##*mmcblk0p}"
+     sgdisk --change-name="${number}":boot-"${label}" /dev/mmcblk0 1>/dev/null
  
-+  echo "start update rofs: rofs-${label}" >> "${ulog}"
-   zstd -d -c "${imgpath}"/"${version}"/image-rofs | dd of="/dev/disk/by-partlabel/rofs-${label}"
-   number="$(readlink -f /dev/disk/by-partlabel/rofs-"${label}")"
-   number="${number##*mmcblk0p}"
-   sgdisk --change-name="${number}":rofs-"${label}" /dev/mmcblk0 1>/dev/null
++    echo "start update rofs: rofs-${label}" >> "${ulog}"
+     zstd -d -c "${imgpath}"/"${version}"/image-rofs | dd of="/dev/disk/by-partlabel/rofs-${label}"
+     number="$(readlink -f /dev/disk/by-partlabel/rofs-"${label}")"
+     number="${number##*mmcblk0p}"
+     sgdisk --change-name="${number}":rofs-"${label}" /dev/mmcblk0 1>/dev/null
  
-   # Run this after sgdisk for labels to take effect.
--  partprobe
-+  echo "start partprobe" >> "${ulog}"
-+  # fix some mtd device get Invalid partition table
-+  partprobe /dev/mmcblk0
+     # Run this after sgdisk for labels to take effect.
+-    partprobe
++    echo "start partprobe" >> "${ulog}"
++    # fix some mtd device get Invalid partition table
++    partprobe /dev/mmcblk0
  
-   # Update hostfw
-+  echo "start try to update hostfw" >> "${ulog}"
-   if [ -f "${imgpath}"/"${version}"/image-hostfw ]; then
-     # Remove patches
-     patchdir="/usr/local/share/hostfw/alternate"
-@@ -596,7 +606,14 @@ mmc_update() {
-     mount "${hostfwdir}"/hostfw-"${label}" "${hostfwdir}"/alternate -o ro
-   fi
+     # Update hostfw
++    echo "start try to update hostfw" >> "${ulog}"
+     if [ -f "${imgpath}"/"${version}"/image-hostfw ]; then
+         # Remove patches
+         patchdir="/usr/local/share/hostfw/alternate"
+@@ -596,7 +606,14 @@ function mmc_update() {
+         mount "${hostfwdir}"/hostfw-"${label}" "${hostfwdir}"/alternate -o ro
+     fi
  
--  set_flashid "${label}"
-+  # handle the ipmi flash bmc update
-+  if [ "${version}" == "bmc-image" ]; then
-+    echo "directly update bootside for ipmi flash bmc" >> "${ulog}"
-+    fw_setenv bootside "${label}"
-+  else
-+    set_flashid "${label}"
-+  fi
-+  echo "end of mmc update" >> "${ulog}"
+-    set_flashid "${label}"
++    # handle the ipmi flash bmc update
++    if [ "${version}" == "bmc-image" ]; then
++      echo "directly update bootside for ipmi flash bmc" >> "${ulog}"
++      fw_setenv bootside "${label}"
++    else
++      set_flashid "${label}"
++    fi
++    echo "end of mmc update" >> "${ulog}"
  }
  
- mmc_remove() {
+ function mmc_remove() {
 -- 
-2.17.1
+2.34.1
 

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend:evb-npcm845 := "${THISDIR}/${PN}:"
 
 SRC_URI:append:evb-npcm845 = " file://0001-Restore-and-verify-BIOS.patch"
-#SRC_URI:append:evb-npcm845 = " file://0002-Support-ignore-update-uboot-with-eMMC-image.patch"
+SRC_URI:append:evb-npcm845 = " file://0002-Support-ignore-update-uboot-with-eMMC-image.patch"
 
 PACKAGECONFIG:evb-npcm845 += "verify_signature flash_bios"
 EXTRA_OEMESON:append:evb-npcm845 = " -Doptional-images=image-bios"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/flash/phosphor-software-manager/support_update_uboot_with_emmc_image.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/flash/phosphor-software-manager/support_update_uboot_with_emmc_image.patch
@@ -1,4 +1,4 @@
-From 4e48c0b94185f06dee46715df6df839e948d5bac Mon Sep 17 00:00:00 2001
+From 374457212fc7ef1131435bebc5c63d31a87026e5 Mon Sep 17 00:00:00 2001
 From: Brian Ma <chma0@nuvoton.com>
 Date: Thu, 17 Feb 2022 08:50:52 +0800
 Subject: [PATCH] Support update uboot with emmc image
@@ -9,7 +9,7 @@ Signed-off-by: Brian Ma <chma0@nuvoton.com>
  1 file changed, 34 insertions(+), 8 deletions(-)
 
 diff --git a/obmc-flash-bmc b/obmc-flash-bmc
-index 54dfbc9..96540f3 100644
+index b76ad62..1b62656 100644
 --- a/obmc-flash-bmc
 +++ b/obmc-flash-bmc
 @@ -1,6 +1,8 @@
@@ -19,106 +19,106 @@ index 54dfbc9..96540f3 100644
 +ulog="/var/log/update.log"
 +
  # Get the root mtd device number (mtdX) from "/dev/ubiblockX_Y on /"
- findrootmtd() {
-   rootmatch=" on / "
-@@ -387,7 +389,7 @@ ubi_setenv() {
- mtd_write() {
-   flashmtd="$(findmtd "${reqmtd}")"
-   img="/tmp/images/${version}/${imgfile}"
--  flashcp -v "${img}" /dev/"${flashmtd}"
-+  flashcp -v "${img}" /dev/"${flashmtd}" >> "${ulog}"
+ function findrootmtd() {
+     rootmatch=" on / "
+@@ -387,7 +389,7 @@ function ubi_setenv() {
+ function mtd_write() {
+     flashmtd="$(findmtd "${reqmtd}")"
+     img="/tmp/images/${version}/${imgfile}"
+-    flashcp -v "${img}" /dev/"${flashmtd}"
++    flashcp -v "${img}" /dev/"${flashmtd}" >> "${ulog}"
  }
  
- backup_env_vars() {
-@@ -491,6 +493,13 @@ cmp_uboot() {
-   device="$1"
-   image="$2"
+ function backup_env_vars() {
+@@ -491,6 +493,13 @@ function cmp_uboot() {
+     device="$1"
+     image="$2"
  
-+  # if no uboot image need to update
-+  if [ ! -f "${image}" ];then
-+    echo "no uboot file for update" >> "${ulog}"
-+    echo 0
-+    return
-+  fi
++    # if no uboot image need to update
++    if [ ! -f "${image}" ];then
++      echo "no uboot file for update" >> "${ulog}"
++      echo 0
++      return
++    fi
 +
-   # Since the image file can be smaller than the device, copy the device to a
-   # tmp file and write the image file on top, then compare the sum of each.
-   # Use cat / redirection since busybox does not have the conv=notrunc option.
-@@ -501,6 +510,9 @@ cmp_uboot() {
-   imgSum="$(sha256sum "${tmpFile}")"
-   rm -f "${tmpFile}"
+     # Since the image file can be smaller than the device, copy the device to a
+     # tmp file and write the image file on top, then compare the sum of each.
+     # Use cat / redirection since busybox does not have the conv=notrunc option.
+@@ -501,6 +510,9 @@ function cmp_uboot() {
+     imgSum="$(sha256sum "${tmpFile}")"
+     rm -f "${tmpFile}"
  
-+  echo "image checksum: ${imgSum}" >> "${ulog}"
-+  echo "mtd device checksum: ${devSum}" >> "${ulog}"
++    echo "image checksum: ${imgSum}" >> "${ulog}"
++    echo "mtd device checksum: ${devSum}" >> "${ulog}"
 +
-   if [ "${imgSum}" == "${devSum}" ]; then
-     echo "0";
-   else
-@@ -554,14 +566,16 @@ mmc_mount() {
+     if [ "${imgSum}" == "${devSum}" ]; then
+         echo "0";
+     else
+@@ -555,14 +567,16 @@ function mmc_mount() {
  }
  
- mmc_update() {
-+  echo "start mmc update, version: ${version}" >> "${ulog}"
-+  echo $(date) >> "${ulog}"
-   # Update u-boot if needed
--  bootPartition="mmcblk0boot0"
--  devUBoot="/dev/${bootPartition}"
-+  devUBoot="/dev/$(findmtd u-boot)"
-   imgUBoot="${imgpath}/${version}/image-u-boot"
-   if [ "$(cmp_uboot "${devUBoot}" "${imgUBoot}")" != "0" ]; then
--    echo 0 > "/sys/block/${bootPartition}/force_ro"
--    dd if="${imgUBoot}" of="${devUBoot}"
--    echo 1 > "/sys/block/${bootPartition}/force_ro"
-+    echo "uboot need update" >> "${ulog}"
-+    imgfile=image-u-boot
-+    reqmtd=u-boot
-+    mtd_write
-   fi
+ function mmc_update() {
++    echo "start mmc update, version: ${version}" >> "${ulog}"
++    echo $(date) >> "${ulog}"
+     # Update u-boot if needed
+-    bootPartition="mmcblk0boot0"
+-    devUBoot="/dev/${bootPartition}"
++    devUBoot="/dev/$(findmtd u-boot)"
+     imgUBoot="${imgpath}/${version}/image-u-boot"
+     if [ "$(cmp_uboot "${devUBoot}" "${imgUBoot}")" != "0" ]; then
+-        echo 0 > "/sys/block/${bootPartition}/force_ro"
+-        dd if="${imgUBoot}" of="${devUBoot}"
+-        echo 1 > "/sys/block/${bootPartition}/force_ro"
++        echo "uboot need update" >> "${ulog}"
++        imgfile=image-u-boot
++        reqmtd=u-boot
++        mtd_write
+     fi
  
-   # Update the secondary (non-running) boot and rofs partitions.
-@@ -569,20 +583,25 @@ mmc_update() {
+     # Update the secondary (non-running) boot and rofs partitions.
+@@ -570,20 +584,25 @@ function mmc_update() {
  
-   # Update the boot and rootfs partitions, restore their labels after the update
-   # by getting the partition number mmcblk0pX from their label.
-+  echo "start update kernel: boot-${label}" >> "${ulog}"
-   zstd -d -c "${imgpath}"/"${version}"/image-kernel | dd of="/dev/disk/by-partlabel/boot-${label}"
-   number="$(readlink -f /dev/disk/by-partlabel/boot-"${label}")"
-   number="${number##*mmcblk0p}"
-   sgdisk --change-name="${number}":boot-"${label}" /dev/mmcblk0 1>/dev/null
+     # Update the boot and rootfs partitions, restore their labels after the update
+     # by getting the partition number mmcblk0pX from their label.
++    echo "start update kernel: boot-${label}" >> "${ulog}"
+     zstd -d -c "${imgpath}"/"${version}"/image-kernel | dd of="/dev/disk/by-partlabel/boot-${label}"
+     number="$(readlink -f /dev/disk/by-partlabel/boot-"${label}")"
+     number="${number##*mmcblk0p}"
+     sgdisk --change-name="${number}":boot-"${label}" /dev/mmcblk0 1>/dev/null
  
-+  echo "start update rofs: rofs-${label}" >> "${ulog}"
-   zstd -d -c "${imgpath}"/"${version}"/image-rofs | dd of="/dev/disk/by-partlabel/rofs-${label}"
-   number="$(readlink -f /dev/disk/by-partlabel/rofs-"${label}")"
-   number="${number##*mmcblk0p}"
-   sgdisk --change-name="${number}":rofs-"${label}" /dev/mmcblk0 1>/dev/null
++    echo "start update rofs: rofs-${label}" >> "${ulog}"
+     zstd -d -c "${imgpath}"/"${version}"/image-rofs | dd of="/dev/disk/by-partlabel/rofs-${label}"
+     number="$(readlink -f /dev/disk/by-partlabel/rofs-"${label}")"
+     number="${number##*mmcblk0p}"
+     sgdisk --change-name="${number}":rofs-"${label}" /dev/mmcblk0 1>/dev/null
  
-   # Run this after sgdisk for labels to take effect.
--  partprobe
-+  echo "start partprobe" >> "${ulog}"
-+  # fix some mtd device get Invalid partition table
-+  partprobe /dev/mmcblk0
+     # Run this after sgdisk for labels to take effect.
+-    partprobe
++    echo "start partprobe" >> "${ulog}"
++    # fix some mtd device get Invalid partition table
++    partprobe /dev/mmcblk0
  
-   # Update hostfw
-+  echo "start try to update hostfw" >> "${ulog}"
-   if [ -f "${imgpath}"/"${version}"/image-hostfw ]; then
-     # Remove patches
-     patchdir="/usr/local/share/hostfw/alternate"
-@@ -595,7 +614,14 @@ mmc_update() {
-     mount "${hostfwdir}"/hostfw-"${label}" "${hostfwdir}"/alternate -o ro
-   fi
+     # Update hostfw
++    echo "start try to update hostfw" >> "${ulog}"
+     if [ -f "${imgpath}"/"${version}"/image-hostfw ]; then
+         # Remove patches
+         patchdir="/usr/local/share/hostfw/alternate"
+@@ -596,7 +615,14 @@ function mmc_update() {
+         mount "${hostfwdir}"/hostfw-"${label}" "${hostfwdir}"/alternate -o ro
+     fi
  
--  set_flashid "${label}"
-+  # handle the ipmi flash bmc update
-+  if [ "${version}" == "bmc-image" ]; then
-+    echo "directly update bootside for ipmi flash bmc" >> "${ulog}"
-+    fw_setenv bootside "${label}"
-+  else
-+    set_flashid "${label}"
-+  fi
-+  echo "end of mmc update" >> "${ulog}"
+-    set_flashid "${label}"
++    # handle the ipmi flash bmc update
++    if [ "${version}" == "bmc-image" ]; then
++      echo "directly update bootside for ipmi flash bmc" >> "${ulog}"
++      fw_setenv bootside "${label}"
++    else
++      set_flashid "${label}"
++    fi
++    echo "end of mmc update" >> "${ulog}"
  }
  
- mmc_remove() {
+ function mmc_remove() {
 -- 
-2.17.1
+2.34.1
 

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -3,6 +3,6 @@ FILESEXTRAPATHS:prepend:scm-npcm845 := "${THISDIR}/${PN}:"
 PACKAGECONFIG:append:scm-npcm845 = " verify_signature flash_bios"
 
 SRC_URI:append:scm-npcm845 = " file://restore_verify_bios.patch"
-#SRC_URI:append:scm-npcm845 = " file://support_update_uboot_with_emmc_image.patch"
+SRC_URI:append:scm-npcm845 = " file://support_update_uboot_with_emmc_image.patch"
 
 EXTRA_OEMESON:append:scm-npcm845 = " -Doptional-images=image-bios"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/watchdog/phosphor-watchdog/0001-Customize-phosphor-watchdog-for-Intel-platforms.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/watchdog/phosphor-watchdog/0001-Customize-phosphor-watchdog-for-Intel-platforms.patch
@@ -1,4 +1,4 @@
-From a2a8b080f73a32c86a4eed4f483d60e293eb7753 Mon Sep 17 00:00:00 2001
+From c1cab76497ad5e7f454e31e70b3f15922d375f41 Mon Sep 17 00:00:00 2001
 From: James Feist <james.feist@linux.intel.com>
 Date: Mon, 17 Jun 2019 12:00:58 -0700
 Subject: [PATCH 1/2] Customize phosphor-watchdog for Intel platforms
@@ -27,7 +27,7 @@ Signed-off-by: Sunita Kumari <sunitax.kumari@intel.com>
  2 files changed, 240 insertions(+), 11 deletions(-)
 
 diff --git a/src/watchdog.cpp b/src/watchdog.cpp
-index 918a372..6eab537 100644
+index c401022..b88636a 100644
 --- a/src/watchdog.cpp
 +++ b/src/watchdog.cpp
 @@ -5,8 +5,10 @@
@@ -245,7 +245,7 @@ index 918a372..6eab537 100644
  
      auto target = actionTargetMap.find(action);
      if (target == actionTargetMap.end())
-@@ -146,12 +322,45 @@ void Watchdog::timeOutHandler()
+@@ -133,12 +309,45 @@ void Watchdog::timeOutHandler()
  
          try
          {
@@ -297,15 +297,15 @@ index 918a372..6eab537 100644
          catch (const sdbusplus::exception_t& e)
          {
 diff --git a/src/watchdog.hpp b/src/watchdog.hpp
-index 16f05f1..822c422 100644
+index a0693ee..406ac86 100644
 --- a/src/watchdog.hpp
 +++ b/src/watchdog.hpp
-@@ -73,7 +73,17 @@ class Watchdog : public WatchdogInherits
+@@ -74,7 +74,17 @@ class Watchdog : public WatchdogInherits
          bus(bus), actionTargetMap(std::move(actionTargetMap)),
          fallback(fallback), minInterval(minInterval),
          timer(event, std::bind(&Watchdog::timeOutHandler, this)),
--        objPath(objPath)
-+        objPath(objPath), powerStateChangedSignal(
+-        objPath(objPath), exitAfterTimeout(exitAfterTimeout)
++        objPath(objPath), exitAfterTimeout(exitAfterTimeout), powerStateChangedSignal(
 +            bus,
 +            sdbusplus::bus::match::rules::propertiesChanged(
 +                "/xyz/openbmc_project/state/host0",
@@ -319,7 +319,7 @@ index 16f05f1..822c422 100644
      {
          // Use default if passed in otherwise just use default that comes
          // with object
-@@ -90,6 +100,12 @@ class Watchdog : public WatchdogInherits
+@@ -91,6 +101,12 @@ class Watchdog : public WatchdogInherits
          tryFallbackOrDisable();
      }
  
@@ -332,7 +332,7 @@ index 16f05f1..822c422 100644
      /** @brief Resets the TimeRemaining to the configured Interval
       *         Optionally enables the watchdog.
       *
-@@ -178,6 +194,10 @@ class Watchdog : public WatchdogInherits
+@@ -179,6 +195,10 @@ class Watchdog : public WatchdogInherits
      /** @brief Contained timer object */
      sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> timer;
  
@@ -344,5 +344,5 @@ index 16f05f1..822c422 100644
      void timeOutHandler();
  
 -- 
-2.17.1
+2.34.1
 

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/watchdog/phosphor-watchdog_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/watchdog/phosphor-watchdog_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-#SRC_URI:append:scm-npcm845 = " file://0001-Customize-phosphor-watchdog-for-Intel-platforms.patch"
-#SRC_URI:append:scm-npcm845 = " file://0002-Customize-phosphor-watchdog-for-Nuvoton-platform.patch"
+SRC_URI:append:scm-npcm845 = " file://0001-Customize-phosphor-watchdog-for-Intel-platforms.patch"
+SRC_URI:append:scm-npcm845 = " file://0002-Customize-phosphor-watchdog-for-Nuvoton-platform.patch"
 
 # Remove the override to keep service running after DC cycle
 SYSTEMD_OVERRIDE:${PN}:remove:scm-npcm845 = "poweron.conf:phosphor-watchdog@poweron.service.d/poweron.conf"

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager/support_update_uboot_with_emmc_image.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager/support_update_uboot_with_emmc_image.patch
@@ -1,4 +1,4 @@
-From 4e48c0b94185f06dee46715df6df839e948d5bac Mon Sep 17 00:00:00 2001
+From 374457212fc7ef1131435bebc5c63d31a87026e5 Mon Sep 17 00:00:00 2001
 From: Brian Ma <chma0@nuvoton.com>
 Date: Thu, 17 Feb 2022 08:50:52 +0800
 Subject: [PATCH] Support update uboot with emmc image
@@ -9,7 +9,7 @@ Signed-off-by: Brian Ma <chma0@nuvoton.com>
  1 file changed, 34 insertions(+), 8 deletions(-)
 
 diff --git a/obmc-flash-bmc b/obmc-flash-bmc
-index 54dfbc9..96540f3 100644
+index b76ad62..1b62656 100644
 --- a/obmc-flash-bmc
 +++ b/obmc-flash-bmc
 @@ -1,6 +1,8 @@
@@ -19,106 +19,106 @@ index 54dfbc9..96540f3 100644
 +ulog="/var/log/update.log"
 +
  # Get the root mtd device number (mtdX) from "/dev/ubiblockX_Y on /"
- findrootmtd() {
-   rootmatch=" on / "
-@@ -387,7 +389,7 @@ ubi_setenv() {
- mtd_write() {
-   flashmtd="$(findmtd "${reqmtd}")"
-   img="/tmp/images/${version}/${imgfile}"
--  flashcp -v "${img}" /dev/"${flashmtd}"
-+  flashcp -v "${img}" /dev/"${flashmtd}" >> "${ulog}"
+ function findrootmtd() {
+     rootmatch=" on / "
+@@ -387,7 +389,7 @@ function ubi_setenv() {
+ function mtd_write() {
+     flashmtd="$(findmtd "${reqmtd}")"
+     img="/tmp/images/${version}/${imgfile}"
+-    flashcp -v "${img}" /dev/"${flashmtd}"
++    flashcp -v "${img}" /dev/"${flashmtd}" >> "${ulog}"
  }
  
- backup_env_vars() {
-@@ -491,6 +493,13 @@ cmp_uboot() {
-   device="$1"
-   image="$2"
+ function backup_env_vars() {
+@@ -491,6 +493,13 @@ function cmp_uboot() {
+     device="$1"
+     image="$2"
  
-+  # if no uboot image need to update
-+  if [ ! -f "${image}" ];then
-+    echo "no uboot file for update" >> "${ulog}"
-+    echo 0
-+    return
-+  fi
++    # if no uboot image need to update
++    if [ ! -f "${image}" ];then
++      echo "no uboot file for update" >> "${ulog}"
++      echo 0
++      return
++    fi
 +
-   # Since the image file can be smaller than the device, copy the device to a
-   # tmp file and write the image file on top, then compare the sum of each.
-   # Use cat / redirection since busybox does not have the conv=notrunc option.
-@@ -501,6 +510,9 @@ cmp_uboot() {
-   imgSum="$(sha256sum "${tmpFile}")"
-   rm -f "${tmpFile}"
+     # Since the image file can be smaller than the device, copy the device to a
+     # tmp file and write the image file on top, then compare the sum of each.
+     # Use cat / redirection since busybox does not have the conv=notrunc option.
+@@ -501,6 +510,9 @@ function cmp_uboot() {
+     imgSum="$(sha256sum "${tmpFile}")"
+     rm -f "${tmpFile}"
  
-+  echo "image checksum: ${imgSum}" >> "${ulog}"
-+  echo "mtd device checksum: ${devSum}" >> "${ulog}"
++    echo "image checksum: ${imgSum}" >> "${ulog}"
++    echo "mtd device checksum: ${devSum}" >> "${ulog}"
 +
-   if [ "${imgSum}" == "${devSum}" ]; then
-     echo "0";
-   else
-@@ -554,14 +566,16 @@ mmc_mount() {
+     if [ "${imgSum}" == "${devSum}" ]; then
+         echo "0";
+     else
+@@ -555,14 +567,16 @@ function mmc_mount() {
  }
  
- mmc_update() {
-+  echo "start mmc update, version: ${version}" >> "${ulog}"
-+  echo $(date) >> "${ulog}"
-   # Update u-boot if needed
--  bootPartition="mmcblk0boot0"
--  devUBoot="/dev/${bootPartition}"
-+  devUBoot="/dev/$(findmtd u-boot)"
-   imgUBoot="${imgpath}/${version}/image-u-boot"
-   if [ "$(cmp_uboot "${devUBoot}" "${imgUBoot}")" != "0" ]; then
--    echo 0 > "/sys/block/${bootPartition}/force_ro"
--    dd if="${imgUBoot}" of="${devUBoot}"
--    echo 1 > "/sys/block/${bootPartition}/force_ro"
-+    echo "uboot need update" >> "${ulog}"
-+    imgfile=image-u-boot
-+    reqmtd=u-boot
-+    mtd_write
-   fi
+ function mmc_update() {
++    echo "start mmc update, version: ${version}" >> "${ulog}"
++    echo $(date) >> "${ulog}"
+     # Update u-boot if needed
+-    bootPartition="mmcblk0boot0"
+-    devUBoot="/dev/${bootPartition}"
++    devUBoot="/dev/$(findmtd u-boot)"
+     imgUBoot="${imgpath}/${version}/image-u-boot"
+     if [ "$(cmp_uboot "${devUBoot}" "${imgUBoot}")" != "0" ]; then
+-        echo 0 > "/sys/block/${bootPartition}/force_ro"
+-        dd if="${imgUBoot}" of="${devUBoot}"
+-        echo 1 > "/sys/block/${bootPartition}/force_ro"
++        echo "uboot need update" >> "${ulog}"
++        imgfile=image-u-boot
++        reqmtd=u-boot
++        mtd_write
+     fi
  
-   # Update the secondary (non-running) boot and rofs partitions.
-@@ -569,20 +583,25 @@ mmc_update() {
+     # Update the secondary (non-running) boot and rofs partitions.
+@@ -570,20 +584,25 @@ function mmc_update() {
  
-   # Update the boot and rootfs partitions, restore their labels after the update
-   # by getting the partition number mmcblk0pX from their label.
-+  echo "start update kernel: boot-${label}" >> "${ulog}"
-   zstd -d -c "${imgpath}"/"${version}"/image-kernel | dd of="/dev/disk/by-partlabel/boot-${label}"
-   number="$(readlink -f /dev/disk/by-partlabel/boot-"${label}")"
-   number="${number##*mmcblk0p}"
-   sgdisk --change-name="${number}":boot-"${label}" /dev/mmcblk0 1>/dev/null
+     # Update the boot and rootfs partitions, restore their labels after the update
+     # by getting the partition number mmcblk0pX from their label.
++    echo "start update kernel: boot-${label}" >> "${ulog}"
+     zstd -d -c "${imgpath}"/"${version}"/image-kernel | dd of="/dev/disk/by-partlabel/boot-${label}"
+     number="$(readlink -f /dev/disk/by-partlabel/boot-"${label}")"
+     number="${number##*mmcblk0p}"
+     sgdisk --change-name="${number}":boot-"${label}" /dev/mmcblk0 1>/dev/null
  
-+  echo "start update rofs: rofs-${label}" >> "${ulog}"
-   zstd -d -c "${imgpath}"/"${version}"/image-rofs | dd of="/dev/disk/by-partlabel/rofs-${label}"
-   number="$(readlink -f /dev/disk/by-partlabel/rofs-"${label}")"
-   number="${number##*mmcblk0p}"
-   sgdisk --change-name="${number}":rofs-"${label}" /dev/mmcblk0 1>/dev/null
++    echo "start update rofs: rofs-${label}" >> "${ulog}"
+     zstd -d -c "${imgpath}"/"${version}"/image-rofs | dd of="/dev/disk/by-partlabel/rofs-${label}"
+     number="$(readlink -f /dev/disk/by-partlabel/rofs-"${label}")"
+     number="${number##*mmcblk0p}"
+     sgdisk --change-name="${number}":rofs-"${label}" /dev/mmcblk0 1>/dev/null
  
-   # Run this after sgdisk for labels to take effect.
--  partprobe
-+  echo "start partprobe" >> "${ulog}"
-+  # fix some mtd device get Invalid partition table
-+  partprobe /dev/mmcblk0
+     # Run this after sgdisk for labels to take effect.
+-    partprobe
++    echo "start partprobe" >> "${ulog}"
++    # fix some mtd device get Invalid partition table
++    partprobe /dev/mmcblk0
  
-   # Update hostfw
-+  echo "start try to update hostfw" >> "${ulog}"
-   if [ -f "${imgpath}"/"${version}"/image-hostfw ]; then
-     # Remove patches
-     patchdir="/usr/local/share/hostfw/alternate"
-@@ -595,7 +614,14 @@ mmc_update() {
-     mount "${hostfwdir}"/hostfw-"${label}" "${hostfwdir}"/alternate -o ro
-   fi
+     # Update hostfw
++    echo "start try to update hostfw" >> "${ulog}"
+     if [ -f "${imgpath}"/"${version}"/image-hostfw ]; then
+         # Remove patches
+         patchdir="/usr/local/share/hostfw/alternate"
+@@ -596,7 +615,14 @@ function mmc_update() {
+         mount "${hostfwdir}"/hostfw-"${label}" "${hostfwdir}"/alternate -o ro
+     fi
  
--  set_flashid "${label}"
-+  # handle the ipmi flash bmc update
-+  if [ "${version}" == "bmc-image" ]; then
-+    echo "directly update bootside for ipmi flash bmc" >> "${ulog}"
-+    fw_setenv bootside "${label}"
-+  else
-+    set_flashid "${label}"
-+  fi
-+  echo "end of mmc update" >> "${ulog}"
+-    set_flashid "${label}"
++    # handle the ipmi flash bmc update
++    if [ "${version}" == "bmc-image" ]; then
++      echo "directly update bootside for ipmi flash bmc" >> "${ulog}"
++      fw_setenv bootside "${label}"
++    else
++      set_flashid "${label}"
++    fi
++    echo "end of mmc update" >> "${ulog}"
  }
  
- mmc_remove() {
+ function mmc_remove() {
 -- 
-2.17.1
+2.34.1
 

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend:olympus-nuvoton := "${THISDIR}/${PN}:"
 
-#SRC_URI:append:olympus-nuvoton = " file://support_update_uboot_with_emmc_image.patch"
+SRC_URI:append:olympus-nuvoton = " file://support_update_uboot_with_emmc_image.patch"
 SRC_URI:append:olympus-nuvoton = " file://restore_verify_bios.patch"
 SRC_URI:append:olympus-nuvoton = " file://report_same_version.patch"
 #SRC_URI:append:olympus-nuvoton = " file://avoid_update_bios_fail_remove_mmc"

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/watchdog/phosphor-watchdog/0001-Customize-phosphor-watchdog-for-Intel-platforms.patch
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/watchdog/phosphor-watchdog/0001-Customize-phosphor-watchdog-for-Intel-platforms.patch
@@ -1,7 +1,7 @@
-From a698c0e71a132acc56a94b2e9aa36cf94b7dd506 Mon Sep 17 00:00:00 2001
+From c1cab76497ad5e7f454e31e70b3f15922d375f41 Mon Sep 17 00:00:00 2001
 From: James Feist <james.feist@linux.intel.com>
 Date: Mon, 17 Jun 2019 12:00:58 -0700
-Subject: [PATCH] Customize phosphor-watchdog for Intel platforms
+Subject: [PATCH 1/2] Customize phosphor-watchdog for Intel platforms
 
 This patch adds various changes to phosphor-watchdog that are
 required for compatibility with Intel platforms.
@@ -27,7 +27,7 @@ Signed-off-by: Sunita Kumari <sunitax.kumari@intel.com>
  2 files changed, 240 insertions(+), 11 deletions(-)
 
 diff --git a/src/watchdog.cpp b/src/watchdog.cpp
-index 05a95e9..ea94082 100644
+index c401022..b88636a 100644
 --- a/src/watchdog.cpp
 +++ b/src/watchdog.cpp
 @@ -5,8 +5,10 @@
@@ -245,7 +245,7 @@ index 05a95e9..ea94082 100644
  
      auto target = actionTargetMap.find(action);
      if (target == actionTargetMap.end())
-@@ -146,12 +322,45 @@ void Watchdog::timeOutHandler()
+@@ -133,12 +309,45 @@ void Watchdog::timeOutHandler()
  
          try
          {
@@ -294,18 +294,18 @@ index 05a95e9..ea94082 100644
 +                bus.call_noreply(method);
 +            }
          }
-         catch (const sdbusplus::exception::exception& e)
+         catch (const sdbusplus::exception_t& e)
          {
 diff --git a/src/watchdog.hpp b/src/watchdog.hpp
-index 31cde63..2b7ff36 100644
+index a0693ee..406ac86 100644
 --- a/src/watchdog.hpp
 +++ b/src/watchdog.hpp
-@@ -73,7 +73,17 @@ class Watchdog : public WatchdogInherits
+@@ -74,7 +74,17 @@ class Watchdog : public WatchdogInherits
          bus(bus), actionTargetMap(std::move(actionTargetMap)),
          fallback(fallback), minInterval(minInterval),
          timer(event, std::bind(&Watchdog::timeOutHandler, this)),
--        objPath(objPath)
-+        objPath(objPath), powerStateChangedSignal(
+-        objPath(objPath), exitAfterTimeout(exitAfterTimeout)
++        objPath(objPath), exitAfterTimeout(exitAfterTimeout), powerStateChangedSignal(
 +            bus,
 +            sdbusplus::bus::match::rules::propertiesChanged(
 +                "/xyz/openbmc_project/state/host0",
@@ -319,7 +319,7 @@ index 31cde63..2b7ff36 100644
      {
          // Use default if passed in otherwise just use default that comes
          // with object
-@@ -90,6 +100,12 @@ class Watchdog : public WatchdogInherits
+@@ -91,6 +101,12 @@ class Watchdog : public WatchdogInherits
          tryFallbackOrDisable();
      }
  
@@ -332,7 +332,7 @@ index 31cde63..2b7ff36 100644
      /** @brief Resets the TimeRemaining to the configured Interval
       *         Optionally enables the watchdog.
       *
-@@ -178,6 +194,10 @@ class Watchdog : public WatchdogInherits
+@@ -179,6 +195,10 @@ class Watchdog : public WatchdogInherits
      /** @brief Contained timer object */
      sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> timer;
  
@@ -344,5 +344,5 @@ index 31cde63..2b7ff36 100644
      void timeOutHandler();
  
 -- 
-2.17.1
+2.34.1
 

--- a/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/watchdog/phosphor-watchdog_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-phosphor/watchdog/phosphor-watchdog_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend:olympus-nuvoton := "${THISDIR}/${PN}:"
 
-#SRC_URI:append:olympus-nuvoton = " file://0001-Customize-phosphor-watchdog-for-Intel-platforms.patch"
-#SRC_URI:append:olympus-nuvoton = " file://0002-Customize-phosphor-watchdog-for-Olympus-platform.patch"
+SRC_URI:append:olympus-nuvoton = " file://0001-Customize-phosphor-watchdog-for-Intel-platforms.patch"
+SRC_URI:append:olympus-nuvoton = " file://0002-Customize-phosphor-watchdog-for-Olympus-platform.patch"
 
 # Remove the override to keep service running after DC cycle
 SYSTEMD_OVERRIDE:${PN}:remove:olympus-nuvoton = "poweron.conf:phosphor-watchdog@poweron.service.d/poweron.conf"


### PR DESCRIPTION
Enable and update the patches cause build break after merge new Openbmc codebase.

Updated:
meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/flash/phosphor-software-manager meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/flash/phosphor-software-manager meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/watchdog/phosphor-watchdog meta-quanta/meta-olympus-nuvoton/recipes-phosphor/flash/phosphor-software-manager meta-quanta/meta-olympus-nuvoton/recipes-phosphor/watchdog/phosphor-watchdog

Signed-off-by: Brian Ma <chma0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
