### PR TITLE
meta-nuvoton: mctpd-intel: update srcrev to a6bd68f

### DIFF
--- a/meta-nuvoton/recipes-phosphor/pmci/mctpd-intel_git.bb
+++ b/meta-nuvoton/recipes-phosphor/pmci/mctpd-intel_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
 SRC_URI = "git://git@github.com/Nuvoton-Israel/mctpd.git;protocol=ssh;branch=main"
-SRCREV = "ef74cd637553f83ab08b1ad2483f7e0e3d1844f0"
+SRCREV = "a6bd68fd617797a6d72f147846d04bbed2dbfc9f"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
1. SMBusBinding: fix bus owner sets eid fail and and scans devices issue.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
