### PR TITLE
meta-scm-npcm845: linux:update DTS reserved memory

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/nuvoton-npcm845-scm.dts
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/nuvoton-npcm845-scm.dts
@@ -71,27 +71,8 @@
 		#size-cells = <2>;
 		ranges;
 
-		gfx_memory: gfx@37000000 {
-			reg = <0x0 0x37000000 0x0 0x1000000>;
-			no-map;
-		};
-
-		optee_memory: optee@36000000 {
-			reg = <0x0 0x36000000 0x0 0x1000000>;
-			no-map;
-		};
-
-		tcg_log: tcg-log@35F00000 {
-			reg = <0x0 0x35F00000 0x0 0x10000>;
-		};
-
-		tip_memory: tip@34f00000 {
-			reg = <0x0 0x34f00000 0x0 0x1000000>;
-			no-map;
-		};
-
-		cp_memory: cp@34d00000 {
-			reg = <0x0 0x34d00000 0x0 0x20000>;
+		tip_reserved: tip@0 {
+			reg = <0x0 0x0 0x0 0x6200000>;
 			no-map;
 		};
 	};
@@ -257,7 +238,6 @@
 				reg = <1>;
 				spi-rx-bus-width = <2>;
 				spi-tx-bus-width = <2>;
-				spi-max-frequency = <50000000>;
 				partitions@88000000 {
 					compatible = "fixed-partitions";
 					#address-cells = <1>;
@@ -278,7 +258,6 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 				reg = <0>;
-				spi-max-frequency = <50000000>;
 				partitions@A0000000 {
 					compatible = "fixed-partitions";
 					#address-cells = <1>;
@@ -294,7 +273,6 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 				reg = <1>;
-				spi-max-frequency = <50000000>;
 				partitions@A8000000 {
 					compatible = "fixed-partitions";
 					#address-cells = <1>;


### PR DESCRIPTION
We have update memory layout after IGPS 3.9.1, so we need update DTS for reserved memory.
