### PR TITLE
meta-evb-npcm750: update target build flow

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/conf/layer.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/conf/layer.conf
@@ -7,5 +7,4 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "evb-npcm750"
 BBFILE_PATTERN_evb-npcm750 = "^${LAYERDIR}/"
-BBFILE_PATTERN_evb-npcm750 = ""
 LAYERSERIES_COMPAT_evb-npcm750 = "langdale mickledore"

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/conf/machine/evb-npcm750.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/conf/machine/evb-npcm750.conf
@@ -9,7 +9,7 @@ require conf/machine/include/obmc-bsp-common.inc
 
 FLASH_SIZE = "32768"
 
-OBMC_MACHINE_FEATURES += "\
+MACHINE_FEATURES += "\
         obmc-phosphor-fan-mgmt \
         obmc-phosphor-chassis-mgmt \
         obmc-phosphor-flash-mgmt \
@@ -18,6 +18,11 @@ OBMC_MACHINE_FEATURES += "\
         obmc-chassis-state-mgmt \
         obmc-bmc-state-mgmt \
         "
+
+MACHINE_FEATURES:append = " ext2"
+
+VIRTUAL-RUNTIME_obmc-host-state-manager = "x86-power-control"
+VIRTUAL-RUNTIME_obmc-chassis-state-manager = "x86-power-control"
 
 PREFERRED_VERSION_linux-nuvoton ?= "5.15%"
 PREFERRED_PROVIDER_virtual/obmc-chassis-mgmt = "packagegroup-evb-npcm750-apps"

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/console/obmc-console_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/console/obmc-console_%.bbappend
@@ -1,9 +1,8 @@
 FILESEXTRAPATHS:prepend:evb-npcm750 := "${THISDIR}/${PN}:"
 
 SRC_URI:append:evb-npcm750 = " file://80-evb-npcm750-sol.rules"
-OBMC_CONSOLE_HOST_TTY:evb-npcm750 = "ttyS1"
 
-do_install:append_evb-npcm750() {
+do_install:append:evb-npcm750() {
         install -m 0755 -d ${D}${sysconfdir}/${BPN}
         rm -f ${D}${sysconfdir}/${BPN}/server.ttyVUART0.conf
         install -m 0644 ${WORKDIR}/${BPN}.conf ${D}${sysconfdir}/

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/ipmi/phosphor-ipmi-fru_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-phosphor/ipmi/phosphor-ipmi-fru_%.bbappend
@@ -20,7 +20,7 @@ EEPROMS_ESCAPED = "${@compose_list(d, 'EEPROM_ESCAPEDFMT', 'EEPROM_NAMES')}"
 
 ENVFMT = "obmc/eeproms/{0}"
 ENVF = "${@compose_list(d, 'ENVFMT', 'EEPROMS')}"
-SYSTEMD_ENVIRONMENT_FILE:${PN}:append_evb-npcm750 := " ${ENVF}"
+SYSTEMD_ENVIRONMENT_FILE:${PN}:append:evb-npcm750 := " ${ENVF}"
 
 TMPL = "obmc-read-eeprom@.service"
 TGT = "${SYSTEMD_DEFAULT_TARGET}"

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-x86/chassis/x86-power-control/power-config-host0.json
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-x86/chassis/x86-power-control/power-config-host0.json
@@ -1,0 +1,51 @@
+{
+  "gpio_configs":[
+    {
+        "Name" : "PostComplete",
+        "LineName" : "POST_COMPLETE",
+        "Type" : "GPIO",
+        "Polarity" : "ActiveHigh"
+    },
+    {
+        "Name" : "PowerButton",
+        "LineName" : "POWER_BUTTON",
+        "Type" : "GPIO",
+        "Polarity" : "ActiveLow"
+    },
+    {
+        "Name" : "PowerOk",
+        "LineName" : "PS_PWROK",
+        "Type" : "GPIO",
+        "Polarity" : "ActiveHigh"
+    },
+    {
+        "Name" : "PowerOut",
+        "LineName" : "POWER_OUT",
+        "Type" : "GPIO",
+        "Polarity" : "ActiveLow"
+    },
+    {
+        "Name" : "ResetButton",
+        "LineName" : "RESET_BUTTON",
+        "Type" : "GPIO",
+        "Polarity" : "ActiveLow"
+    },
+    {
+        "Name" : "ResetOut",
+        "LineName" : "RESET_OUT",
+        "Type" : "GPIO",
+        "Polarity" : "ActiveLow"
+    }
+  ],
+    "timing_configs":{
+        "PowerPulseMs": 200,
+        "ForceOffPulseMs": 15000,
+        "ResetPulseMs": 500,
+        "PowerCycleMs": 5000,
+        "SioPowerGoodWatchdogMs": 1000,
+        "PsPowerOKWatchdogMs": 8000,
+        "GracefulPowerOffS": 300,
+        "WarmResetCheckMs": 500,
+        "PowerOffSaveMs": 7000
+    }
+}

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-x86/chassis/x86-power-control_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm750/recipes-x86/chassis/x86-power-control_%.bbappend
@@ -1,0 +1,11 @@
+FILESEXTRAPATHS:prepend:evb-npcm750 := "${THISDIR}/${PN}:"
+
+SRC_URI:append:evb-npcm750 = " file://power-config-host0.json"
+
+FILES:${PN}:append:evb-npcm750 = " ${datadir}/x86-power-control/power-config-host0.json"
+
+do_install:append:evb-npcm750() {
+    install -d ${D}${datadir}/x86-power-control
+    install -m 0644 -D ${WORKDIR}/power-config-host0.json \
+        ${D}${datadir}/x86-power-control/power-config-host0.json
+}


### PR DESCRIPTION
1. Since "meta-phosphor: remove OBMC_MACHINE_FEATURES indirect" commit remove the keyword, change to use MACHINE_FEATURES.
2. Add ext2(e2fsprogs) packagegroup.
3. Add x86-power-control for host/chassis state manager.
4. remove redundant BBFILE_PATTERN value.
5. Fix overrides syntax error.

Tested:
Build and bring up pass with evb-npcm750 environment.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
