### PR TITLE
meta-nuvoton: npcm8xx-igps: update to 03.09.07

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.05.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.05.bb
@@ -1,4 +1,0 @@
-# tag IGPS_03.09.05
-SRCREV = "a6ba5ac55619fa3babe658da4eb811b4c1c1ea25"
-
-require npcm8xx-igps.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.07.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.07.bb
@@ -1,0 +1,4 @@
+# tag IGPS_03.09.07
+SRCREV = "09b1162fef7783b6e681905f6a4ddb4c3ceb3694"
+
+require npcm8xx-igps.inc


### PR DESCRIPTION
Changelog:

IGPS 03.09.07 - Nov 6 2023
============
- Remove Google TIP_FW. SA FW replaces it.
- Bootblock version 0.3.8:
   * bootblock output file rename back to arbel_a35_bootblock.bin.
   * unused fuse data moved under ifdef
   * Add 3 fields to header (FIU_DRD_CFG for fiu 0, 1, 3). User can change these values in IGPS. bootblock does not check 
     value is legal.
   * Cleanup makefile.
- XML: add FIU_DRD_CFG0, 1, 3 to bootblock headers.

IGPS 03.09.06 - Nov 2 2023
============
- TIP_FW: 0.6.5 L0 0.5.4 L1
    * MC reset, if needed, performed synchronously from TIP side while BMC is in reset.
- Bootblock version 0.3.7
    * Modify the Makefile to ensure compatibility with Linux compilation and incorporate a build.sh script.
    * In NO_TIP mode: if training fails perform FSW to retry.
    * In TIP mode: need to use TIP_FW 0.6.5 and up so that TIP will reset MC before bootblock to ensure no BMC access 
    * during reset MC.
    * Update timer driver with registers and basic functionality.
    * Update FIU divider on every reset, according to the header.
    * Set RDLEN to 0 on AHB6 and AHB13.
- bl31: https://github.com/Nuvoton-Israel/arm-trusted-firmware/releases/tag/v2.9.0
    * Fix GFX frame buffer memory corruption during secondary boot.
- Scripts: create image_no_tip_SA.bin for A1 mimic no_tip mode (concatenated file image_no_tip + SA FW).

Tested:
Build pass and boot up successful both A1/TIP and A2/TIP/NO TIP mode.