### PR TITLE
meta-nuvoton: npcm8xx-igps: update to 03.09.02

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.4.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.4.bb
@@ -1,3 +1,0 @@
-SRCREV = "3c8eb05241ea16199d861f8cfbf2d2eca1bb48b2"
-
-require npcm8xx-bootblock.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.5.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.5.bb
@@ -1,0 +1,3 @@
+SRCREV = "bc1b9c304490e54553f2d449fa2e9950a6f9e4ae"
+
+require npcm8xx-bootblock.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.01.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.01.bb
@@ -1,4 +1,0 @@
-# tag IGPS_03.09.01
-SRCREV = "2053299fad5ab24e6df054c304d13f877bee67b6"
-
-require npcm8xx-igps.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.02.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.02.bb
@@ -1,0 +1,4 @@
+# tag IGPS_03.09.02
+SRCREV = "c087fcc14a67ae912a51d6fd90c3daa27560d8bc"
+
+require npcm8xx-igps.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.6.1.0.5.0.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.6.1.0.5.0.bb
@@ -1,4 +1,4 @@
-SRCREV = "26d7677ddf1068f697e570f45bae7f51041cb2f1"
+SRCREV = "49c4ddb7feed3653dde1c77e235e41e42c3e73e5"
 
 OUTPUT_BIN = "output_binaries_${DEVICE_GEN}_${IGPS_MACHINE}"
 


### PR DESCRIPTION
Changelog:

IGPS 03.09.02 - Jul 24th 2023
==============

- bootblock 0.3.5 https://github.com/Nuvoton-Israel/npcm8xx-bootblock/releases/tag/A35_BootBlock_0.3.5
  * bug fix: support NO_TIP mode + updated memory map. all images are loaded to DRAM. (from version bootblock 0.3.4)
  * Call CLK_ConfigureFIUClock only in PORST (update SPI dividers from header).
  * re-enable HOST_IF field in header. Supported values: 0xFF: do nothing 0x00: LPC. 0x01: eSPI 0x02: GPIOs TRIS. 0x03: release host wait, disable eSPI configuration is done only in PORST.
- add baud rate field to header:
  * Supported values: 9600,14400,19200,38400,57600,115200,230400, 380400,460800,921600. Default is 115200.
- Update README with signing options.
- Support pkcs11-tool on Linux.
- Bingo 0.0.6. https://github.com/Nuvoton-Israel/bingo/releases/tag/Bingo_0.0.6

- update Monitor 1.0.9 (contact Nuvoton for internal users only)
- Optee npcm845x_3.22.0-rc1-7: https://github.com/Nuvoton-Israel/optee_os/releases/tag/3.22.0-rc1-7
  * change load address of OPTEE-OS from 0x36000000 to 0x02100000
  * added HUK reading from TIP Mailbox DME PCR0

- TIP_FW 0.6.1 L0 0.5.0 L1:
  * Update RCR regs whenever PORST bit is set in TIP_SCR1 (ignore all other bits)
  * Export PCI parameters on any reset. re-order the parameter locations.
  * Fix typos un uptime and similar.
  * SWRST4 is TIP_RESET. ##uboot https://github.com/Nuvoton-Israel/u-boot/releases/tag/v2021.04-npcm8xx-20230724
  * u-boot.bin is built with extra config to skip UART initialization in u-boot (CONFIG_SYS_SKIP_UART_INIT=y)

- Update bootblock XML:
  * Add host IF field. eSPI in all flavors except Google XML.
  * Add BAUD rate field. default is 115200.