### PR TITLE
meta-nuvoton: trusted-firmware-a: fix recipe warning

### DIFF
--- a/meta-nuvoton/recipes-bsp/arm-trusted-firmware/trusted-firmware-a.inc
+++ b/meta-nuvoton/recipes-bsp/arm-trusted-firmware/trusted-firmware-a.inc
@@ -3,8 +3,6 @@ DESCRIPTION = "ARM Trusted Firmware"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM ?= "file://license.rst;md5=1dd070c98a281d18d9eefd938729b031"
 
-PV="1.3.0+git${SRCPV}"
-
 inherit deploy
 
 S = "${WORKDIR}/git"

--- a/meta-nuvoton/recipes-bsp/arm-trusted-firmware/trusted-firmware-a_2.6.0.bb
+++ b/meta-nuvoton/recipes-bsp/arm-trusted-firmware/trusted-firmware-a_2.6.0.bb
@@ -1,4 +1,3 @@
-ATF_VERSION = "1.3"
 SRCREV = "69e6d531f055bd6328d529b6f797b548c2c00aa1"
 LIC_FILES_CHKSUM = "file://license.rst;md5=1dd070c98a281d18d9eefd938729b031"
 


### PR DESCRIPTION
Fix wrong PV setting for avoid preferred version not available warning.
