### PR TITLE
scm-npcm845: linux: update SGPIO DTS

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/0004-kernel-scm-dts.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/0004-kernel-scm-dts.patch
@@ -418,9 +418,9 @@ index 000000000000..c4455dd4d2fe
 +
 +			sgpio2: sgpio@102000 {
 +				status = "okay";
-+				bus-frequency = <16000000>;
-+				nin_gpios = <38>;
-+				nout_gpios = <13>;
++				bus-frequency = <8000000>;
++				nuvoton,input-ngpios = <38>;
++				nuvoton,output-ngpios = <13>;
 +				gpio-line-names =
 +					"BMC_SPI_CPLD_FPGA_SEL","TPM_BMC_ALERT_N","BMC_PCH_FNM","FM_UV_ADR_TRIGGER_EN","FM_SPD_SWITCH_CTRL_N","SMB_SLIVER_RST_BMC_N","PWRBRK_SLI_OE_N","FM_ME_RECOVERY_N",
 +					"FM_BIOS_RECOVERY","FM_BIOS_MRC_DEBUG_MSG_DIS_N","RST_BMC_RTCRST","NMI_OUT","FM_BMC_ONCTL_N",


### PR DESCRIPTION
Update npcm-v2.12 scm DTS due to we update kernel SGPIO keyword nin_gpios to nuvoton,input-ngpios.
