### PR TITLE
meta-nuvoton: u-boot: bump srcrev d83424e7...960898ca

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton/0001-uboot-scm-dts.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton/0001-uboot-scm-dts.patch
@@ -1,4 +1,4 @@
-From f8c447c921b59826093aae658d150d8ad2655d48 Mon Sep 17 00:00:00 2001
+From c9ee0481e0014a6c1e14b209a1ef6fd9a27987e1 Mon Sep 17 00:00:00 2001
 From: Stanley Chu <yschu@nuvoton.com>
 Date: Fri, 10 Jun 2022 10:33:32 +0800
 Subject: [PATCH] uboot scm dts
@@ -7,23 +7,22 @@ Signed-off-by: Stanley Chu <yschu@nuvoton.com>
 Signed-off-by: Joseph Liu <kwliu@nuvoton.com>
 ---
  arch/arm/dts/Makefile                        |   3 +-
- arch/arm/dts/nuvoton-common-npcm8xx.dtsi     |   4 +
  arch/arm/dts/nuvoton-npcm845-scm-pincfg.dtsi | 706 +++++++++++++++++++
  arch/arm/dts/nuvoton-npcm845-scm.dts         | 341 +++++++++
- 4 files changed, 1053 insertions(+), 1 deletion(-)
+ 3 files changed, 1049 insertions(+), 1 deletion(-)
  create mode 100644 arch/arm/dts/nuvoton-npcm845-scm-pincfg.dtsi
  create mode 100644 arch/arm/dts/nuvoton-npcm845-scm.dts
 
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index 40ff9042f9..ced4709bbb 100644
+index 6dc59494dc..13618a99aa 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -1033,7 +1033,8 @@ dtb-$(CONFIG_TARGET_DURIAN) += phytium-durian.dtb
- dtb-$(CONFIG_TARGET_PRESIDIO_ASIC) += ca-presidio-engboard.dtb
+@@ -1034,7 +1034,8 @@ dtb-$(CONFIG_TARGET_PRESIDIO_ASIC) += ca-presidio-engboard.dtb
  
  dtb-$(CONFIG_TARGET_ARBEL_EVB) += \
--	nuvoton-npcm845-evb.dtb
-+	nuvoton-npcm845-evb.dtb \
+ 	nuvoton-npcm845-evb.dtb \
+-	nuvoton-npcm845-meta-evb.dtb
++	nuvoton-npcm845-meta-evb.dtb \
 +	nuvoton-npcm845-scm.dtb
  
  dtb-$(CONFIG_ARCH_NPCM7xx) += \

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton/0006-set-clock-divisor-for-uart456.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton/0006-set-clock-divisor-for-uart456.patch
@@ -1,4 +1,4 @@
-From f28b744e05c35ad47ebfedbe06d3ec7765f6b53b Mon Sep 17 00:00:00 2001
+From 459c5c1bd7a6ab4b9598d2ecf885f0ec379d5c78 Mon Sep 17 00:00:00 2001
 From: Stanley Chu <yschu@nuvoton.com>
 Date: Fri, 29 Jul 2022 15:57:54 +0800
 Subject: [PATCH] set clock divisor for uart456
@@ -9,21 +9,21 @@ Signed-off-by: Stanley Chu <yschu@nuvoton.com>
  1 file changed, 8 insertions(+)
 
 diff --git a/board/nuvoton/arbel/arbel.c b/board/nuvoton/arbel/arbel.c
-index 0e21aa5bce..29cc8b7bdc 100644
+index c5f830b326..a0f5abd3ec 100644
 --- a/board/nuvoton/arbel/arbel.c
 +++ b/board/nuvoton/arbel/arbel.c
-@@ -19,8 +19,10 @@
+@@ -26,8 +26,10 @@
  DECLARE_GLOBAL_DATA_PTR;
  
  #define CLKSEL	0x4
-+#define CLKDIV3	0x58
++#define CLKDIV3    0x58
  #define PIXCKSEL_GFX	0
  #define PIXCKSEL_MASK	GENMASK(5, 4)
-+#define CLKDIV3_UARTDIV2_MASK	GENMASK(15, 11)
- #define SR_MII_CTRL_SWR_BIT15   15
- #define VR_MII_MMD_DIG_CTRL1_R2TLBE_BIT14 14
++#define CLKDIV3_UARTDIV2_MASK  GENMASK(15, 11)
+ #define SR_MII_CTRL_SWR_BIT15	15
  
-@@ -70,6 +72,12 @@ static void arbel_clk_init(void)
+ #define DRAM_512MB_ECC_SIZE	0x1C000000ULL
+@@ -102,6 +104,12 @@ static void arbel_clk_init(void)
  	val &= ~PIXCKSEL_MASK;
  	val |= FIELD_PREP(PIXCKSEL_MASK, PIXCKSEL_GFX);
  	writel(val, NPCM_CLK_BA + CLKSEL);
@@ -37,5 +37,5 @@ index 0e21aa5bce..29cc8b7bdc 100644
  
  int board_init(void)
 -- 
-2.17.1
+2.34.1
 

--- a/meta-nuvoton/recipes-bsp/u-boot/u-boot-common-nuvoton.inc
+++ b/meta-nuvoton/recipes-bsp/u-boot/u-boot-common-nuvoton.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 
 UBRANCH = "npcm-v2021.04"
 SRC_URI = "git://github.com/Nuvoton-Israel/u-boot.git;branch=${UBRANCH};protocol=https"
-SRCREV = "d83424e76d68f92530c6655bd9fcd5c31f82237c"
+SRCREV = "960898ca7f524779da9acc8494b69fe386c11f8b"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Stanley Chu (6):
      spi: npcm_pspi: use ACTIVE_LOW flag for cs gpio and set default max_hz
      npcm845-evb: support TPM spi device
      arbel: add CONFIG_EXT_TPM2_SPI for external tpm2 device
      phy: add dt-bindig for npcm usb phy
      npcm8xx: support 4Gb ram
      gpio: npcm: set output state before enabling the output

Tim Lee (1):
      configs: arbel: enable CONFIG_SPI_FLASH_GOOGLE

And update patches in meta-scm-npcm845 to fix build break.
