### PR TITLE
meta-quanta: meta-olympus-nuvoton: systemd: fix olympus build error

### DIFF
--- a/meta-quanta/meta-olympus-nuvoton/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-core/systemd/systemd_%.bbappend
@@ -1,5 +1,5 @@
 FILESEXTRAPATHS:prepend:olympus-nuvoton := "${THISDIR}/files:"
 
-SRC_URI:append:olympus-nuvoton = " \
-    file://0001-networkd-create-new-socket.patch \
-"
+#SRC_URI:append:olympus-nuvoton = " \
+#    file://0001-networkd-create-new-socket.patch \
+#"


### PR DESCRIPTION
Fix Olympus build error because of OpenBmc updating.

Test done:
	- Build OK

Signed-off-by: Allen Kang <jhkang@nuvoton.com>
