### PR TITLE
meta-nuvoton: u-boot-nuvoton: srcrev bump 23a146cf..edea231c

### DIFF
--- a/meta-nuvoton/recipes-bsp/u-boot/u-boot-common-nuvoton.inc
+++ b/meta-nuvoton/recipes-bsp/u-boot/u-boot-common-nuvoton.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 
 UBRANCH = "npcm-v2021.04"
 SRC_URI = "git://github.com/Nuvoton-Israel/u-boot.git;branch=${UBRANCH};protocol=https"
-SRCREV = "23a146cf407df0845a4550cd92e9ef4cbf7f7774"
+SRCREV = "edea231cc1df74576e5a46c70bf163bb2b365d99"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Brian Ma (1):
      spi-nor-ids: Add flash model w25q01jv support

Eason Yang (1):
      cmd: fuse: casting u32 to u8 if CONFIG_NPCM

Marvin Lin (1):
      cmd: Reset GFX PCI before configuration

Stanley Chu (4):
      board: arbel: fix incorrect ram size of 4GB dram with ECC enabled
      configs: poleg: update supported baud rate
      configs: npcm8xx: disable CONFIG_SPI_FLASH_USE_4K_SECTORS
      npcm8xx: support dcache off

Tim Lee (1):
      i2c: npcm: enable support Fast mode

