### PR TITLE
meta-nuvoton: fix software-manager fw update fail

### DIFF
--- a/meta-nuvoton/recipes-phosphor/flash/phosphor-software-manager/disable-mmc-mirroruboot.patch
+++ b/meta-nuvoton/recipes-phosphor/flash/phosphor-software-manager/disable-mmc-mirroruboot.patch
@@ -1,0 +1,12 @@
+diff --git a/obmc-flash-bmc b/obmc-flash-bmc
+index 032096a..187f231 100644
+--- a/obmc-flash-bmc
++++ b/obmc-flash-bmc
+@@ -647,6 +647,7 @@ function mmc_setprimary() {
+ }
+ 
+ function mmc_mirroruboot() {
++    return
+     # Get current boot device; 0-primary_bootdev device; 1 - alt_bootdev
+     bootdev=$(cat /sys/kernel/debug/aspeed/sbc/abr_image)
+     if [[ "${bootdev}" == "0" ]]; then

--- a/meta-nuvoton/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-nuvoton/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -1,1 +1,2 @@
-require ${@bb.utils.contains('DISTRO_FEATURES', 'phosphor-mmc', 'rm-mirror-uboot.inc', '', d)}
+FILESEXTRAPATHS:prepend:nuvoton := "${THISDIR}/${PN}:"
+SRC_URI:append:nuvoton:df-phosphor-mmc = " file://disable-mmc-mirroruboot.patch"

--- a/meta-nuvoton/recipes-phosphor/flash/rm-mirror-uboot.inc
+++ b/meta-nuvoton/recipes-phosphor/flash/rm-mirror-uboot.inc
@@ -1,7 +1,0 @@
-# Nuvoton implement PFR in fTPM, so we don't need check U-Boot again.
-
-# move mirror uboot service to disable
-SYSTEMD_SERVICE:phosphor-software-manager-updater-mmc:remove:nuvoton = "obmc-flash-mmc-mirroruboot.service"
-SOFTWARE_MGR_PACKAGES:append:nuvoton = " ${PN}-disabled"
-SYSTEMD_SERVICE:${PN}-disabled:nuvoton = "obmc-flash-mmc-mirroruboot.service"
-SYSTEMD_AUTO_ENABLE:${PN}-disabled:nuvoton = "disable"


### PR DESCRIPTION
Due to mmc-mirroruboot.service is tightly intergrade in item updater, we cannot directly remove it. Just skip the action for mmc mirror uboot in obmc-flash-bmc.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
