### PR TITLE
meta-scm-npcm845: update KCS_DEVICE name

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config/channel_config.json
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config/channel_config.json
@@ -165,7 +165,7 @@
     }
   },
   "15" : {
-    "name" : "ipmi-kcs1",
+    "name" : "ipmi_kcs1",
     "is_valid" : true,
     "active_sessions" : 0,
     "channel_info" : {

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-kcs/99-ipmi-kcs.rules.rules
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-kcs/99-ipmi-kcs.rules.rules
@@ -1,1 +1,0 @@
-KERNEL=="ipmi-kcs1", SYMLINK+="ipmi_kcs1"

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-kcs_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-kcs_%.bbappend
@@ -1,10 +1,1 @@
-FILESEXTRAPATHS:prepend:evb-npcm845 := "${THISDIR}/${PN}:"
-
-SRC_URI:append:evb-npcm845 = " file://99-ipmi-kcs.rules.rules"
-
-KCS_DEVICE:evb-npcm845 = "ipmi_kcs1"
-
-do_install:append:evb-npcm845() {
-        install -d ${D}/lib/udev/rules.d
-        install -m 0644 ${WORKDIR}/99-ipmi-kcs.rules.rules ${D}/lib/udev/rules.d
-}
+KCS_DEVICE:evb-npcm845 = "ipmi-kcs1"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config/channel_config.json
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config/channel_config.json
@@ -165,7 +165,7 @@
     }
   },
   "15" : {
-    "name" : "ipmi-kcs1",
+    "name" : "ipmi_kcs1",
     "is_valid" : true,
     "active_sessions" : 0,
     "channel_info" : {

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-kcs/99-ipmi-kcs.rules.rules
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-kcs/99-ipmi-kcs.rules.rules
@@ -1,1 +1,0 @@
-KERNEL=="ipmi-kcs1", SYMLINK+="ipmi_kcs1"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-kcs_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-kcs_%.bbappend
@@ -1,10 +1,1 @@
-FILESEXTRAPATHS:prepend:scm-npcm845 := "${THISDIR}/${PN}:"
-
-SRC_URI:append:scm-npcm845 = " file://99-ipmi-kcs.rules.rules"
-
-KCS_DEVICE:scm-npcm845 = "ipmi_kcs1"
-
-do_install:append:scm-npcm845() {
-        install -d ${D}/lib/udev/rules.d
-        install -m 0644 ${WORKDIR}/99-ipmi-kcs.rules.rules ${D}/lib/udev/rules.d
-}
+KCS_DEVICE:scm-npcm845 = "ipmi-kcs1"


### PR DESCRIPTION
Due to KCS bridge already allow we pass kcs device name with "-", we don't need link kcs device as ipmi_kcs1.
Please ref kcs bridge commit: 4a4d1d03d99fabe089e649aa226ad4c61e71684e

Signed-off-by: Brian Ma <chma0@nuvoton.com>
