### PR TITLE
meta-nuvoton: u-boot-nuvoton: srcrev bump 02f2872a...23a146cf

### DIFF
--- a/meta-nuvoton/recipes-bsp/u-boot/u-boot-common-nuvoton.inc
+++ b/meta-nuvoton/recipes-bsp/u-boot/u-boot-common-nuvoton.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 
 UBRANCH = "npcm-v2021.04"
 SRC_URI = "git://github.com/Nuvoton-Israel/u-boot.git;branch=${UBRANCH};protocol=https"
-SRCREV = "02f2872a1c408396dd0703f9b38853aa72bb5976"
+SRCREV = "23a146cf407df0845a4550cd92e9ef4cbf7f7774"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
For support skip UART initialization in u-boot that
need to add extra config CONFIG_SYS_SKIP_UART_INIT=y

Stanley Chu (7):
      pinctrl: npcm8xx: sync with upstream driver
      pinctrl: npcm8xx: add name for gpio function
      board: nuvoton: set console environment variable
      serial: npcm: support skip uart initialization
      configs: arbel/poleg: support more uart baud rate
      watchdog: npcm: fix reset/expire function
      dts: npcm8xx: add watchdog