### PR TITLE
meta-scm-npcm845: add socket id for ttyS1 console

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/console/obmc-console/server.ttyS1.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/console/obmc-console/server.ttyS1.conf
@@ -1,3 +1,4 @@
 local-tty = ttyS1
 local-tty-baud = 115200
+socket-id = ttyS1
 logfile = /var/log/obmc-console-host-S1.log


### PR DESCRIPTION
We should keep only one obmc-console server service without socket id for default SOL(web, ipmi) use. Others should set socket id to avoid conflict.

Solved: host SOL un-expected behavior.

Signed-off-by: Brian Ma <chma0@nuvoton.com>
