### PR TITLE
meta-evb: meta-evb-nuvoton: meta-buv-runbmc: recipes-phosphor: Enable…

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/inventory/phosphor-inventory-manager/associations.json
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/inventory/phosphor-inventory-manager/associations.json
@@ -129,9 +129,13 @@
                 },
                 "paths":
                 [
-                    "/xyz/openbmc_project/sensors/current/MB_P12V_INA219_Output_Current",
-                    "/xyz/openbmc_project/sensors/voltage/MB_P12V_INA219_Output_Voltage",
-                    "/xyz/openbmc_project/sensors/power/MB_P12V_INA219_Output_Power"
+                    "/xyz/openbmc_project/sensors/temperature/PSU0_Temperature",
+                    "/xyz/openbmc_project/sensors/current/PSU0_Input_Current",
+                    "/xyz/openbmc_project/sensors/voltage/PSU0_Input_Voltage",
+                    "/xyz/openbmc_project/sensors/power/PSU0_Input_Power",
+                    "/xyz/openbmc_project/sensors/current/PSU0_Output_Current",
+                    "/xyz/openbmc_project/sensors/voltage/PSU0_Output_Voltage",
+                    "/xyz/openbmc_project/sensors/power/PSU0_Output_Power"
                 ]
             },
             {
@@ -168,9 +172,13 @@
                 },
                 "paths":
                 [
-                    "/xyz/openbmc_project/sensors/current/MB_P3V3_INA219_Output_Current",
-                    "/xyz/openbmc_project/sensors/voltage/MB_P3V3_INA219_Output_Voltage",
-                    "/xyz/openbmc_project/sensors/power/MB_P3V3_INA219_Output_Power"
+                    "/xyz/openbmc_project/sensors/temperature/PSU1_Temperature",
+                    "/xyz/openbmc_project/sensors/current/PSU1_Input_Current",
+                    "/xyz/openbmc_project/sensors/voltage/PSU1_Input_Voltage",
+                    "/xyz/openbmc_project/sensors/power/PSU1_Input_Power",
+                    "/xyz/openbmc_project/sensors/current/PSU1_Output_Current",
+                    "/xyz/openbmc_project/sensors/voltage/PSU1_Output_Voltage",
+                    "/xyz/openbmc_project/sensors/power/PSU1_Output_Power"
                 ]
             },
             {
@@ -221,6 +229,20 @@
                     "/xyz/openbmc_project/sensors/voltage/ADC6",
                     "/xyz/openbmc_project/sensors/voltage/ADC7",
                     "/xyz/openbmc_project/sensors/voltage/ADC8",
+                    "/xyz/openbmc_project/sensors/temperature/PSU1_Temperature",
+                    "/xyz/openbmc_project/sensors/current/PSU1_Input_Current",
+                    "/xyz/openbmc_project/sensors/voltage/PSU1_Input_Voltage",
+                    "/xyz/openbmc_project/sensors/power/PSU1_Input_Power",
+                    "/xyz/openbmc_project/sensors/current/PSU1_Output_Current",
+                    "/xyz/openbmc_project/sensors/voltage/PSU1_Output_Voltage",
+                    "/xyz/openbmc_project/sensors/power/PSU1_Output_Power",
+                    "/xyz/openbmc_project/sensors/temperature/PSU0_Temperature",
+                    "/xyz/openbmc_project/sensors/current/PSU0_Input_Current",
+                    "/xyz/openbmc_project/sensors/voltage/PSU0_Input_Voltage",
+                    "/xyz/openbmc_project/sensors/power/PSU0_Input_Power",
+                    "/xyz/openbmc_project/sensors/current/PSU0_Output_Current",
+                    "/xyz/openbmc_project/sensors/voltage/PSU0_Output_Voltage",
+                    "/xyz/openbmc_project/sensors/power/PSU0_Output_Power",
                     "/xyz/openbmc_project/sensors/voltage/MB_P12V_INA219_Output_Voltage",
                     "/xyz/openbmc_project/sensors/voltage/MB_P3V3_INA219_Output_Voltage",
                     "/xyz/openbmc_project/sensors/power/MB_P12V_INA219_Output_Power",

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/sensors/phosphor-hwmon/obmc/hwmon/ahb/apb/i2c@81000/power-supply@5a.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/sensors/phosphor-hwmon/obmc/hwmon/ahb/apb/i2c@81000/power-supply@5a.conf
@@ -1,0 +1,55 @@
+LABEL_curr1 = "PSU0_Input_Current"
+MINVALUE_curr1 = "0"
+MAXVALUE_curr1 = "3"
+CRITHI_curr1 = "1900"
+CRITLO_curr1 = "0"
+WARNHI_curr1 = "1800"
+WARNLO_curr1= "0"
+
+LABEL_power1 = "PSU0_Input_Power"
+MINVALUE_power1 = "0"
+MAXVALUE_power1 = "24"
+CRITHI_power1 = "23000000"
+CRITLO_power1 = "0"
+WARNHI_power1 = "22000000"
+WARNLO_power1 = "0"
+
+LABEL_in1 = "PSU0_Input_Voltage"
+MINVALUE_in1 = "0"
+MAXVALUE_in1 = "13"
+CRITHI_in1 = "13000"
+CRITLO_in1 = "0"
+WARNHI_in1 = "12500"
+WARNLO_in1 = "11500"
+
+LABEL_curr2 = "PSU0_Output_Current"
+MINVALUE_curr2 = "0"
+MAXVALUE_curr2 = "3"
+CRITHI_curr2 = "1900"
+CRITLO_curr2 = "0"
+WARNHI_curr2 = "1800"
+WARNLO_curr2= "0"
+
+LABEL_power2 = "PSU0_Output_Power"
+MINVALUE_power2 = "0"
+MAXVALUE_power2 = "24"
+CRITHI_power2 = "23000000"
+CRITLO_power2 = "0"
+WARNHI_power2 = "22000000"
+WARNLO_power2 = "0"
+
+LABEL_in2 = "PSU0_Output_Voltage"
+MINVALUE_in2 = "0"
+MAXVALUE_in2 = "13"
+CRITHI_in2 = "13000"
+CRITLO_in2 = "0"
+WARNHI_in2 = "12500"
+WARNLO_in2 = "11500"
+
+LABEL_temp1="PSU0_Temperature"
+WARNLO_temp1=10000
+WARNHI_temp1=40000
+CRITHI_temp1=70000
+CRITLO_temp1=0
+MINVALUE_temp1 = "-128"
+MAXVALUE_temp1 = "127"

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/sensors/phosphor-hwmon/obmc/hwmon/ahb/apb/i2c@81000/power-supply@5b.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/sensors/phosphor-hwmon/obmc/hwmon/ahb/apb/i2c@81000/power-supply@5b.conf
@@ -1,0 +1,55 @@
+LABEL_curr1 = "PSU1_Input_Current"
+MINVALUE_curr1 = "0"
+MAXVALUE_curr1 = "3"
+CRITHI_curr1 = "1900"
+CRITLO_curr1 = "0"
+WARNHI_curr1 = "1800"
+WARNLO_curr1= "0"
+
+LABEL_power1 = "PSU1_Input_Power"
+MINVALUE_power1 = "0"
+MAXVALUE_power1 = "24"
+CRITHI_power1 = "23000000"
+CRITLO_power1 = "0"
+WARNHI_power1 = "22000000"
+WARNLO_power1 = "0"
+
+LABEL_in1 = "PSU1_Input_Voltage"
+MINVALUE_in1 = "0"
+MAXVALUE_in1 = "13"
+CRITHI_in1 = "13000"
+CRITLO_in1 = "0"
+WARNHI_in1 = "12500"
+WARNLO_in1 = "11500"
+
+LABEL_curr2 = "PSU1_Output_Current"
+MINVALUE_curr2 = "0"
+MAXVALUE_curr2 = "3"
+CRITHI_curr2 = "1900"
+CRITLO_curr2 = "0"
+WARNHI_curr2 = "1800"
+WARNLO_curr2= "0"
+
+LABEL_power2 = "PSU1_Output_Power"
+MINVALUE_power2 = "0"
+MAXVALUE_power2 = "24"
+CRITHI_power2 = "23000000"
+CRITLO_power2 = "0"
+WARNHI_power2 = "22000000"
+WARNLO_power2 = "0"
+
+LABEL_in2 = "PSU1_Output_Voltage"
+MINVALUE_in2 = "0"
+MAXVALUE_in2 = "13"
+CRITHI_in2 = "13000"
+CRITLO_in2 = "0"
+WARNHI_in2 = "12500"
+WARNLO_in2 = "11500"
+
+LABEL_temp1="PSU1_Temperature"
+WARNLO_temp1=10000
+WARNHI_temp1=40000
+CRITHI_temp1=70000
+CRITLO_temp1=0
+MINVALUE_temp1 = "-128"
+MAXVALUE_temp1 = "127"

--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/sensors/phosphor-hwmon_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/sensors/phosphor-hwmon_%.bbappend
@@ -2,6 +2,8 @@ FILESEXTRAPATHS:prepend:buv-runbmc := "${THISDIR}/${PN}:"
 
 
 NAMES = " \
+        i2c@81000/power-supply@5a \
+        i2c@81000/power-supply@5b \
         i2c@8d000/tmp75@4a \
         i2c@8c000/tmp75@48 \
         i2c@8b000/ina219@40 \


### PR DESCRIPTION
… PowerShelves support for inventory-manager

Based on commit: d13699f523596cb2d9ee028a134dbbd6f81da1a2 To fill PSU data to redfish API in inventory-manager. Add sensor configs for  each PSU's sensors.
Modify associations.json to associate PSU's sensors and DBus.
