### PR TITLE
meta-nuvoton: npcm8xx-tip-fw: update to 0.6.4.0.5.3

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.6.4.0.5.3.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.6.4.0.5.3.bb
@@ -1,4 +1,4 @@
-SRCREV = "abcf1e2f4dfb0431cd74497925eb3e25dfbdba70"
+SRCREV = "4d8c0b36cdb6bdd227a6e5a7a0f53cd16c141de3"
 
 OUTPUT_BIN = "output_binaries_${DEVICE_GEN}_${IGPS_MACHINE}"
 


### PR DESCRIPTION
Changelog:

TIP FW 0.6.4 L0 0.5.3 L1
==============

- Fix DRAM window handling bug, oinorder to allow loading images to any address in DRAM.
- Fix access for Z1 devices to NCL lib.
- Move tip log to end of recovery flash.
- Support flash encryption. Need to create per die key and enable in each image header.
- Fix TAG aliign issue.
- Support A35 bootblock reset case.
- Switch to lightweight X.509 and base64 API to remove mbedTLS from L0 completely
- Extend key scan option from TIP_ROM to all images
- Enhance NCL hash porting with SW SHA1 support
- TIP_SCR0 fix configuration during BMC reset.
- Update OEM table
- Customize TIP DICE layer 0 to generate ECC-384 device ID key pair matching ROM
- Generate counter DICE is missing. Fuse DME and DICE request.

Tested:
Buid pass and boot up successful with correct TIP FW latest version.