### PR TITLE
meta-scm-npcm845: WA: fix bmcweb SOL function fail

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/interfaces/bmcweb/workaround-set-bmcweb-default-serial-socket-name.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/interfaces/bmcweb/workaround-set-bmcweb-default-serial-socket-name.patch
@@ -1,0 +1,13 @@
+diff --git a/include/obmc_console.hpp b/include/obmc_console.hpp
+index 3ab13ee4c..b6c93e2b8 100644
+--- a/include/obmc_console.hpp
++++ b/include/obmc_console.hpp
+@@ -130,7 +130,7 @@ inline void requestRoutes(App& app)
+         sessions.insert(&conn);
+         if (hostSocket == nullptr)
+         {
+-            const std::string consoleName("\0obmc-console", 13);
++            const std::string consoleName("\0obmc-console.default", 21);
+             boost::asio::local::stream_protocol::endpoint ep(consoleName);
+ 
+             hostSocket =

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -1,3 +1,6 @@
+FILESEXTRAPATHS:prepend:scm-npcm845 := "${THISDIR}/${PN}:"
+SRC_URI:append:scm-npcm845 = "file://workaround-set-bmcweb-default-serial-socket-name.patch"
+
 # Enable Redfish Journal support
 EXTRA_OEMESON:append:scm-npcm845 = " -Dredfish-bmc-journal=enabled"
 


### PR DESCRIPTION
Due to obmc console is moving configurations to D-Bus to support multi-console. But its functions is not totally ready and the bmcweb side change is reviewing. Update the bmcweb socket name as the obmc-console default value to fix the SOL feature cannot work issue on bmcweb.

Note. This just is workaround patch. After the changes for bmcweb is merged, we should remove this commit.

Ref:
obmc-console: Provide a default value for `console-id` https://gerrit.openbmc.org/c/openbmc/obmc-console/+/63179

Use console information from DBUS
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/62525 

