### PR TITLE
meta-nuvoton: Update npcm8xx-bootblock LICENSE

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock.inc
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock.inc
@@ -2,18 +2,16 @@ SUMMARY = "Primary bootloader for NPCM8XX (Arbel) devices"
 DESCRIPTION = "Primary bootloader for NPCM8XX (Arbel) devices"
 HOMEPAGE = "https://github.com/Nuvoton-Israel/npcm8xx-bootblock"
 LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=650b869bd8ff2aed59c62bad2a22a821"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 FILENAME = "arbel_a35_bootblock.${PV}.bin"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    https://github.com/Nuvoton-Israel/npcm8xx-bootblock/blob/${SRCREV}/LICENSE;name=lic \
+    git://github.com/Nuvoton-Israel/npcm8xx-bootblock;branch=main;protocol=https \
     https://github.com/Nuvoton-Israel/npcm8xx-bootblock/releases/download/${RELEASE}/${FILENAME};downloadfilename=${FILENAME};name=bin \
 "
-
-SRC_URI[lic.sha256sum] = "7c34d28e784b202aa4998f477fd0aa9773146952d7f6fa5971369fcdda59cf48"
 
 inherit deploy
 


### PR DESCRIPTION
Due to the license link in source URL is invalid, we will get build error at first time fetch this package. Use the COMMON_LICENSE_DIR license file to replace license fetch URL.

Signed-off-by: Brian Ma <chma0@nuvoton.com>
