### PR TITLE
meta-nuvoton: bmcweb: Add patch to fix web socket connection failed

### DIFF
--- a/meta-nuvoton/recipes-phosphor/interfaces/bmcweb/0001-Fix-WS-connection-failed.patch
+++ b/meta-nuvoton/recipes-phosphor/interfaces/bmcweb/0001-Fix-WS-connection-failed.patch
@@ -1,0 +1,25 @@
+From 368b2a9ce312faae181cd97910c5ed0e7aea3069 Mon Sep 17 00:00:00 2001
+From: Marvin Lin <milkfafa@gmail.com>
+Date: Wed, 28 Dec 2022 11:02:28 +0800
+Subject: [PATCH] Fix WS connection failed
+
+---
+ http/routing.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/http/routing.hpp b/http/routing.hpp
+index ed1b7e48..b444a8f8 100644
+--- a/http/routing.hpp
++++ b/http/routing.hpp
+@@ -1267,7 +1267,7 @@ class Router
+         }
+ 
+         if ((rules[ruleIndex]->getMethods() &
+-             (1U << static_cast<size_t>(req.method()))) == 0)
++             (static_cast<size_t>(req.method()))) == 0)
+         {
+             BMCWEB_LOG_DEBUG << "Rule found but method mismatch: " << req.url
+                              << " with " << req.methodString() << "("
+-- 
+2.34.1
+

--- a/meta-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-nuvoton/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:append:nuvoton := ":${THISDIR}/${PN}"
+
+SRC_URI:append:nuvoton = " file://0001-Fix-WS-connection-failed.patch"


### PR DESCRIPTION
Add patch to fix web socket connection failed.
Issue link: https://github.com/openbmc/bmcweb/issues/243

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
