### PR TITLE
meta-nuvoton: optee-os: update to 3.20

### DIFF
--- a/meta-nuvoton/conf/machine/include/npcm8xx.inc
+++ b/meta-nuvoton/conf/machine/include/npcm8xx.inc
@@ -38,10 +38,6 @@ MACHINEOVERRIDES .= ":npcm8xx"
 
 require conf/machine/include/arm/armv8a/tune-cortexa35.inc
 
-PREFERRED_VERSION_optee-os = "3.18.0"
-PREFERRED_VERSION_optee-os-tadevkit = "3.18.0"
-PREFERRED_VERSION_optee-test = "3.18.0"
-
 UBOOT_MKIMAGE:append:npcm8xx = " -E -B 8"
 
 COMPATIBLE_MACHINE:npcm8xx = "npcm8xx"

--- a/meta-nuvoton/dynamic-layers/arm-layer/recipes-security/optee/optee-os-tadevkit_3.18.0.bbappend
+++ b/meta-nuvoton/dynamic-layers/arm-layer/recipes-security/optee/optee-os-tadevkit_3.18.0.bbappend
@@ -1,9 +1,0 @@
-SRC_URI:remove:npcm8xx = "git://github.com/OP-TEE/optee_os.git;branch=master;protocol=https"
-
-SRC_URI:remove:npcm8xx = " \
-    file://0001-allow-setting-sysroot-for-libgcc-lookup.patch \
-   "
-
-SRC_URI:append:npcm8xx = "git://github.com/Nuvoton-Israel/optee_os.git;branch=npcm_3_18;protocol=https"
-
-SRCREV:npcm8xx = "485dc7ac4e4a3f51d86c5b6562e3720a338441c7"

--- a/meta-nuvoton/dynamic-layers/arm-layer/recipes-security/optee/optee-os-tadevkit_3.20.0.bbappend
+++ b/meta-nuvoton/dynamic-layers/arm-layer/recipes-security/optee/optee-os-tadevkit_3.20.0.bbappend
@@ -1,0 +1,12 @@
+SRC_URI:remove:npcm8xx = "git://github.com/OP-TEE/optee_os.git;branch=master;protocol=https"
+
+SRC_URI:remove:npcm8xx = "file://0003-core-link-add-no-warn-rwx-segments.patch"
+SRC_URI:remove:npcm8xx = "file://0004-core-Define-section-attributes-for-clang.patch"
+SRC_URI:remove:npcm8xx = "file://0005-core-arm-S-EL1-SPMC-boot-ABI-update.patch"
+SRC_URI:remove:npcm8xx = "file://0006-core-ffa-add-TOS_FW_CONFIG-handling.patch"
+SRC_URI:remove:npcm8xx = "file://0007-core-spmc-handle-non-secure-interrupts.patch"
+SRC_URI:remove:npcm8xx = "file://0008-core-spmc-configure-SP-s-NS-interrupt-action-based-o.patch"
+
+SRC_URI:append:npcm8xx = "git://github.com/Nuvoton-Israel/optee_os.git;branch=npcm_3_21;protocol=https"
+
+SRCREV:npcm8xx = "606609bd8780a786210c17135cfa7a42a6aed79e"

--- a/meta-nuvoton/dynamic-layers/arm-layer/recipes-security/optee/optee-os_3.20.0.bbappend
+++ b/meta-nuvoton/dynamic-layers/arm-layer/recipes-security/optee/optee-os_3.20.0.bbappend
@@ -2,12 +2,14 @@ SRC_URI:remove:npcm8xx = "git://github.com/OP-TEE/optee_os.git;branch=master;pro
 
 SRC_URI:remove:npcm8xx = "file://0003-core-link-add-no-warn-rwx-segments.patch"
 SRC_URI:remove:npcm8xx = "file://0004-core-Define-section-attributes-for-clang.patch"
-SRC_URI:remove:npcm8xx = "file://0005-core-ldelf-link-add-z-execstack.patch"
-SRC_URI:remove:npcm8xx = "file://0006-arm32-libutils-libutee-ta-add-.note.GNU-stack-sectio.patch"
+SRC_URI:remove:npcm8xx = "file://0005-core-arm-S-EL1-SPMC-boot-ABI-update.patch"
+SRC_URI:remove:npcm8xx = "file://0006-core-ffa-add-TOS_FW_CONFIG-handling.patch"
+SRC_URI:remove:npcm8xx = "file://0007-core-spmc-handle-non-secure-interrupts.patch"
+SRC_URI:remove:npcm8xx = "file://0008-core-spmc-configure-SP-s-NS-interrupt-action-based-o.patch"
 
-SRC_URI:append:npcm8xx = "git://github.com/Nuvoton-Israel/optee_os.git;branch=npcm_3_18;protocol=https"
+SRC_URI:append:npcm8xx = "git://github.com/Nuvoton-Israel/optee_os.git;branch=npcm_3_21;protocol=https"
 
-SRCREV:npcm8xx = "57e44ae6b3d6de756da8652ec132ffd7005439b7"
+SRCREV:npcm8xx = "606609bd8780a786210c17135cfa7a42a6aed79e"
 
 EXTRA_OEMAKE:append:npcm8xx = " \
     CFG_REE_FS=n \


### PR DESCRIPTION
Keep up with the latest support of optee-os in openbmc.

Tested: build pass and boot successfully.