### PR TITLE
meta-buv-runbmc: fix postinstall scriptlets error

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/power/first-boot-set-psu/first-boot-set-psu@.service
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-buv-runbmc/power/first-boot-set-psu/first-boot-set-psu@.service
@@ -10,5 +10,3 @@ SyslogIdentifier=first-boot-set-psu
 Restart=on-failure
 RestartSec=20
 
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
ERROR: obmc-phosphor-image-1.0-r0 do_rootfs: Postinstall scriptlets of ['first-boot-set-psu'] have failed. If the intention is to defer them to first boot, then please place them into pkg_postinst_ontarget:${PN} (). Deferring to first boot via 'exit 1' is no longer supported.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
