### PR TITLE
meta-evb: meta-evb-nuvoton: meta-buv-runbmc: Start monitoring two tes…

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/machine/buv-runbmc.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/machine/buv-runbmc.conf
@@ -31,7 +31,7 @@ VIRTUAL-RUNTIME_obmc-host-state-manager = "x86-power-control"
 VIRTUAL-RUNTIME_obmc-chassis-state-manager = "x86-power-control"
 VIRTUAL-RUNTIME_obmc-discover-system-state = "x86-power-control"
 
-OBMC_POWER_SUPPLY_INSTANCES = "0"
+OBMC_POWER_SUPPLY_INSTANCES = "0 1"
 
 #KCS_DEVICE = "ipmi-kcs1"
 #PREFERRED_PROVIDER_virtual/obmc-host-ipmi-hw = "phosphor-ipmi-kcs"

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/power/phosphor-power/obmc/power-supply-monitor/power-supply-monitor-0.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/power/phosphor-power/obmc/power-supply-monitor/power-supply-monitor-0.conf
@@ -1,3 +1,3 @@
-DEVPATH=/sys/bus/i2c/devices/2-0058
+DEVPATH=/sys/bus/i2c/devices/1-005a
 INSTANCE=0
 INVENTORY=/system/chassis/motherboard/powersupply0

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/power/phosphor-power/obmc/power-supply-monitor/power-supply-monitor-1.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/power/phosphor-power/obmc/power-supply-monitor/power-supply-monitor-1.conf
@@ -1,0 +1,3 @@
+DEVPATH=/sys/bus/i2c/devices/1-005b
+INSTANCE=1
+INVENTORY=/system/chassis/motherboard/powersupply1

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/power/phosphor-power/obmc/power-supply-monitor/power-supply-monitor-em-0.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/power/phosphor-power/obmc/power-supply-monitor/power-supply-monitor-em-0.conf
@@ -1,3 +1,3 @@
-DEVPATH=/sys/bus/i2c/devices/2-0058
+DEVPATH=/sys/bus/i2c/devices/1-005a
 INSTANCE=0
 INVENTORY=/system/powersupply/powersupply0

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/power/phosphor-power/obmc/power-supply-monitor/power-supply-monitor-em-1.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/power/phosphor-power/obmc/power-supply-monitor/power-supply-monitor-em-1.conf
@@ -1,0 +1,3 @@
+DEVPATH=/sys/bus/i2c/devices/1-005b
+INSTANCE=1
+INVENTORY=/system/powersupply/powersupply1

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/power/phosphor-power/psu.json
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/power/phosphor-power/psu.json
@@ -28,6 +28,7 @@
     }
   ],
   "psuDevices": {
-    "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0" : "/sys/bus/i2c/devices/2-0058"
+    "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply0" : "/sys/bus/i2c/devices/1-005a",
+    "/xyz/openbmc_project/inventory/system/chassis/motherboard/powersupply1" : "/sys/bus/i2c/devices/1-005b"
   }
 }

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/power/phosphor-power/psu_em.json
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/power/phosphor-power/psu_em.json
@@ -28,6 +28,7 @@
     }
   ],
   "psuDevices": {
-    "/xyz/openbmc_project/inventory/system/powersupply/powersupply0" : "/sys/bus/i2c/devices/2-0058"
+    "/xyz/openbmc_project/inventory/system/powersupply/powersupply0" : "/sys/bus/i2c/devices/1-005a",
+    "/xyz/openbmc_project/inventory/system/powersupply/powersupply1" : "/sys/bus/i2c/devices/1-005b"
   }
 }

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton/0009-Add-buv-runbmc-PSU-driver-inspur-ipsps.c.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton/0009-Add-buv-runbmc-PSU-driver-inspur-ipsps.c.patch
@@ -1,4 +1,4 @@
-From f097e76d8367fc2efa83302c29a4a4caf065ea79 Mon Sep 17 00:00:00 2001
+From d11f3e6368b5ad4e5a2d153d04609646adb3a0fc Mon Sep 17 00:00:00 2001
 From: Allen Kang <jhkang@nuvoton.com>
 Date: Mon, 6 Mar 2023 16:14:17 +0800
 Subject: [PATCH] Add buv-runbmc PSU driver, inspur-ipsps.c.
@@ -6,8 +6,7 @@ Subject: [PATCH] Add buv-runbmc PSU driver, inspur-ipsps.c.
 Signed-off-by: Allen Kang <jhkang@nuvoton.com>
 ---
  arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts | 9 +++++----
- drivers/hwmon/pmbus/inspur-ipsps.c               | 2 +-
- 2 files changed, 6 insertions(+), 5 deletions(-)
+ 1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts b/arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts
 index 25b58a47203f..72985a81dbe3 100644
