### PR TITLE
meta-nuvoton: npcm8xx-igps: update to 03.09.03

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.02.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.02.bb
@@ -1,4 +1,0 @@
-# tag IGPS_03.09.02
-SRCREV = "c087fcc14a67ae912a51d6fd90c3daa27560d8bc"
-
-require npcm8xx-igps.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.03.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.03.bb
@@ -1,0 +1,4 @@
+# tag IGPS_03.09.03
+SRCREV = "32997b388992458b0fb55104be79328dc792b140"
+
+require npcm8xx-igps.inc


### PR DESCRIPTION
Changelog:

IGPS 03.09.03 - Aug 10th 2023
==============

- uboot
  * Release tag: v2021.04-npcm8xx-20230809
  * Fix incorrect ram size of 4GB dram with ECC enabled
- TIP_FW 0.6.2 L0 0.5.1 L1
  * Release tag: TIP_FW_L0_0.6.2_L1_0.5.1
  * Fix trap issue in export found on DC_SCM only.
  * Optimize memory usage.
  * RSA and RNG code cleanup.
- Update scripts: fix typos.
- Update scripts: copy all keys always. To replace a key please remove it from both:
  * IGPS_..\py_scripts\ImageGeneration\keys
  * IGPS_..\py_scripts\ImageGeneration\inputs\key_input

Tested:
Build pass and boot up successful both TIP and NO TIP mode.