### PR TITLE
meta-phosphor: npcm8xx.bbclass: sign images for TIP mode only

### DIFF
--- a/meta-phosphor/classes/image_types_phosphor_nuvoton_npcm8xx.bbclass
+++ b/meta-phosphor/classes/image_types_phosphor_nuvoton_npcm8xx.bbclass
@@ -91,9 +91,9 @@ check_keys() {
     fi
 }
 
-# Sign images for secure os be enabled
+# Sign images for secure os be enabled and TIP mode only
 do_sign_binary() {
-    if [ "${SECURED_IMAGE}" != "True" ]; then
+    if [ "${SECURED_IMAGE}" != "True" -o "${TIP_IMAGE}" != "True" ]; then
        return
     fi
     checked=`check_keys`


### PR DESCRIPTION
For NO TIP mode there is no need for signatures at all.

    Tested result:
                          | TIP_IMAGE = True | TIP_IMAGE = False
    ----------------------|------------------|------------------
    SECURED_IMAGE = True  | Need sign        | No need sign
    ----------------------|------------------|------------------
    SECURED_IMAGE = False | No need sign     | No need sign

