### PR TITLE
meta-nuvoton: fix build non-eMMC distro fail

### DIFF
--- a/meta-nuvoton/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-nuvoton/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -1,7 +1,1 @@
-# Nuvoton implement PFR in fTPM, so we don't need check U-Boot again.
-
-# move mirror uboot service to disable
-SYSTEMD_SERVICE:phosphor-software-manager-updater-mmc:remove:nuvoton = "obmc-flash-mmc-mirroruboot.service"
-SOFTWARE_MGR_PACKAGES:append:nuvoton = " ${PN}-disabled"
-SYSTEMD_SERVICE:${PN}-disabled:nuvoton = "obmc-flash-mmc-mirroruboot.service"
-SYSTEMD_AUTO_ENABLE:${PN}-disabled:nuvoton = "disable"
+require ${@bb.utils.contains('DISTRO_FEATURES', 'phosphor-mmc', 'rm-mirror-uboot.inc', '', d)}

--- a/meta-nuvoton/recipes-phosphor/flash/rm-mirror-uboot.inc
+++ b/meta-nuvoton/recipes-phosphor/flash/rm-mirror-uboot.inc
@@ -1,0 +1,7 @@
+# Nuvoton implement PFR in fTPM, so we don't need check U-Boot again.
+
+# move mirror uboot service to disable
+SYSTEMD_SERVICE:phosphor-software-manager-updater-mmc:remove:nuvoton = "obmc-flash-mmc-mirroruboot.service"
+SOFTWARE_MGR_PACKAGES:append:nuvoton = " ${PN}-disabled"
+SYSTEMD_SERVICE:${PN}-disabled:nuvoton = "obmc-flash-mmc-mirroruboot.service"
+SYSTEMD_AUTO_ENABLE:${PN}-disabled:nuvoton = "disable"


### PR DESCRIPTION
Move the remove mirror uboot recipe to inc file, include it when we build distro with feature phosphor-mmc
