### PR TITLE
meta-nuvoton: u-boot: bump srcrev d83424e7...960898ca

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton/0001-uboot-scm-dts.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton/0001-uboot-scm-dts.patch
@@ -1,4 +1,4 @@
-From d7041359ea0beca3b2f27b3ee4699103685872c2 Mon Sep 17 00:00:00 2001
+From a98b7ab99f91d24f160bf3008eb7c3cae8765458 Mon Sep 17 00:00:00 2001
 From: Stanley Chu <yschu@nuvoton.com>
 Date: Tue, 14 Feb 2023 11:42:49 +0800
 Subject: [PATCH] uboot scm dts
@@ -9,19 +9,19 @@ Signed-off-by: Stanley Chu <yschu@nuvoton.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index e64d162b20..3aba574f67 100644
+index 6dc59494dc..13618a99aa 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -1033,7 +1033,8 @@ dtb-$(CONFIG_TARGET_DURIAN) += phytium-durian.dtb
- dtb-$(CONFIG_TARGET_PRESIDIO_ASIC) += ca-presidio-engboard.dtb
+@@ -1034,7 +1034,8 @@ dtb-$(CONFIG_TARGET_PRESIDIO_ASIC) += ca-presidio-engboard.dtb
  
  dtb-$(CONFIG_TARGET_ARBEL_EVB) += \
--	nuvoton-npcm845-evb.dtb
-+	nuvoton-npcm845-evb.dtb \
+ 	nuvoton-npcm845-evb.dtb \
+-	nuvoton-npcm845-meta-evb.dtb
++	nuvoton-npcm845-meta-evb.dtb \
 +	nuvoton-npcm845-scm.dtb
  
  dtb-$(CONFIG_ARCH_NPCM7xx) += \
  		nuvoton-npcm750-buv.dtb \
 -- 
-2.17.1
+2.34.1
 

--- a/meta-nuvoton/recipes-bsp/u-boot/u-boot-common-nuvoton.inc
+++ b/meta-nuvoton/recipes-bsp/u-boot/u-boot-common-nuvoton.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 
 UBRANCH = "npcm-v2021.04"
 SRC_URI = "git://github.com/Nuvoton-Israel/u-boot.git;branch=${UBRANCH};protocol=https"
-SRCREV = "d83424e76d68f92530c6655bd9fcd5c31f82237c"
+SRCREV = "960898ca7f524779da9acc8494b69fe386c11f8b"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Stanley Chu (6):
      spi: npcm_pspi: use ACTIVE_LOW flag for cs gpio and set default max_hz
      npcm845-evb: support TPM spi device
      arbel: add CONFIG_EXT_TPM2_SPI for external tpm2 device
      phy: add dt-bindig for npcm usb phy
      npcm8xx: support 4Gb ram
      gpio: npcm: set output state before enabling the output

Tim Lee (1):
      configs: arbel: enable CONFIG_SPI_FLASH_GOOGLE

And update patch to fix build break.
