### PR TITLE
meta-nuvoton: npcm8xx-tip-fw: update to 0.6.2.0.5.1

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.6.2.0.5.1.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.6.2.0.5.1.bb
@@ -1,4 +1,4 @@
-SRCREV = "49c4ddb7feed3653dde1c77e235e41e42c3e73e5"
+SRCREV = "abcf1e2f4dfb0431cd74497925eb3e25dfbdba70"
 
 OUTPUT_BIN = "output_binaries_${DEVICE_GEN}_${IGPS_MACHINE}"
 


### PR DESCRIPTION
Changelog:

TIP FW 0.6.2 L0 0.5.1 L1
==============

- Release tag: TIP_FW_L0_0.6.2_L1_0.5.1
- Fix trap issue in export found on DC_SCM only.
- Optimize memory usage.
- RSA and RNG code cleanup.

Tested:
Build pass and boot up successful with correct TIP FW latest version.