### PR TITLE
meta-evb-nuvoton: logging: remove specific err_info_cap length

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/logging/phosphor-logging_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/logging/phosphor-logging_%.bbappend
@@ -1,1 +1,0 @@
-EXTRA_OEMESON:append:evb-npcm845 = " -Derror_info_cap=256"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/logging/phosphor-logging_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/logging/phosphor-logging_%.bbappend
@@ -1,1 +1,0 @@
-EXTRA_OEMESON:append:scm-npcm845 = " -Derror_info_cap=256"


### PR DESCRIPTION
Change error_info_cap according flash size already be merged in upstream.
Thus, we don't need anymore to add those bbappend to specific it.