### PR TITLE
meta-nuvoton: linux kernel 6.1 bump srcrev d2439cf7...fd356a64

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_6.1.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_6.1.bb
@@ -1,7 +1,7 @@
 KSRC = "git://github.com/Nuvoton-Israel/linux;protocol=https;branch=${KBRANCH}"
 KBRANCH = "NPCM-6.1-OpenBMC"
 LINUX_VERSION = "6.1.12"
-SRCREV = "d2439cf7c210f22d3a706538f0335b097c12121e"
+SRCREV = "fd356a64e9c997e8f1981a9c0a90d948d96d2d84"
 
 require linux-nuvoton.inc
 


### PR DESCRIPTION
Marvin Lin (3):
      i3c: hub: Configure Open-Drain/Push-Pull mode for slave port
      i3c: npcm-bic: Add NPCM BIC driver
      media: nuvoton: Sync with upstream v13 and v14 refinements

Stanley Chu (5):
      i3c: master: svc: support setting scl timing according to dts
      arm64: dts: npcm845-evb: revert the dts change in commit d62046f2
      misc: npcm8xx-jtag-master: support running tcks in specified state
      mctp i3c: MCTP I3C driver
      i3c: master: svc: set master pid info

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
