### PR TITLE
Revert "meta-nuvoton: optee-os_3.18: optee-ftpm: add EARLY_TA OEMAKE"

### DIFF
--- a/meta-nuvoton/dynamic-layers/arm-layer/recipes-security/optee/optee-os_3.18.0.bbappend
+++ b/meta-nuvoton/dynamic-layers/arm-layer/recipes-security/optee/optee-os_3.18.0.bbappend
@@ -19,13 +19,6 @@ EXTRA_OEMAKE:append:npcm8xx = " \
     CFG_TEE_RAM_VA_SIZE=3145728 \
     "
 
-EXTRA_OEMAKE:append:npcm8xx = "\
-    ${@bb.utils.contains('MACHINE_FEATURES', \
-    'optee-ftpm', \
-    'CFG_EARLY_TA=y EARLY_TA_PATHS="${STAGING_DIR_TARGET}/${nonarch_base_libdir}/optee_armtz/${FTPM_UUID}.stripped.elf"', \
-    '', \
-    d)} "
-
 do_deploy:npcm8xx() {
     install -d ${DEPLOYDIR}/
     install -m 644 ${D}${nonarch_base_libdir}/firmware/* ${DEPLOYDIR}/


### PR DESCRIPTION
This reverts commit 274e230a000df32fbefeb51e1dd7c4f97b4dc278.

This change already merged on upstream
meta-arm/meta-arm/recipes-security/optee-ftpm/optee-os_%.bbappend. So revert our change in optee bbappend.

