### PR TITLE
meta-nuvoton:linux-nuvoton_6.1:bump srcrev:5c9a4d3f..352c801b

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_6.1.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_6.1.bb
@@ -1,7 +1,7 @@
 KSRC = "git://github.com/Nuvoton-Israel/linux;protocol=https;branch=${KBRANCH}"
 KBRANCH = "NPCM-6.1-OpenBMC"
 LINUX_VERSION = "6.1.12"
-SRCREV = "5c9a4d3fd32af95175d72271864f4df2e4ca525f"
+SRCREV = "b8ca47c26d90d06043ef821f433f4b821a9cee95"
 
 require linux-nuvoton.inc
 


### PR DESCRIPTION
Tomer Maimon (6):
      pci: controller: npcm: add NPCM7xx support
      pci: npcm: replace RC and EP GPIO order
      Add PCIe NPCM7xx support
      arm64: dts: npcm8xx: modify PCIe node
      pinctrl: npcm7xx: prevent glitch when setting the GPIO to output high
      pinctrl: npcm8xx: prevent glitch when setting the GPIO to output high

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
