### PR TITLE
buv-runbmc: phosphor-pid-control: update recipe

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/fans/phosphor-pid-control_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/fans/phosphor-pid-control_%.bbappend
@@ -23,15 +23,15 @@ SYSTEMD_SERVICE:${PN}:append:buv-runbmc = " fan-boot-control.service"
 do_install:append:buv-runbmc() {
     install -d ${D}/${bindir}
     install -m 0755 ${WORKDIR}/fan-default-speed.sh ${D}/${bindir}
+    is_entity="${@entity_enabled(d, 'yes', '')}"
 
-    if [ "${DISTRO}" != "buv-entity" ];then
-        install -d ${D}${datadir}/swampd
+    if [ -z "${is_entity}" ];then
         install -m 0644 -D ${WORKDIR}/config-buv-nuvoton.json \
             ${D}${datadir}/swampd/config.json
     fi
 
     install -d ${D}${systemd_unitdir}/system/
-    if [ "${DISTRO}" != "buv-entity" ];then
+    if [ -z "${is_entity}" ];then
         install -m 0644 ${WORKDIR}/phosphor-pid-control_buv.service \
             ${D}${systemd_unitdir}/system/phosphor-pid-control.service
     fi


### PR DESCRIPTION
Due to we move the eMMC setting from machine to distro config, buv-entity is not only the distro contains feature entity manager. Update this recipe to make the config setting work correct.