@@ -29,19 +28,6 @@ index 25b58a47203f..72985a81dbe3 100644
  };
  
  &i2c3 {
-diff --git a/drivers/hwmon/pmbus/inspur-ipsps.c b/drivers/hwmon/pmbus/inspur-ipsps.c
-index 0f614e8d95f6..c92ac46cd563 100644
---- a/drivers/hwmon/pmbus/inspur-ipsps.c
-+++ b/drivers/hwmon/pmbus/inspur-ipsps.c
-@@ -16,7 +16,7 @@
- #define IPSPS_REG_VENDOR_ID	0x99
- #define IPSPS_REG_MODEL		0x9A
- #define IPSPS_REG_FW_VERSION	0x9B
--#define IPSPS_REG_PN		0x9C
-+#define IPSPS_REG_PN		0xAD
- #define IPSPS_REG_SN		0x9E
- #define IPSPS_REG_HW_VERSION	0xB0
- #define IPSPS_REG_MODE		0xFC
 -- 
 2.34.1
 

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton/0010-dts-add-two-test-PSUs-settings.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton/0010-dts-add-two-test-PSUs-settings.patch
@@ -1,0 +1,40 @@
+From 2b005e47237d25ed79b475884470f8c5816c917f Mon Sep 17 00:00:00 2001
+From: Allen Kang <jhkang@nuvoton.com>
+Date: Thu, 23 Mar 2023 10:58:27 +0800
+Subject: [PATCH] dts: add two test PSUs settings
+
+---
+ arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts b/arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts
+index 72985a81dbe3..c551c72e546c 100644
+--- a/arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts
++++ b/arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts
+@@ -281,14 +281,18 @@ &i2c1 {
+ 	#size-cells = <0>;
+ 	clock-frequency = <100000>;
+ 	status = "okay";
++	power-supply@5a {
++		compatible = "inspur,ipsps1";
++		reg = <0x5a>;
++	};
++	power-supply@5b {
++		compatible = "inspur,ipsps1";
++		reg = <0x5b>;
++	};
+ };
+ 
+ &i2c2 {
+-	/* Refer Olympus's setting, should be modified once needed. */
+-	power-supply@58 {
+-		compatible = "inspur,ipsps1";
+-		reg = <0x58>;
+-	};
++	status = "okay";
+ };
+ 
+ &i2c3 {
+-- 
+2.34.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton/0011-drivers-hwmon-pmbus-remove-fan-func-in-inspur-ipsps..patch
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton/0011-drivers-hwmon-pmbus-remove-fan-func-in-inspur-ipsps..patch
@@ -1,0 +1,30 @@
+From cd9abe5b5be599cb69d12a26786c7011be71e6e8 Mon Sep 17 00:00:00 2001
+From: Allen Kang <jhkang@nuvoton.com>
+Date: Mon, 10 Apr 2023 11:08:30 +0800
+Subject: [PATCH] drivers: hwmon: pmbus: remove fan func in inspur-ipsps.c
+
+Signed-off-by: Allen Kang <jhkang@nuvoton.com>
+---
+ drivers/hwmon/pmbus/inspur-ipsps.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/hwmon/pmbus/inspur-ipsps.c b/drivers/hwmon/pmbus/inspur-ipsps.c
+index 0f614e8d95f6..12d8d2cfb337 100644
+--- a/drivers/hwmon/pmbus/inspur-ipsps.c
++++ b/drivers/hwmon/pmbus/inspur-ipsps.c
+@@ -179,10 +179,10 @@ static struct pmbus_driver_info ipsps_info = {
+ 	.pages = 1,
+ 	.func[0] = PMBUS_HAVE_VIN | PMBUS_HAVE_VOUT | PMBUS_HAVE_IOUT |
+ 		PMBUS_HAVE_IIN | PMBUS_HAVE_POUT | PMBUS_HAVE_PIN |
+-		PMBUS_HAVE_FAN12 | PMBUS_HAVE_TEMP | PMBUS_HAVE_TEMP2 |
++		PMBUS_HAVE_TEMP | PMBUS_HAVE_TEMP2 |
+ 		PMBUS_HAVE_TEMP3 | PMBUS_HAVE_STATUS_VOUT |
+ 		PMBUS_HAVE_STATUS_IOUT | PMBUS_HAVE_STATUS_INPUT |
+-		PMBUS_HAVE_STATUS_TEMP | PMBUS_HAVE_STATUS_FAN12,
++		PMBUS_HAVE_STATUS_TEMP,
+ 	.groups = ipsps_groups,
+ };
+ 
+-- 
+2.34.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton_%.bbappend
@@ -7,4 +7,6 @@ SRC_URI:append:buv-runbmc = " \
   file://0007-Ampere-Altra-MAX-SSIF-IPMI-driver.patch \
   file://0008-driver-misc-seven-segment-display-gpio-driver.patch \
   file://0009-Add-buv-runbmc-PSU-driver-inspur-ipsps.c.patch \
+  file://0010-dts-add-two-test-PSUs-settings.patch \
+  file://0011-drivers-hwmon-pmbus-remove-fan-func-in-inspur-ipsps..patch \
   "

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/configuration/entity-manager/psu0.json
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/configuration/entity-manager/psu0.json
@@ -1,80 +1,104 @@
 {
     "Exposes": [
         {
-            "Address": "0x40",
-            "Bus": 11,
-            "EntityId": 19,
-            "EntityInstance": 1,
-            "Name": "MB_P12V_INA219",
-            "CurrScaleFactor": 200,
+            "Address": "0x5a",
+            "Bus": "1",
+            "Name": "PSU0",
             "Labels": [
-                "in1",
-                "curr1",
-                "power1"
+                "pin",
+                "pout1",
+                "vin",
+                "vout1",
+                "iout1",
+                "temp1"
             ],
-            "PowerScaleFactor": 200000,
-            "power1_Max": 300.0,
-            "in1_Max": 20.0,
-            "curr1_Max": 25.0,
             "Thresholds": [
                 {
                     "Direction": "greater than",
-                    "Label": "in1",
+                    "Label": "pin",
                     "Name": "upper critical",
                     "Severity": 1,
-                    "Value": 12.96
+                    "Value": 1000
                 },
                 {
                     "Direction": "greater than",
-                    "Label": "in1",
+                    "Label": "pin",
                     "Name": "upper non critical",
                     "Severity": 0,
-                    "Value": 12.56
-                },
-                {
-                    "Direction": "less than",
-                    "Label": "in1",
-                    "Name": "lower non critical",
-                    "Severity": 0,
-                    "Value": 11.44
-                },
-                {
-                    "Direction": "less than",
-                    "Label": "in1",
-                    "Name": "lower critical",
-                    "Severity": 1,
-                    "Value": 11.04
+                    "Value": 950
                 },
                 {
                     "Direction": "greater than",
-                    "Label": "curr1",
-                    "Name": "upper non critical",
-                    "Severity": 0,
-                    "Value": 1.5
-                },
-                {
-                    "Direction": "less than",
-                    "Label": "curr1",
-                    "Name": "lower non critical",
-                    "Severity": 0,
-                    "Value": 0
-                },
-                {
-                    "Direction": "greater than",
-                    "Label": "power1",
+                    "Label": "temp1",
                     "Name": "upper critical",
                     "Severity": 1,
-                    "Value": 24.0
+                    "Value": 70
+                },
+                {
+                    "Direction": "greater than",
+                    "Label": "temp1",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 50
+                },
+                {
+                    "Direction": "greater than",
+                    "Label": "vin",
+                    "Name": "upper critical",
+                    "Severity": 1,
+                    "Value": 240
+                },
+                {
+                    "Direction": "greater than",
+                    "Label": "vin",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 233
                 },
                 {
                     "Direction": "less than",
-                    "Label": "power1",
+                    "Label": "vin",
                     "Name": "lower critical",
                     "Severity": 1,
-                    "Value": 0
+                    "Value": 200
+                },
+                {
+                    "Direction": "less than",
+                    "Label": "vin",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 210
+                },
+                {
+                    "Direction": "greater than",
+                    "Label": "vout1",
+                    "Name": "upper critical",
+                    "Severity": 1,
+                    "Value": 13.494
+                },
+                {
+                    "Direction": "greater than",
+                    "Label": "vout1",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 13.101
+                },
+                {
+                    "Direction": "less than",
+                    "Label": "vout1",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 10.616
+                },
+                {
+                    "Direction": "less than",
+                    "Label": "vout1",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 10.945
                 }
             ],
-            "Type": "pmbus"
+            "Type": "IPSPS1"
         }
     ],
     "Name": "powersupply0",

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/configuration/entity-manager/psu1.json
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/configuration/entity-manager/psu1.json
@@ -1,67 +1,105 @@
 {
     "Exposes": [
         {
-            "Address": "0x41",
-            "Bus": 11,
-            "EntityId": 19,
-            "EntityInstance": 2,
-            "Name": "MB_P3V_INA219",
-            "CurrScaleFactor": 200,
+            "Address": "0x5b",
+            "Bus": "1",
+            "Name": "PSU1",
             "Labels": [
-                "in1",
-                "curr1",
-                "power1"
+                "pin",
+                "pout1",
+                "vin",
+                "vout1",
+                "iout1",
+                "temp1"
             ],
-            "PowerScaleFactor": 200000,
-            "power1_Max": 300.0,
-            "in1_Max": 20.0,
-            "curr1_Max": 100.0,
             "Thresholds": [
                 {
                     "Direction": "greater than",
-                    "Label": "in1",
+                    "Label": "pin",
                     "Name": "upper critical",
                     "Severity": 1,
-                    "Value": 3.95
-                },
-                {
-                    "Direction": "less than",
-                    "Label": "in1",
-                    "Name": "lower critical",
-                    "Severity": 1,
-                    "Value": 2.64
+                    "Value": 1000
                 },
                 {
                     "Direction": "greater than",
-                    "Label": "curr1",
+                    "Label": "pin",
                     "Name": "upper non critical",
                     "Severity": 0,
-                    "Value": 4.5
-                },
-                {
-                    "Direction": "less than",
-                    "Label": "curr1",
-                    "Name": "lower non critical",
-                    "Severity": 0,
-                    "Value": 0
+                    "Value": 950
                 },
                 {
                     "Direction": "greater than",
-                    "Label": "power1",
+                    "Label": "temp1",
                     "Name": "upper critical",
                     "Severity": 1,
-                    "Value": 12.0
+                    "Value": 70
+                },
+                {
+                    "Direction": "greater than",
+                    "Label": "temp1",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 50
+                },
+                {
+                    "Direction": "greater than",
+                    "Label": "vin",
+                    "Name": "upper critical",
+                    "Severity": 1,
+                    "Value": 240
+                },
+                {
+                    "Direction": "greater than",
+                    "Label": "vin",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 233
                 },
                 {
                     "Direction": "less than",
-                    "Label": "power1",
+                    "Label": "vin",
                     "Name": "lower critical",
                     "Severity": 1,
-                    "Value": 0
+                    "Value": 200
+                },
+                {
+                    "Direction": "less than",
+                    "Label": "vin",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 210
+                },
+                {
+                    "Direction": "greater than",
+                    "Label": "vout1",
+                    "Name": "upper critical",
+                    "Severity": 1,
+                    "Value": 13.494
+                },
+                {
+                    "Direction": "greater than",
+                    "Label": "vout1",
+                    "Name": "upper non critical",
+                    "Severity": 0,
+                    "Value": 13.101
+                },
+                {
+                    "Direction": "less than",
+                    "Label": "vout1",
+                    "Name": "lower critical",
+                    "Severity": 1,
+                    "Value": 10.616
+                },
+                {
+                    "Direction": "less than",
+                    "Label": "vout1",
+                    "Name": "lower non critical",
+                    "Severity": 0,
+                    "Value": 10.945
                 }
             ],
-            "Type": "pmbus"
-        }    
+            "Type": "IPSPS1"
+        }
     ],
     "Name": "powersupply1",
     "Probe": "TRUE",
@@ -69,8 +107,8 @@
     "xyz.openbmc_project.Inventory.Decorator.Asset": {
         "Manufacturer": "Nuvoton",
         "Model": "Nuvoton",
-        "PartNumber": "M9T5C8W2N1Z7Q6B4",
-        "SerialNumber": "SN8461K3V9F2T7"
+        "PartNumber": "X9F7K2T6Y3P8J4R5",
+        "SerialNumber": "SN78594K3TQ2P7"
     },
     "xyz.openbmc_project.Inventory.Item": {
         "Present": true,


### PR DESCRIPTION
…t PSUs

Connect two (ChiconyPower) test PSUs on BUV-Runbmc module. PSU0 address is 0x5a, PSU1 address is 0x5b.

Disable fan related func in inspur-ipsps.c to avoid psusensor reads wrong sysfs path. It will cause psusensor crash.

PSU hot plug feature is implemented in entity-manager. This feature is based on phosphor-gpio-monitor.
Before testing, you should define PSU0 present pin in BUV-GpioMonitorConfig-EM.json.
	- echo 5 > /sys/class/gpio/export
	- echo out > /sys/class/gpio/gpio5/direction
	- Install PSU0:
		- echo 0 > /sys/class/gpio/gpio5/value
	- Remove PSU0:
		- echo 1 > /sys/class/gpio/gpio5/value When you remove PSU0, you are able to see the PSU0 and related sensors disappear on WebUI.

Test commands:
	- busctl tree xyz.openbmc_project.PSUSensor
	- busctl introspect xyz.openbmc_project.EntityManager /xyz/openbmc_project/inventory/system/powersupply/powersupply0/PSU0
	- busctl introspect xyz.openbmc_project.EntityManager /xyz/openbmc_project/inventory/system/powersupply/powersupply1/PSU1
