### PR TITLE
Revert "meta-scm-npcm845: obmc-console: fix SOL fail"

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/console/obmc-console/server.ttyS2.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/console/obmc-console/server.ttyS2.conf
@@ -1,4 +1,3 @@
 local-tty = ttyS2
 local-tty-baud = 115200
-socket-id = console0
 logfile = /var/log/obmc-console-host.log


### PR DESCRIPTION
This reverts commit 82f75e345c949daefee8d8123957e4aa09a01f15.

Due to following two openbmc commits, we should remove default SOL socket id.
  Revert "Add socket-id for the first console"
    https://gerrit.openbmc.org/c/openbmc/openbmc/+/63393
  obmc-console: srcrev bump 4ee702a865..ae2460d0b8
    https://gerrit.openbmc.org/c/openbmc/openbmc/+/63392
