### PR TITLE
meta-scm-npcm845: update phosphor health monitor

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/files/0001-change-the-cpu-sensor-name-from-CPU-to-CPU_Utilizati.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/files/0001-change-the-cpu-sensor-name-from-CPU-to-CPU_Utilizati.patch
@@ -1,7 +1,7 @@
-From c0ac6d275cc7322047ad22d26b85fbea0d41ccab Mon Sep 17 00:00:00 2001
+From d9a94e8edd1a5b0ea2ec2c4ca0519426a5b699f8 Mon Sep 17 00:00:00 2001
 From: Joseph Liu <kwliu@nuvoton.com>
 Date: Tue, 12 Jul 2022 15:17:49 +0800
-Subject: [PATCH] change the cpu sensor name from CPU to CPU_Utilization
+Subject: [PATCH 1/2] change the cpu sensor name from CPU to CPU_Utilization
 
 Signed-off-by: Joseph Liu <kwliu@nuvoton.com>
 ---
@@ -9,23 +9,24 @@ Signed-off-by: Joseph Liu <kwliu@nuvoton.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/healthMonitor.cpp b/healthMonitor.cpp
-index aaa27ee..9a92b58 100644
+index 1477323..49a029c 100644
 --- a/healthMonitor.cpp
 +++ b/healthMonitor.cpp
-@@ -481,11 +481,12 @@ void printConfig(HealthConfig& cfg)
+@@ -546,12 +546,13 @@ void printConfig(HealthConfig& cfg)
  }
  
  /* Create dbus utilization sensor object for each configured sensors */
 +constexpr auto util_path = "_Utilization";
- void HealthMon::createHealthSensors(const std::vector<std::string>& chassisIds)
+ void HealthMon::createHealthSensors(
+     const std::vector<std::string>& bmcInventoryPaths)
  {
      for (auto& cfg : sensorConfigs)
      {
 -        std::string objPath = std::string(HEALTH_SENSOR_PATH) + cfg.name;
 +        std::string objPath = std::string(HEALTH_SENSOR_PATH) + cfg.name + util_path;
-         auto healthSensor = std::make_shared<HealthSensor>(bus, objPath.c_str(),
-                                                            cfg, chassisIds);
+         auto healthSensor = std::make_shared<HealthSensor>(
+             bus, objPath.c_str(), cfg, bmcInventoryPaths);
          healthSensors.emplace(cfg.name, healthSensor);
 -- 
-2.17.1
+2.34.1
 

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/files/0002-Add-support-health-SEL-service.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/files/0002-Add-support-health-SEL-service.patch
@@ -1,7 +1,7 @@
-From b2cee74741050926f7381d0b94fea9e996cf5b24 Mon Sep 17 00:00:00 2001
+From 3f0ab4b7a4ec1c07ce025fb0bb5abad5ede4f9ab Mon Sep 17 00:00:00 2001
 From: Brian Ma <chma0@nuvoton.com>
 Date: Fri, 30 Sep 2022 15:31:58 +0800
-Subject: [PATCH] Add support health SEL service
+Subject: [PATCH 2/2] Add support health SEL service
 
 ---
  healthMonitor.cpp | 35 ++++++++++++++++++++++++++++++++++-
@@ -9,10 +9,10 @@ Subject: [PATCH] Add support health SEL service
  2 files changed, 36 insertions(+), 1 deletion(-)
 
 diff --git a/healthMonitor.cpp b/healthMonitor.cpp
-index 9a92b58..49a9207 100644
+index 49a029c..995ec16 100644
 --- a/healthMonitor.cpp
 +++ b/healthMonitor.cpp
-@@ -336,7 +336,7 @@ void HealthSensor::checkSensorThreshold(const double value)
+@@ -440,7 +440,7 @@ void HealthSensor::checkSensorThreshold(const double value)
                  error(
                      "ASSERT: sensor {SENSOR} is above the upper threshold warning high",
                      "SENSOR", sensorConfig.name);
@@ -21,7 +21,7 @@ index 9a92b58..49a9207 100644
              }
          }
          return;
-@@ -346,9 +346,12 @@ void HealthSensor::checkSensorThreshold(const double value)
+@@ -450,9 +450,12 @@ void HealthSensor::checkSensorThreshold(const double value)
      {
          WarningInterface::warningAlarmHigh(false);
          if (sensorConfig.warningLog)
@@ -34,7 +34,7 @@ index 9a92b58..49a9207 100644
      }
  }
  
-@@ -416,6 +419,36 @@ void HealthSensor::startUnit(const std::string& sysdUnit)
+@@ -520,6 +523,36 @@ void HealthSensor::startUnit(const std::string& sysdUnit)
      bus.call_noreply(msg);
  }
  
@@ -72,10 +72,10 @@ index 9a92b58..49a9207 100644
  {
      PHOSPHOR_LOG2_USING;
 diff --git a/healthMonitor.hpp b/healthMonitor.hpp
-index b86563e..dba9a85 100644
+index c6e77dd..0a07390 100644
 --- a/healthMonitor.hpp
 +++ b/healthMonitor.hpp
-@@ -126,6 +126,8 @@ class HealthSensor : public healthIfaces
+@@ -134,6 +134,8 @@ class HealthSensor : public healthIfaces
      void readHealthSensor();
      /** @brief Start configured threshold systemd unit */
      void startUnit(const std::string& sysdUnit);
@@ -83,7 +83,7 @@ index b86563e..dba9a85 100644
 +    std::string getUnitInfo(const std::string& sysdUnit, bool asserted);
  };
  
- class HealthMon
+ class BmcInventory : public BmcInterface
 -- 
-2.17.1
+2.34.1
 

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/phosphor-health-monitor_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/phosphor-health-monitor_%.bbappend
@@ -10,7 +10,6 @@ SRC_URI:append:scm-npcm845 = " \
   file://0002-Add-support-health-SEL-service.patch \
 "
 FILES:${PN}:append:scm-npcm845 = " ${systemd_system_unitdir}/utilization-health-sel@.service"
-SRCREV:scm-npcm845 = "b7d7bd5a384ea501766b15e4613eb9b14fe71e7f"
 
 do_install:append:scm-npcm845() {
     install -d ${D}/${sysconfdir}/healthMon/


### PR DESCRIPTION
Update phosphor health monitor to fix ipmi get SDR error:
 ipmitool: ipmi_sdr_get_record() failed. The root cause is same with DIMM
sensor. Upstream phosphor health monitor fixed this issue, but we fix the source revision with old one. Update patches to apply new one.

Signed-off-by: Brian Ma <chma0@nuvoton.com>
