### PR TITLE
meta-scm-npcm845: entity: update fan configuration

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/configuration/entity-manager/aurea-hpm.json
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/configuration/entity-manager/aurea-hpm.json
@@ -3,8 +3,6 @@
         {
             "LED": "fan_fault",
             "Name": "DUAL ROTOR FAN CONN",
-            "Pwm": 0,
-            "PwmName": "PWM_1",
             "PowerState": "On",
             "EntityId": "0x07",
             "EntityInstance": "0x00",
@@ -308,6 +306,173 @@
             "PowerState": "On",
             "Index": 11,
             "Name": "Fan_5B",
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 600
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 1000
+                }
+            ],
+            "Type": "I2CFan"
+        },
+        {
+            "Name": "SINGLE ROTOR FAN CONN",
+            "Pwm": 0,
+            "PwmName": "PWM_1",
+            "PowerState": "On",
+            "EntityId": "0x07",
+            "EntityInstance": "0x01",
+            "Tachs": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "Type": "FanConnector"
+        },
+        {
+            "Address": "0x20",
+            "Bus": 4,
+            "EntityId": "0x1D",
+            "EntityInstance": "0x11",
+            "BindConnector": "SINGLE ROTOR FAN CONN",
+            "PowerState": "On",
+            "Index": 0,
+            "Name": "Fan_6",
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 600
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 1000
+                }
+            ],
+            "Type": "I2CFan"
+        },
+        {
+            "Address": "0x20",
+            "Bus": 4,
+            "EntityId": "0x1D",
+            "EntityInstance": "0x12",
+            "BindConnector": "SINGLE ROTOR FAN CONN",
+            "PowerState": "On",
+            "Index": 1,
+            "Name": "Fan_7",
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 600
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 1000
+                }
+            ],
+            "Type": "I2CFan"
+        },
+        {
+            "Address": "0x20",
+            "Bus": 4,
+            "EntityId": "0x1D",
+            "EntityInstance": "0x13",
+            "BindConnector": "SINGLE ROTOR FAN CONN",
+            "PowerState": "On",
+            "Index": 2,
+            "Name": "Fan_8",
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 600
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 1000
+                }
+            ],
+            "Type": "I2CFan"
+        },
+        {
+            "Address": "0x20",
+            "Bus": 4,
+            "EntityId": "0x1D",
+            "EntityInstance": "0x14",
+            "BindConnector": "SINGLE ROTOR FAN CONN",
+            "PowerState": "On",
+            "Index": 3,
+            "Name": "Fan_9",
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 600
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 1000
+                }
+            ],
+            "Type": "I2CFan"
+        },
+        {
+            "Address": "0x20",
+            "Bus": 4,
+            "EntityId": "0x1D",
+            "EntityInstance": "0x15",
+            "BindConnector": "SINGLE ROTOR FAN CONN",
+            "PowerState": "On",
+            "Index": 4,
+            "Name": "Fan_10",
+            "Thresholds": [
+                {
+                    "Direction": "less than",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 600
+                },
+                {
+                    "Direction": "less than",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 1000
+                }
+            ],
+            "Type": "I2CFan"
+        },
+        {
+            "Address": "0x20",
+            "Bus": 4,
+            "EntityId": "0x1D",
+            "EntityInstance": "0x16",
+            "BindConnector": "SINGLE ROTOR FAN CONN",
+            "PowerState": "On",
+            "Index": 5,
+            "Name": "Fan_11",
             "Thresholds": [
                 {
                     "Direction": "less than",


### PR DESCRIPTION
Update entity manager HPM configuration fan settings.

Test:
Fan sensor list in SDR:
root@scm-npcm845:~# ipmitool sdr list
...
PWM_1            | 69.78 percent     | ok
Fan_0A           | 0 RPM             | cr
Fan_0B           | 0 RPM             | cr
Fan_1A           | 0 RPM             | cr
Fan_1B           | 0 RPM             | cr
Fan_2A           | 0 RPM             | cr
Fan_2B           | 0 RPM             | cr
Fan_3A           | 0 RPM             | cr
Fan_3B           | 0 RPM             | cr
Fan_4A           | 0 RPM             | cr
Fan_4B           | 0 RPM             | cr
Fan_5A           | 0 RPM             | cr
Fan_5B           | 0 RPM             | cr
Fan_6            | 0 RPM             | cr
Fan_7            | 0 RPM             | cr
Fan_8            | 0 RPM             | cr
Fan_9            | 0 RPM             | cr
Fan_10           | 0 RPM             | cr
Fan_11           | 0 RPM             | cr

pid controll service work well:
root@scm-npcm845:~# systemctl status phosphor-pid-control.service
* phosphor-pid-control.service - Fan Control Daemon Loaded: loaded (/lib/systemd/system/phosphor-pid-control.service; enabled; preset: enabled) Active: active (running) since Tue 2023-02-21 07:42:56 UTC; 53min ago

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
