### PR TITLE
meta-nuvoton: linux kernel 6.1 bump srcrev 39208658...d2439cf7

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_6.1.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_6.1.bb
@@ -1,7 +1,7 @@
 KSRC = "git://github.com/Nuvoton-Israel/linux;protocol=https;branch=${KBRANCH}"
 KBRANCH = "NPCM-6.1-OpenBMC"
 LINUX_VERSION = "6.1.12"
-SRCREV = "392086587466beb94b49ed1b7355123b7d2634f3"
+SRCREV = "d2439cf7c210f22d3a706538f0335b097c12121e"
 
 require linux-nuvoton.inc
 


### PR DESCRIPTION
Marvin Lin (5):
      misc: vcd: Add HSYNC mode support
      EDAC/npcm: Sync with upstream refinements
      media: nuvoton: Add optional ECE support
      i3c: hub: core: I3C HUB driver implementation
      media: nuvoton: Set INTCR_DEHS according to DT property in probe stage

Mia Lin (5):
      driver: rtc: add intrusion event detection
      driver: rtc: Add record intrusion and vcc drop timestamps when bmc boots up.
      RTC: nuvoton: Modify the setting timing of write ownership
      rtc: nuvoton: Compatible NCT3015Y-R and NCT3018Y-R
      rtc: nuvoton: Compatible with NCT3015Y-R and NCT3018Y-R

Stanley Chu (8):
      i3c: master: svc:  fix hot join issue
      i3c: master: svc: fix spurious slave event
      arm64: dts: nuvoton: update reg size in i3c node
      i3c: master: svc: support hdr-ddr
      i3c: master: svc: fix build warning
      i3c: master: svc: use hdr mode only when transfer size is even
      i3c: export send CCC command API
      i3c: hub: send SETHID/SETAASA ccc

Tomer Maimon (3):
      arm64: dts: nuvoton: add FW images reserved memory
      i2c: muxes: add NPCM I2C mux support
      i2c: muxes: npcm: add channel 6 and 7 support

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
