### PR TITLE
Workaround for nbd 3.24 not working, rollback to 3.20

### DIFF
--- a/meta-nuvoton/conf/machine/include/nuvoton.inc
+++ b/meta-nuvoton/conf/machine/include/nuvoton.inc
@@ -3,6 +3,8 @@ PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-nuvoton"
 PREFERRED_PROVIDER_u-boot ?= "u-boot-nuvoton"
 PREFERRED_PROVIDER_u-boot-fw-utils ?= "u-boot-fw-utils-nuvoton"
 
+PREFERRED_VERSION_nbd ?= "3.20"
+
 MACHINEOVERRIDES .= ":nuvoton"
 
 # fix build mmc distro error

--- a/meta-nuvoton/recipes-support/nbd/nbd_3.20.bb
+++ b/meta-nuvoton/recipes-support/nbd/nbd_3.20.bb
@@ -1,0 +1,21 @@
+DESCRIPTION = "Network Block Device"
+HOMEPAGE = "http://nbd.sourceforge.net"
+SECTION = "net"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+DEPENDS = "glib-2.0"
+PV = "3.20"
+
+SRC_URI = "${SOURCEFORGE_MIRROR}/${BPN}/${BPN}-${PV}.tar.xz"
+SRC_URI[md5sum] = "910fe6c152f8c30ad8608388e6a4ce89"
+SRC_URI[sha256sum] = "e0e1b3538ab7ae5accf56180afd1a9887d415b98d21223b8ad42592b4af7d6cd"
+
+inherit autotools pkgconfig
+
+PACKAGES = "${PN}-client ${PN}-server ${PN}-dbg ${PN}-trdump ${PN}-doc"
+
+FILES:${PN}-client = "${sbindir}/${BPN}-client"
+FILES:${PN}-server = "${bindir}/${BPN}-server"
+FILES:${PN}-trdump = "${bindir}/${BPN}-trdump"
+


### PR DESCRIPTION
Rollback to 3.20 to prevent abnormal VM.

Signed-off-by: kcfeng0 <kcfeng0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
