### PR TITLE
meta-nuvoton: npcm8xx-igps: update to 03.09.05

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.03.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.03.bb
@@ -1,4 +1,0 @@
-# tag IGPS_03.09.03
-SRCREV = "32997b388992458b0fb55104be79328dc792b140"
-
-require npcm8xx-igps.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.05.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.05.bb
@@ -1,0 +1,4 @@
+# tag IGPS_03.09.05
+SRCREV = "a6ba5ac55619fa3babe658da4eb811b4c1c1ea25"
+
+require npcm8xx-igps.inc


### PR DESCRIPTION
Changelog:

IGPS 03.09.05 - Oct 23 2023
==============

- OPTEE: 0.0.4 : https://github.com/Nuvoton-Israel/optee_os/releases/tag/npcm_4_0_0 Reading HUK from UUID stored in two scratchpad registers
- Add UpdateInputBinaries for A2. Files are the same as A1.
- u-boot: v2023.10-npcm8xx-20231023: https://github.com/Nuvoton-Israel/u-boot/releases/tag/v2023.10-npcm8xx-20231023 first release of npcm-v2023.10 Fix memory corruption in GFX frame buffer.
- TIP_FW 0.6.4 L0 0.5.3 L1 Fix DRAM window handling bug, in order to allow loading images to any address in DRAM. Fix access for Z1 devices to NCL lib. Move tip log to end of recovery flash. Support flash encryption. Need to create per die key and enable in each image header. Fix TAG alignment issue. Support A35 bootblock reset case. Switch to lightweight X.509 and base64 API to remove mbedTLS from L0 completely Extend key scan option from TIP_ROM to all images Enhance NCL hash porting with SW SHA1 support TIP_SCR0 fix configuration during BMC reset. Update OEM table Customize TIP DICE layer 0 to generate ECC-384 device ID key pair matching ROM Generate counter DICE is missing. Fuse DME and DICE requests.
- Bootblock 0.3.6: Fix SPIX settings. SPIX should be below 33MHz. It was calculated according to SPI0 and not SPIX, and then set to SPIX. Read the DIE information from OTP and place it in SCRACHPAD 72 and 73, for the OPTEE to read it Bug fix: return pass status to TIP in secondary reset if training is skipped.

Tested:
Build pass and boot up successful both TIP and NO TIP mode.