### PR TITLE
scm-npcm845: settings: add chassis poh path

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/settings/phosphor-settings-manager/chassis-poh.override.yml
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/settings/phosphor-settings-manager/chassis-poh.override.yml
@@ -1,0 +1,7 @@
+---
+/xyz/openbmc_project/state/chassis0:
+    - Interface: xyz.openbmc_project.State.PowerOnHours
+      Properties:
+          POHCounter:
+              Default: 0
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/settings/phosphor-settings-manager_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/settings/phosphor-settings-manager_%.bbappend
@@ -1,3 +1,4 @@
 FILESEXTRAPATHS:prepend:scm-npcm845 := "${THISDIR}/${PN}:"
 
 SRC_URI:append:scm-npcm845 = " file://sol-default.override.yml"
+SRC_URI:append:scm-npcm845 = " file://chassis-poh.override.yml"


### PR DESCRIPTION
Add the dbus POH path to fix ipmi chassis poh command error.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
