### PR TITLE
meta-nuvoton: linux-nuvoton 5.15.85: bump srcrev 91140a4c...c596e7c2

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_5.15.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_5.15.bb
@@ -2,10 +2,9 @@ KSRC = "git://github.com/Nuvoton-Israel/linux;protocol=https;branch=${KBRANCH}"
 KBRANCH = "NPCM-5.15-OpenBMC"
 LINUX_VERSION = "5.15.85"
 SRCREV:npcm8xx = "9701d3eef021f3c49ac710f4b82d78d584dd1952"
-SRCREV:npcm7xx = "91140a4c93b3d314a2865059645d7d57e5ec6e1e"
+SRCREV:npcm7xx = "c596e7c23e0b78d4af6232a14a609921a2d94066"
 
 require linux-nuvoton.inc
 
-SRC_URI:append:nuvoton = " file://0003-i2c-nuvoton-npcm750-runbmc-integrate-the-slave-mqueu.patch"
 SRC_URI:append:nuvoton = " file://0017-drivers-i2c-workaround-for-i2c-slave-behavior.patch"
 


### PR DESCRIPTION
Brian Ma (1):
      ARM: npcm: Add CPU hotplug callbacks for kexec support

Eason Yang (1):
      i2c: slave-mqueue: add slave mqueue driver

Marvin Lin (2):
      media: nuvoton: Add RGB565 pixel format support
      media: nuvoton: Add resolution change interrupt support

Stanley Chu (2):
      i3c: master: svc: fix no initial-role property error
      i3c: fix driver remove error

William A. Kennington III (2):
      crypto: npcm_aes: Fix build when OTP is disabled
      crypto: npcm: drv remove should not be defined as __exit

build tested:
buv-runbmc  evb-npcm750  evb-npcm845  olympus-nuvoton  scm-npcm845