### PR TITLE
meta-nuvoton: remove mirror U-Boot service

### DIFF
--- a/meta-nuvoton/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-nuvoton/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -1,0 +1,7 @@
+# Nuvoton implement PFR in fTPM, so we don't need check U-Boot again.
+
+# move mirror uboot service to disable
+SYSTEMD_SERVICE:phosphor-software-manager-updater-mmc:remove:nuvoton = "obmc-flash-mmc-mirroruboot.service"
+SOFTWARE_MGR_PACKAGES:append:nuvoton = " ${PN}-disabled"
+SYSTEMD_SERVICE:${PN}-disabled:nuvoton = "obmc-flash-mmc-mirroruboot.service"
+SYSTEMD_AUTO_ENABLE:${PN}-disabled:nuvoton = "disable"


### PR DESCRIPTION
Remove mirror U-Boot service in phosphor software manager due to we do place bootloader image in eMMC and our fTPM we take care the bootloader image.
