### PR TITLE
meta-nuvoton: linux-nuvoton 5.15: bump srcrev 3a68d8e3..b78d9fe3

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_5.15.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_5.15.bb
@@ -1,7 +1,7 @@
 KSRC = "git://github.com/Nuvoton-Israel/linux;protocol=https;branch=${KBRANCH}"
 KBRANCH = "NPCM-5.15-OpenBMC"
 LINUX_VERSION = "5.15.85"
-SRCREV = "3a68d8e33f9d7ce2d6ac33292517af412fd48812"
+SRCREV = "597f526fa214992ac4ff8c1402e89eef5cb75909"
 
 require linux-nuvoton.inc
 


### PR DESCRIPTION
Tomer Maimon (4):
      iio: adc: npcm: modify wait event function
      pci: npcm: replace RC and EP GPIO order
      pinctrl: npcm7xx: prevent glitch when setting the GPIO to output high
      pinctrl: npcm8xx: prevent glitch when setting the GPIO to output high
