### PR TITLE
meta-phosphor: fix image-emmc.gz link error

### DIFF
--- a/meta-phosphor/classes/image_types_phosphor_nuvoton.bbclass
+++ b/meta-phosphor/classes/image_types_phosphor_nuvoton.bbclass
@@ -82,7 +82,7 @@ do_generate_ext4_tar:npcm7xx() {
     # if "wic.gz" in d.getVar('IMAGE_FSTYPES')
     wic_gz="${@bb.utils.contains('IMAGE_FSTYPES', 'wic.gz', 'yes', '', d)}"
     if [ -n "$wic_gz" ];then
-        ln -sf ${IMAGE_NAME}.rootfs.wic.gz image-emmc.gz
+        ln -sf ${IMAGE_NAME}.wic.gz image-emmc.gz
     elif [ -h image-emmc.gz ];then
         rm -f image-emmc.gz
     fi

--- a/meta-phosphor/classes/image_types_phosphor_nuvoton_npcm8xx.bbclass
+++ b/meta-phosphor/classes/image_types_phosphor_nuvoton_npcm8xx.bbclass
@@ -236,7 +236,7 @@ do_generate_ext4_tar:append() {
     ln -sf ${DEPLOY_DIR_IMAGE}/${FLASH_KERNEL_IMAGE} image-kernel
     ln -sf ${S}/ext4/${IMAGE_LINK_NAME}.${FLASH_EXT4_BASETYPE}.zst image-rofs
     ln -sf ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.rwfs.${FLASH_EXT4_OVERLAY_BASETYPE} image-rwfs
-    ln -sf ${IMAGE_NAME}.rootfs.wic.gz image-emmc.gz
+    ln -sf ${IMAGE_NAME}.wic.gz image-emmc.gz
 }
 
 addtask do_pad_binary before do_prepare_bootloaders


### PR DESCRIPTION
Update nuvoton bbclass to fix image-emmc.gz link error.
