### PR TITLE
meta-nuvoton: linux-nuvoton 5.10: bump srcrev b41d3585..73b95b81

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_5.10.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_5.10.bb
@@ -1,6 +1,6 @@
 KSRC = "git://github.com/Nuvoton-Israel/linux;protocol=https;branch=${KBRANCH}"
 KBRANCH = "NPCM-5.10-OpenBMC"
 LINUX_VERSION = "5.10.161"
-SRCREV = "b41d35854cb6fc2323b8cb1e99e98a6362fb8058"
+SRCREV = "45ae05f0464f9bcdbf20200e9a64ef155874a16a"
 
 require linux-nuvoton.inc


### PR DESCRIPTION
Tomer Maimon (3):
      iio: adc: modify wake up function
      pinctrl: npcm7xx: prevent glitch when setting the GPIO to output high
      pinctrl: npcm8xx: prevent glitch when setting the GPIO to output high

