### PR TITLE
meta-nuvoton: fix build emmc distro break

### DIFF
--- a/meta-nuvoton/conf/machine/include/nuvoton.inc
+++ b/meta-nuvoton/conf/machine/include/nuvoton.inc
@@ -4,3 +4,6 @@ PREFERRED_PROVIDER_u-boot ?= "u-boot-nuvoton"
 PREFERRED_PROVIDER_u-boot-fw-utils ?= "u-boot-fw-utils-nuvoton"
 
 MACHINEOVERRIDES .= ":nuvoton"
+
+# fix build mmc distro error
+IMAGE_FSTYPES:remove:df-phosphor-mmc = "mtd-static mtd-static-tar mtd-static-alltar"


### PR DESCRIPTION
Due to commit e20e692f16c2d2ad59be61320fcc8bc7a52969c1 move IMAGE_FSTYPES handle to each include file. But we inclide phosphor-mmc.inc in distro conf after obmc-bsp-common.inc (machie conf), the distro override cannot take effect. This is Nuvoton workaround for build same mahcine with several distro. We should include phosphor-mmc.inc first in machine conf if we need enable mmc feature.

Signed-off-by: Brian Ma <chma0@nuvoton.com>
