### PR TITLE
meta-nuvoton: npcm8xx-bootblock: update to 0.3.6

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.5.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.5.bb
@@ -1,3 +1,0 @@
-SRCREV = "bc1b9c304490e54553f2d449fa2e9950a6f9e4ae"
-
-require npcm8xx-bootblock.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.6.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.6.bb
@@ -1,0 +1,3 @@
+SRCREV = "344214ea18d884e0ba4c0fc21fa732858386d351"
+
+require npcm8xx-bootblock.inc


### PR DESCRIPTION
Changelog:

version 0.3.6 - Oct 19th 2023
=============
- Fix SPIX settings. SPIX should be below 33MHz. It was calculated according to SPI0 and not SPIX, and then set to SPIX.
- Read the DIE information from OTP and place it in SCRACHPAD 72 and 73, for the OPTEE to read it.
- Bug fix: return pass status to TIP in secondary reset if training is skipped.
