### PR TITLE
meta-quanta: meta-olympus-nuvoton: fix flash boot failed

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/conf/machine/olympus-nuvoton.conf
+++ b/meta-quanta/meta-olympus-nuvoton/conf/machine/olympus-nuvoton.conf
@@ -5,10 +5,11 @@ require conf/machine/include/npcm7xx.inc
 require conf/machine/include/obmc-bsp-common.inc
 
 FLASH_SIZE = "65536"
-FLASH_UBOOT_OFFSET = "0"
-FLASH_KERNEL_OFFSET = "2048"
-FLASH_ROFS_OFFSET = "8192"
-FLASH_RWFS_OFFSET = "62464"
+# avoid image_types_phosphor.bbclass override
+FLASH_UBOOT_OFFSET:flash-65536 = "0"
+FLASH_KERNEL_OFFSET:flash-65536 = "2048"
+FLASH_ROFS_OFFSET:flash-65536 = "8192"
+FLASH_RWFS_OFFSET:flash-65536 = "62464"
 
 UBOOT_MACHINE = "PolegRunBMC_defconfig"
 UBOOT_DEVICETREE = "nuvoton-npcm750-olympus"


### PR DESCRIPTION
Note:
The flash size setting is modified to 64MB, it will boot failed without this patch.

Signed-off-by: Allen Kang <jhkang@nuvoton.com>