### PR TITLE
meta-phosphor: npcm8xx.bbclass: modify npcm8xx-tip-fw dependency

### DIFF
--- a/meta-phosphor/classes/image_types_phosphor_nuvoton_npcm8xx.bbclass
+++ b/meta-phosphor/classes/image_types_phosphor_nuvoton_npcm8xx.bbclass
@@ -218,7 +218,7 @@ python do_merge_bootloaders() {
 }
 
 do_pad_binary[depends] += " \
-    npcm8xx-tip-fw:do_deploy \
+    ${@'npcm8xx-tip-fw:do_deploy' if TIP_IMAGE == 'True' else ''} \
     npcm8xx-bootblock:do_deploy \
     u-boot-nuvoton:do_deploy \
     trusted-firmware-a:do_deploy \


### PR DESCRIPTION
For NO TIP mode there is no need for building npcm8xx-tip-fw recipe

Tested:
1. Set TIP_IMAGE = False
2. bitbake -c cleanall npcm8xx-tip-fw
3. bitbake obmc-phosphor-image
4. npcm8xx-tip-fw recipe does not build
5. Set TIP_IMAGE = True
6. bitbake obmc-phosphor-image
7. npcm8xx-tip-fw recipe does build