### PR TITLE
meta-buv-runbmc: add subtree parameter to Power Distribution

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/interfaces/bmcweb/0001-Implement-Power-Equipment-Distribution-Supply-Supply.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-phosphor/interfaces/bmcweb/0001-Implement-Power-Equipment-Distribution-Supply-Supply.patch
@@ -18,10 +18,10 @@ Signed-off-by: Allen Kang <jhkang@nuvoton.com>
  create mode 100644 redfish-core/lib/power_equipment.hpp
  create mode 100644 redfish-core/lib/power_supply_metrics.hpp
 
-diff --git a/redfish-core/include/redfish.hpp b/redfish-core/include/redfish.hpp
-index 3d8dae97a..138d228f0 100644
---- a/redfish-core/include/redfish.hpp
-+++ b/redfish-core/include/redfish.hpp
+Index: git/redfish-core/include/redfish.hpp
+===================================================================
+--- git.orig/redfish-core/include/redfish.hpp
++++ git/redfish-core/include/redfish.hpp
 @@ -39,8 +39,11 @@
  #include "pcie.hpp"
  #include "pcie_slots.hpp"
@@ -47,12 +47,11 @@ index 3d8dae97a..138d228f0 100644
          requestRoutesThermalSubsystem(app);
          requestRoutesFan(app);
          requestRoutesFanCollection(app);
-diff --git a/redfish-core/lib/power_distribution.hpp b/redfish-core/lib/power_distribution.hpp
-new file mode 100644
-index 000000000..c1a7fe8a7
+Index: git/redfish-core/lib/power_distribution.hpp
+===================================================================
 --- /dev/null
-+++ b/redfish-core/lib/power_distribution.hpp
-@@ -0,0 +1,574 @@
++++ git/redfish-core/lib/power_distribution.hpp
+@@ -0,0 +1,575 @@
 +#pragma once
 +
 +#include "app.hpp"
@@ -92,7 +91,8 @@ index 000000000..c1a7fe8a7
 +        "xyz.openbmc_project.Inventory.Item.Board",
 +        "xyz.openbmc_project.Inventory.Item.Chassis"};
 +    collection_util::getCollectionMembers(
-+        asyncResp, boost::urls::url("/redfish/v1/PowerEquipment/PowerShelves"), interfaces);
++        asyncResp, boost::urls::url("/redfish/v1/PowerEquipment/PowerShelves"),
++        interfaces, "/xyz/openbmc_project/inventory");
 +}
 +
 +inline void getPowerDistributionProductionDate(
@@ -627,11 +627,10 @@ index 000000000..c1a7fe8a7
 +}
 +
 +} // namespace redfish
-diff --git a/redfish-core/lib/power_equipment.hpp b/redfish-core/lib/power_equipment.hpp
-new file mode 100644
-index 000000000..baba5474c
+Index: git/redfish-core/lib/power_equipment.hpp
+===================================================================
 --- /dev/null
-+++ b/redfish-core/lib/power_equipment.hpp
++++ git/redfish-core/lib/power_equipment.hpp
 @@ -0,0 +1,54 @@
 +#pragma once
 +
@@ -687,11 +686,11 @@ index 000000000..baba5474c
 +}
 +
 +} // namespace redfish
-diff --git a/redfish-core/lib/power_supply.hpp b/redfish-core/lib/power_supply.hpp
-index 0035b118f..e64e9e64d 100644
---- a/redfish-core/lib/power_supply.hpp
-+++ b/redfish-core/lib/power_supply.hpp
-@@ -22,10 +22,12 @@ static constexpr std::array<std::string_view, 1> powerSupplyInterface = {
+Index: git/redfish-core/lib/power_supply.hpp
+===================================================================
+--- git.orig/redfish-core/lib/power_supply.hpp
++++ git/redfish-core/lib/power_supply.hpp
+@@ -22,10 +22,12 @@ static constexpr std::array<std::string_
      "xyz.openbmc_project.Inventory.Item.PowerSupply"};
  
  inline void updatePowerSupplyList(
@@ -788,7 +787,7 @@ index 0035b118f..e64e9e64d 100644
          });
  }
  
-@@ -129,7 +158,68 @@ inline void handlePowerSupplyCollectionGet(
+@@ -129,7 +158,68 @@ inline void handlePowerSupplyCollectionG
  
      redfish::chassis_utils::getValidChassisPath(
          asyncResp, chassisId,
@@ -858,7 +857,7 @@ index 0035b118f..e64e9e64d 100644
  }
  
  inline void requestRoutesPowerSupplyCollection(App& app)
-@@ -143,6 +233,17 @@ inline void requestRoutesPowerSupplyCollection(App& app)
+@@ -143,6 +233,17 @@ inline void requestRoutesPowerSupplyColl
          .privileges(redfish::privileges::getPowerSupplyCollection)
          .methods(boost::beast::http::verb::get)(
              std::bind_front(handlePowerSupplyCollectionGet, std::ref(app)));
@@ -1281,7 +1280,7 @@ index 0035b118f..e64e9e64d 100644
  }
  
  inline void requestRoutesPowerSupply(App& app)
-@@ -565,6 +850,12 @@ inline void requestRoutesPowerSupply(App& app)
+@@ -565,6 +850,12 @@ inline void requestRoutesPowerSupply(App
          .privileges(redfish::privileges::getPowerSupply)
          .methods(boost::beast::http::verb::get)(
              std::bind_front(handlePowerSupplyGet, std::ref(app)));
@@ -1294,11 +1293,10 @@ index 0035b118f..e64e9e64d 100644
  }
  
  } // namespace redfish
-diff --git a/redfish-core/lib/power_supply_metrics.hpp b/redfish-core/lib/power_supply_metrics.hpp
-new file mode 100644
-index 000000000..dab873000
+Index: git/redfish-core/lib/power_supply_metrics.hpp
+===================================================================
 --- /dev/null
-+++ b/redfish-core/lib/power_supply_metrics.hpp
++++ git/redfish-core/lib/power_supply_metrics.hpp
 @@ -0,0 +1,261 @@
 +#pragma once
 +
@@ -1561,10 +1559,10 @@ index 000000000..dab873000
 +}
 +
 +} // namespace redfish
-diff --git a/redfish-core/lib/service_root.hpp b/redfish-core/lib/service_root.hpp
-index 6ae16c378..b9578e47f 100644
---- a/redfish-core/lib/service_root.hpp
-+++ b/redfish-core/lib/service_root.hpp
+Index: git/redfish-core/lib/service_root.hpp
+===================================================================
+--- git.orig/redfish-core/lib/service_root.hpp
++++ git/redfish-core/lib/service_root.hpp
 @@ -86,6 +86,8 @@ inline void handleServiceRootGetImpl(
      asyncResp->res.jsonValue["TelemetryService"]["@odata.id"] =
          "/redfish/v1/TelemetryService";
@@ -1574,6 +1572,3 @@ index 6ae16c378..b9578e47f 100644
  
      asyncResp->res.jsonValue["Links"]["ManagerProvidingService"]["@odata.id"] =
          "/redfish/v1/Managers/bmc";
--- 
-2.34.1
-


### PR DESCRIPTION
Based on commit 36b5f1ed, all calls to getCollectionMembers have been updated to pass the 'subtree' parameter.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
