### PR TITLE
meta-nuvoton: ipmi: change PCI device-id for NPCM8xx

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-flash_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-flash_%.bbappend
@@ -8,7 +8,3 @@ PACKAGECONFIG:append:evb-npcm845 = " nuvoton-p2a-mbox static-bmc reboot-update"
 IMAGE_PATH = "/run/initramfs/image-bmc"
 EXTRA_OEMESON:append:evb-npcm845 = " -Dstatic-handler-staged-name=${IMAGE_PATH}"
 IPMI_FLASH_BMC_ADDRESS:evb-npcm845 = "${NUVOTON_FLASH_PCIMBOX1}"
-
-# NPCM8xx is using 0x0850 as PCI device-id.
-NUVOTON_PCI_DID = "2128"
-EXTRA_OEMESON:append:evb-npcm845 = " -Dnuvoton-pci-did=${NUVOTON_PCI_DID}"

--- a/meta-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-flash_%.bbappend
+++ b/meta-nuvoton/recipes-phosphor/ipmi/phosphor-ipmi-flash_%.bbappend
@@ -1,0 +1,3 @@
+# NPCM8xx is using 0x0850 as PCI device-id.
+NUVOTON_PCI_DID = "2128"
+EXTRA_OEMESON:append:npcm8xx = " -Dnuvoton-pci-did=${NUVOTON_PCI_DID}"


### PR DESCRIPTION
There are two kinds of PCI device-id for NPCM7xx and NPCM8xx respectively. For NPCM7xx the device-id is using 0x0750 and NPCM8xx is using 0x0850. Thus, change this PCI device-id for supporting NPCM8xx platform.

Use this variable that can help to build host tool burn_my_bmc compatible with different platforms and make in-band firmware update work well.
