### PR TITLE
m1120-c2195: u-boot: fix serial output data error

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton/m1120.dts
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton/m1120.dts
@@ -66,10 +66,7 @@
 
 &serial0 {
 	status = "okay";
-	assigned-clocks = <&clk NPCM8XX_CLK_UART>,
-			  <&clk NPCM8XX_CLK_UART2>;
-	assigned-clock-parents = <&clk NPCM8XX_CLK_PLL2DIV2>;
-	assigned-clock-rates = <24000000>, <24000000>;
+	clock-frequency = <24000000>;
 };
 
 &serial4 {


### PR DESCRIPTION
Update U-Boot DTS to fix abnormal U-Boot UART output.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
