### PR TITLE
meta-scm-npcm845: update eth name to end

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config/channel_config.json
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config/channel_config.json
@@ -11,7 +11,7 @@
     }
   },
   "1" : {
-    "name" : "eth0",
+    "name" : "end0",
     "is_valid" : true,
     "active_sessions" : 0,
     "channel_info" : {
@@ -22,7 +22,7 @@
     }
   },
   "2" : {
-    "name" : "eth1",
+    "name" : "end1",
     "is_valid" : true,
     "active_sessions" : 0,
     "channel_info" : {
@@ -33,7 +33,7 @@
     }
   },
   "3" : {
-    "name" : "eth3",
+    "name" : "end3",
     "is_valid" : true,
     "active_sessions" : 0,
     "channel_info" : {

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-net_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-net_%.bbappend
@@ -4,4 +4,4 @@ SRC_URI:append:scm-npcm845 = " file://0002-Add-RemoteIPAddr-support.patch"
 SRC_URI:append:scm-npcm845 = " file://0003-add-server-type-and-oem-id-to-meet-MS-spec.patch"
 SRC_URI:append:scm-npcm845 = " file://0004-set-channel-security-keys.patch"
 
-RMCPP_IFACE = "eth0"
+RMCPP_IFACE = "end0"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/settings/phosphor-settings-manager/sol-default.override.yml
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/settings/phosphor-settings-manager/sol-default.override.yml
@@ -1,5 +1,5 @@
 ---
-/xyz/openbmc_project/ipmi/sol/eth0:
+/xyz/openbmc_project/ipmi/sol/end0:
     - Interface: xyz.openbmc_project.Ipmi.SOL
       Properties:
           Privilege:


### PR DESCRIPTION
Due to systemd update, the ethX name change to endX, update relative configuration to fix errors like SOL cannot work.

Note: The systemd readme suggest we should not use eth as the interface name, so update the new name to config files.
Ref: https://www.freedesktop.org/software/systemd/man/systemd.link.html

Signed-off-by: Brian Ma <chma0@nuvoton.com>
