### PR TITLE
meta-evb-nuvoton: evb-npcm845: fix the NAME of network interface to eth

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-core/systemd/systemd/85-persistent-net.rules
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-core/systemd/systemd/85-persistent-net.rules
@@ -1,0 +1,6 @@
+ACTION=="remove", GOTO="persistent_net_end"
+SUBSYSTEM!="net", GOTO="persistent_net_end"
+
+ENV{ID_NET_NAME_ONBOARD}!="", NAME="eth%n"
+
+LABEL="persistent_net_end"

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend:nuvoton := "${THISDIR}/${PN}:"
+
+SRC_URI:append:nuvoton = " file://85-persistent-net.rules"
+
+do_install:append:nuvoton() {
+	install -m 0644 ${WORKDIR}/85-persistent-net.rules ${D}${sysconfdir}/udev/rules.d/
+}

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/network/phosphor-network/default.link.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/network/phosphor-network/default.link.conf
@@ -1,2 +1,0 @@
-[Link]
-NamePolicy=keep kernel

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/network/phosphor-network_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/network/phosphor-network_%.bbappend
@@ -1,10 +1,1 @@
-FILESEXTRAPATHS:prepend:evb-npcm845 := "${THISDIR}/${PN}:"
-
 PACKAGECONFIG:remove:evb-npcm845 = "default-link-local-autoconf"
-
-SRC_URI:append:evb-npcm845 = " file://default.link.conf"
-
-do_install:append:evb-npcm845() {
-        install -m 0755 -d ${D}/etc/systemd/network/99-default.link.d
-        install -m 0644 ${WORKDIR}/default.link.conf ${D}/etc/systemd/network/99-default.link.d
-}


### PR DESCRIPTION
Signed-off-by: kcfeng0 <kcfeng0@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
