### PR TITLE
meta-scm-npcm845: change socket-id to console-id

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/console/obmc-console/obmc-console-ttyS1-ssh@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/console/obmc-console/obmc-console-ttyS1-ssh@.service
@@ -5,7 +5,7 @@ Wants=obmc-console@ttyS1.service
 [Service]
 Environment="DROPBEAR_RSAKEY_DIR=/etc/dropbear"
 EnvironmentFile=/etc/default/dropbear
-ExecStart=/usr/sbin/dropbear -i -r ${DROPBEAR_RSAKEY_DIR}/dropbear_rsa_host_key -c "/usr/bin/obmc-console-client -c /etc/obmc-console/server.ttyS1.conf" -p ttyS1 -F $DROPBEAR_EXTRA_ARGS
+ExecStart=/usr/sbin/dropbear -i -r ${DROPBEAR_RSAKEY_DIR}/dropbear_rsa_host_key -c "/usr/bin/obmc-console-client -c /etc/obmc-console/server.ttyS1.conf" -F $DROPBEAR_EXTRA_ARGS
 SyslogIdentifier=dropbear
 ExecReload=/bin/kill -HUP $MAINPID
 StandardInput=socket

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/console/obmc-console/obmc-console-ttyS2-ssh@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/console/obmc-console/obmc-console-ttyS2-ssh@.service
@@ -5,7 +5,7 @@ Wants=obmc-console@ttyS2.service
 [Service]
 Environment="DROPBEAR_RSAKEY_DIR=/etc/dropbear"
 EnvironmentFile=/etc/default/dropbear
-ExecStart=/usr/sbin/dropbear -i -r ${DROPBEAR_RSAKEY_DIR}/dropbear_rsa_host_key -c "/usr/bin/obmc-console-client -c /etc/obmc-console/server.ttyS2.conf" -p ttyS2 -F $DROPBEAR_EXTRA_ARGS
+ExecStart=/usr/sbin/dropbear -i -r ${DROPBEAR_RSAKEY_DIR}/dropbear_rsa_host_key -c "/usr/bin/obmc-console-client -c /etc/obmc-console/server.ttyS2.conf" -F $DROPBEAR_EXTRA_ARGS
 SyslogIdentifier=dropbear
 ExecReload=/bin/kill -HUP $MAINPID
 StandardInput=socket

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/console/obmc-console/obmc-console-ttyS5-ssh@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/console/obmc-console/obmc-console-ttyS5-ssh@.service
@@ -5,7 +5,7 @@ Wants=obmc-console@ttyS5.service
 [Service]
 Environment="DROPBEAR_RSAKEY_DIR=/etc/dropbear"
 EnvironmentFile=/etc/default/dropbear
-ExecStart=/usr/sbin/dropbear -i -r ${DROPBEAR_RSAKEY_DIR}/dropbear_rsa_host_key -c "/usr/bin/obmc-console-client -c /etc/obmc-console/server.ttyS5.conf" -p ttyS5 -F $DROPBEAR_EXTRA_ARGS
+ExecStart=/usr/sbin/dropbear -i -r ${DROPBEAR_RSAKEY_DIR}/dropbear_rsa_host_key -c "/usr/bin/obmc-console-client -c /etc/obmc-console/server.ttyS5.conf" -F $DROPBEAR_EXTRA_ARGS
 SyslogIdentifier=dropbear
 ExecReload=/bin/kill -HUP $MAINPID
 StandardInput=socket

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/console/obmc-console/server.ttyS1.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/console/obmc-console/server.ttyS1.conf
@@ -1,4 +1,4 @@
 local-tty = ttyS1
 local-tty-baud = 115200
-socket-id = ttyS1
+console-id = ttyS1
 logfile = /var/log/obmc-console-host-S1.log

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/console/obmc-console/server.ttyS5.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/console/obmc-console/server.ttyS5.conf
@@ -1,4 +1,4 @@
 local-tty = ttyS5
 local-tty-baud = 115200
-socket-id = ttyS5
+console-id = ttyS5
 logfile = /var/log/obmc-console-cp.log


### PR DESCRIPTION
Update server conf socket-id to console-id due to obmc-console is no longer support socket-id.
And also remove some parameter in console service which not used.
