### PR TITLE
meta-evb-nuvoton: network: enable link local autoconfiguration

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/network/phosphor-network_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/network/phosphor-network_%.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG:remove:evb-npcm845 = "default-link-local-autoconf"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/network/phosphor-network_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/network/phosphor-network_%.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG:remove:scm-npcm845 = "default-link-local-autoconf"


### PR DESCRIPTION
The fix of link local autoconfiguration already be merged in upstream.
Thus, we can enable this functionality normally. No need to remove it.