### PR TITLE
meta-scm-npcm845: fix SDR get dimm sensor error

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0008-add-dimm-sensor.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0008-add-dimm-sensor.patch
@@ -1,7 +1,7 @@
-From 77b2719c471f578b0aaf9cac99e7e29dd65bd54b Mon Sep 17 00:00:00 2001
+From c61ea2f20bbc1b18acacb71b37e4b43a4e34969a Mon Sep 17 00:00:00 2001
 From: Stanley Chu <yschu@nuvoton.com>
 Date: Mon, 15 Aug 2022 16:13:12 +0800
-Subject: [PATCH 8/8] add dimm sensor
+Subject: [PATCH] add dimm sensor
 
 Signed-off-by: Stanley Chu <yschu@nuvoton.com>
 ---
@@ -9,9 +9,9 @@ Signed-off-by: Stanley Chu <yschu@nuvoton.com>
  include/amd-apml.h     |  74 ++++++
  include/i3cdev.h       |  39 +++
  meson_options.txt      |   1 +
- src/DIMMSensor.cpp     | 576 +++++++++++++++++++++++++++++++++++++++++
+ src/DIMMSensor.cpp     | 577 +++++++++++++++++++++++++++++++++++++++++
  src/meson.build        |  15 ++
- 6 files changed, 756 insertions(+)
+ 6 files changed, 757 insertions(+)
  create mode 100644 include/DIMMSensor.hpp
  create mode 100644 include/amd-apml.h
  create mode 100644 include/i3cdev.h
@@ -210,10 +210,10 @@ index d6a8b966..c0ec6454 100644
 +option('dimm', type: 'feature', value: 'enabled', description: 'Enable DIMM sensor.',)
 diff --git a/src/DIMMSensor.cpp b/src/DIMMSensor.cpp
 new file mode 100644
-index 00000000..31ea0f69
+index 00000000..dd685090
 --- /dev/null
 +++ b/src/DIMMSensor.cpp
-@@ -0,0 +1,576 @@
+@@ -0,0 +1,577 @@
 +#include <DIMMSensor.hpp>
 +#include <Utils.hpp>
 +#include <VariantVisitors.hpp>
@@ -748,6 +748,7 @@ index 00000000..31ea0f69
 +    auto systemBus = std::make_shared<sdbusplus::asio::connection>(io);
 +    systemBus->request_name("xyz.openbmc_project.DIMMSensor");
 +    sdbusplus::asio::object_server objectServer(systemBus);
++    objectServer.add_manager("/xyz/openbmc_project/sensors");
 +
 +    io.post([&]() { createSensors(io, objectServer, sensors, systemBus); });
 +


### PR DESCRIPTION
Due to IPMID commit 9a9ac0bcfc2df48873ca0f9725eb5255f7191d84 make all dbus sensor should be implementing an ObjectManager at /xyz/openbmc_project/sensors. Update patch to match requirement.

Issue:
$ ipmitool sdr list
...
ipmitool: ipmi_sdr_get_record() failed

$ journalctl -n 10
...
Jan 04 00:32:21 scm-npcm845 ipmid[378]: GetMangagedObjects for getSensorMap failed Jan 04 00:32:21 scm-npcm845 ipmid[378]: Failed to update sensor map for threshold sensor Jan 04 00:32:21 scm-npcm845 ipmid[378]: ipmiStorageGetSDR: fail to get SDR

Test:
root@scm-npcm845:~# ipmitool sdr get Temp_DIMM_A
Sensor ID              : Temp_DIMM_A (0x20)
 Entity ID             : 32.0 (Memory Device)
 Sensor Type (Threshold)  : Temperature (0x01)
 Sensor Reading        : No Reading
 Status                : Not Available
 Positive Hysteresis   : Unspecified
 Negative Hysteresis   : Unspecified
 Minimum sensor range  : 65.000
 Maximum sensor range  : 65.000
 Event Message Control : Per-threshold
 Readable Thresholds   : unc ucr
 Settable Thresholds   : unc ucr
 Threshold Read Mask   : unc ucr
 Assertion Events      :
 Event Enable          : Event Messages Disabled
 Assertions Enabled    : lnc- lcr- unc+ ucr+
 Deassertions Enabled  : lnc+ lcr+ unc- ucr-

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
