### PR TITLE
meta-buv-runbmc: fix build buv-dev distro error

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/classes/buv-entity-utils.bbclass
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/classes/buv-entity-utils.bbclass
@@ -5,10 +5,8 @@
 #    ${@entity_enabled(d, '--enable-configure-dbus=yes')}"
 
 def distro_enabled(d, distro, truevalue, falsevalue=""):
-    if d.getVar("DISTRO") == distro:
-        return truevalue
-    else:
-        return falsevalue
+    return bb.utils.contains('DISTRO_FEATURES', distro, truevalue,
+        falsevalue, d)
 
 def entity_enabled(d, val, fval=""):
     return bb.utils.contains('DISTRO_FEATURES',

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/classes/buv-image.bbclass
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/classes/buv-image.bbclass
@@ -2,5 +2,5 @@ inherit buv-entity-utils
 
 OBMC_IMAGE_EXTRA_INSTALL += " \
     ${@entity_enabled(d, 'packagegroup-buv-runbmc-apps-entity')} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'buv-dev', 'packagegroup-buv-runbmc-apps-dev', '', d)} \
+    ${@distro_enabled(d, 'buv-dev', 'packagegroup-buv-runbmc-apps-devtools')} \
     "

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/packagegroups/packagegroup-buv-runbmc-apps.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/packagegroups/packagegroup-buv-runbmc-apps.bb
@@ -9,8 +9,8 @@ PACKAGES = " \
     ${PN}-chassis \
     ${PN}-fans \
     ${PN}-system \
-    ${@entity_enabled(d, '${PN}-entity')} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'buv-dev', '${PN}-dev', '', d)} \
+    ${PN}-entity \
+    ${PN}-devtools \
     "
 
 RPROVIDES:${PN}-chassis += "virtual-obmc-chassis-mgmt"
@@ -62,12 +62,14 @@ RDEPENDS:${PN}-system:append = " \
         "
 
 SUMMARY:${PN}-entity = "BUV RunBMC entity"
-#RDEPENDS:${PN}-entity = " \
-#    intel-ipmi-oem \
-#    "
+RDEPENDS:${PN}-entity = " \
+    entity-manager \
+    fru-device \
+    dbus-sensors \
+    "
 
-SUMMARY:${PN}-dev = "BUV RunBMC development tools"
-RDEPENDS:${PN}-dev = " \
+SUMMARY:${PN}-devtools = "BUV RunBMC development tools"
+RDEPENDS:${PN}-devtools = " \
     ent \
     dhrystone \
     rw-perf \


### PR DESCRIPTION
Update packagegroups to fix build error distro feaure buv-dev with distro buv-runbmc-emmc-entity. And also make build entity manager into other distro easier.

Tested:
build distro buv-runbmc-emmc-entity + DISTRO_FEATURES:append = " buv-dev" build distso buv-runbmc-emmc +
    DISTRO_FEATURES:append = " entity-manager buv-dev"
