### PR TITLE
nuvoton: optee: fix fTPM not work

### DIFF
--- a/meta-nuvoton/dynamic-layers/arm-layer/recipes-security/optee/optee-client_%.bbappend
+++ b/meta-nuvoton/dynamic-layers/arm-layer/recipes-security/optee/optee-client_%.bbappend
@@ -1,6 +1,7 @@
 FILESEXTRAPATHS:append:npcm8xx := "${THISDIR}/${PN}:"
 
-SRC_URI:append:npcm8xx = " file://tee-supplicant.service"
+SYSTEMD_SERVICE:${PN}:npcm8xx = "tee-supplicant@0.service"
+FILES:${PN}:append:npcm8xx = " ${systemd_system_unitdir}/tee-supplicant@.service"
 
 EXTRA_OECMAKE:append:npcm8xx = " \
     -DCFG_TEE_FS_PARENT_PATH='/var/tee' \

--- a/meta-nuvoton/dynamic-layers/arm-layer/recipes-security/optee/optee-os_%.bbappend
+++ b/meta-nuvoton/dynamic-layers/arm-layer/recipes-security/optee/optee-os_%.bbappend
@@ -8,6 +8,14 @@ EXTRA_OEMAKE:append:npcm8xx = " \
     CFG_TEE_SDP_MEM_SIZE=0x00100000 \
     "
 
+# enable RPMB FS for fTPM
+EXTRA_OEMAKE:append:npcm8xx = " \
+    CFG_REE_FS=n \
+    CFG_RPMB_FS=y \
+    "
+# use TEST key only on special device
+# EXTRA_OEMAKE:append:npcm8xx = " CFG_RPMB_TESTKEY=y"
+
 do_deploy:npcm8xx() {
     install -d ${DEPLOYDIR}/
     install -m 644 ${D}${nonarch_base_libdir}/firmware/* ${DEPLOYDIR}/


### PR DESCRIPTION
1. Enable tee-supplicant@0.service for optee-client update
2. Add back RPMB_FS in OPTEE OS for support fTPM

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
