### PR TITLE
meta-buv-runbmc: conf: remove duplicate inclusion

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/distro/buv-runbmc-emmc-entity.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/distro/buv-runbmc-emmc-entity.conf
@@ -1,4 +1,3 @@
-require conf/machine/buv-runbmc.conf
 require conf/distro/openbmc-phosphor.conf
 require conf/distro/include/phosphor-mmc.inc
 

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/distro/buv-runbmc-emmc.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/distro/buv-runbmc-emmc.conf
@@ -1,4 +1,3 @@
-require conf/machine/buv-runbmc.conf
 require conf/distro/openbmc-phosphor.conf
 require conf/distro/include/phosphor-mmc.inc
 


### PR DESCRIPTION
We should not include machine conf in distro conf.
