### PR TITLE
evb-npcm750: software-manager: update patches

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/flash/phosphor-software-manager/0001-Support-ignore-update-uboot-with-eMMC-image.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/flash/phosphor-software-manager/0001-Support-ignore-update-uboot-with-eMMC-image.patch
@@ -1,7 +1,7 @@
-From 2e0b0534569bf84f17cc5c705706599c59a60d44 Mon Sep 17 00:00:00 2001
+From 4e900b198f2620515ced0a9e772e29c2c201554b Mon Sep 17 00:00:00 2001
 From: Brian Ma <chma0@nuvoton.com>
 Date: Thu, 17 Feb 2022 08:50:52 +0800
-Subject: [PATCH 2/2] Support ignore update uboot with eMMC image
+Subject: [PATCH 1/3] Support ignore update uboot with eMMC image
 
 Signed-off-by: Brian Ma <chma0@nuvoton.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Brian Ma <chma0@nuvoton.com>
  1 file changed, 29 insertions(+), 12 deletions(-)
 
 diff --git a/obmc-flash-bmc b/obmc-flash-bmc
-index b76ad62..bd4506c 100644
+index 833a565..032096a 100644
 --- a/obmc-flash-bmc
 +++ b/obmc-flash-bmc
 @@ -1,6 +1,8 @@
@@ -116,3 +116,4 @@ index b76ad62..bd4506c 100644
  function mmc_remove() {
 -- 
 2.34.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/flash/phosphor-software-manager/0002-porting-bios-verify-feature.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/flash/phosphor-software-manager/0002-porting-bios-verify-feature.patch
@@ -1,4 +1,4 @@
-From 553a48765b1b80c11da6cc3f1d7a303f8b4edb16 Mon Sep 17 00:00:00 2001
+From 4d4c6170dac91d0b468c72c40b334c846a508f38 Mon Sep 17 00:00:00 2001
 From: Brian Ma <chma0@nuvoton.com>
 Date: Thu, 17 Feb 2022 08:54:24 +0800
 Subject: [PATCH 2/3] porting bios verify feature
@@ -11,22 +11,22 @@ Signed-off-by: Brian Ma <chma0@nuvoton.com>
  3 files changed, 26 insertions(+), 1 deletion(-)
 
 diff --git a/image_verify.cpp b/image_verify.cpp
-index d67cfac..071e124 100644
+index 2b20340..e5aa5da 100644
 --- a/image_verify.cpp
 +++ b/image_verify.cpp
-@@ -93,6 +93,7 @@ bool Signature::verifyFullImage()
-     bool ret = true;
- #ifdef WANT_SIGNATURE_FULL_VERIFY
+@@ -108,6 +108,7 @@ bool Signature::verifyFullImage()
+     }
+ 
      std::vector<std::string> fullImages = {
 +        fs::path(imageDirPath) / "image-bios.sig",
          fs::path(imageDirPath) / "image-bmc.sig",
          fs::path(imageDirPath) / "image-hostfw.sig",
          fs::path(imageDirPath) / "image-kernel.sig",
 diff --git a/item_updater.cpp b/item_updater.cpp
-index fe9c808..730b9f7 100644
+index 3ea954c..929d190 100644
 --- a/item_updater.cpp
 +++ b/item_updater.cpp
-@@ -749,6 +749,28 @@ bool ItemUpdater::checkImage(const std::string& filePath,
+@@ -847,6 +847,28 @@ bool ItemUpdater::checkImage(const std::string& filePath,
  }
  
  #ifdef HOST_BIOS_UPGRADE
@@ -55,7 +55,7 @@ index fe9c808..730b9f7 100644
  void ItemUpdater::createBIOSObject()
  {
      std::string path = BIOS_OBJPATH;
-@@ -764,7 +786,7 @@ void ItemUpdater::createBIOSObject()
+@@ -862,7 +884,7 @@ void ItemUpdater::createBIOSObject()
      createFunctionalAssociation(path);
  
      auto versionId = path.substr(pos + 1);
@@ -65,10 +65,10 @@ index fe9c808..730b9f7 100644
      biosActivation = std::make_unique<Activation>(
          bus, path, *this, versionId, server::Activation::Activations::Active,
 diff --git a/meson.build b/meson.build
-index 1367a72..0d16964 100644
+index 0d9d68d..f99a034 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -58,6 +58,8 @@ conf.set_quoted('ALT_RWFS', '/media/alt/var/persist')
+@@ -57,6 +57,8 @@ conf.set_quoted('UPDATEABLE_REV_ASSOCIATION', 'software_version')
  conf.set_quoted('BMC_ROFS_PREFIX', get_option('media-dir') + '/rofs-')
  # The name of the BMC table of contents file
  conf.set_quoted('OS_RELEASE_FILE', '/etc/os-release')
@@ -78,5 +78,5 @@ index 1367a72..0d16964 100644
  conf.set_quoted('PERSIST_DIR', '/var/lib/phosphor-bmc-code-mgmt/')
  
 -- 
-2.17.1
+2.34.1
 

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/flash/phosphor-software-manager/0003-Add-support-report-same-version-error.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/flash/phosphor-software-manager/0003-Add-support-report-same-version-error.patch
@@ -1,4 +1,4 @@
-From 55abd2cd1e412c9f704c64407996015610ce0cac Mon Sep 17 00:00:00 2001
+From f8c5e55ec2f309658d484114f388bbc4704a7810 Mon Sep 17 00:00:00 2001
 From: Brian Ma <chma0@nuvoton.com>
 Date: Thu, 17 Feb 2022 08:55:45 +0800
 Subject: [PATCH 3/3] Add support report same version error
@@ -9,7 +9,7 @@ Signed-off-by: Brian Ma <chma0@nuvoton.com>
  1 file changed, 9 insertions(+), 3 deletions(-)
 
 diff --git a/image_manager.cpp b/image_manager.cpp
-index a9a5a69..f4dadee 100644
+index f998871..6e0cdcd 100644
 --- a/image_manager.cpp
 +++ b/image_manager.cpp
 @@ -11,10 +11,11 @@
@@ -25,7 +25,7 @@ index a9a5a69..f4dadee 100644
  
  #include <algorithm>
  #include <cstring>
-@@ -31,11 +32,14 @@ namespace manager
+@@ -34,11 +35,14 @@ namespace manager
  PHOSPHOR_LOG2_USING;
  using namespace phosphor::logging;
  using namespace sdbusplus::xyz::openbmc_project::Software::Image::Error;
@@ -40,7 +40,7 @@ index a9a5a69..f4dadee 100644
  namespace fs = std::filesystem;
  
  struct RemovablePath
-@@ -219,8 +223,10 @@ int Manager::processImage(const std::string& tarFilePath)
+@@ -230,8 +234,10 @@ int Manager::processImage(const std::string& tarFilePath)
      }
      else
      {
@@ -54,5 +54,5 @@ index a9a5a69..f4dadee 100644
      return 0;
  }
 -- 
-2.17.1
+2.34.1
 

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend:evb-npcm750 := "${THISDIR}/${PN}:"
 
 SRC_URI:append:evb-npcm750 = " \
-    file://0001-Support-update-uboot-with-emmc-image.patch \
+    file://0001-Support-ignore-update-uboot-with-eMMC-image.patch \
     file://0002-porting-bios-verify-feature.patch  \
     file://0003-Add-support-report-same-version-error.patch \
     "


### PR DESCRIPTION
Update phosphor-software-manager patches to fix build break
