### PR TITLE
meta-nuvoton: add support Google kernel repo recipe

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_5.15.108.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_5.15.108.bb
@@ -1,0 +1,8 @@
+KSRC ?= "git://gbmc.googlesource.com/linux;protocol=https;branch=${KBRANCH}"
+KBRANCH = "gbmc-5.15"
+LINUX_VERSION = "5.15.108"
+SRCREV = "1720a480503b8bcf69419c11af5fdaf54fa43d03"
+
+require linux-nuvoton.inc
+
+SRC_URI:append:nuvoton = " file://0017-drivers-i2c-workaround-for-i2c-slave-behavior.patch"

--- a/meta-quanta/meta-olympus-nuvoton/recipes-kernel/linux/linux-nuvoton_5.15.108%.bbappend
+++ b/meta-quanta/meta-olympus-nuvoton/recipes-kernel/linux/linux-nuvoton_5.15.108%.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/linux-nuvoton:"
+
+SRC_URI:append:olympus-nuvoton = " file://olympus-nuvoton.cfg"
+
+SRC_URI:remove:olympus-nuvoton = " file://0001-drivers-misc-porting-mcu-flash-driver.patch"
+SRC_URI:remove:olympus-nuvoton = " file://0001-Modify-Olympus-PSU-driver-to-inspur-ipsps.c.patch"


### PR DESCRIPTION
Using PREFERRED_VERSION_linux-nuvoton to set specific kernel for Google repo. Currently, Google using gbmc 5.15.108 branch Thus, we need to set as "5.15.108%" for testing in olympus-nuvoton.conf

Tested: build linux-nuvoton and obmc-phosphor-image both pass.