### PR TITLE
meta-nuvoton: npcm8xx-bootblock: update to 0.3.8

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.6.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.6.bb
@@ -1,3 +1,0 @@
-SRCREV = "344214ea18d884e0ba4c0fc21fa732858386d351"
-
-require npcm8xx-bootblock.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.8.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.8.bb
@@ -1,0 +1,3 @@
+SRCREV = "282a8a1f0af17bbb517d31e846c0626c42b9673c"
+
+require npcm8xx-bootblock.inc


### PR DESCRIPTION
Changelog:

version 0.3.8 - Nov 6th 2023
=============
- bootblock output file rename back to arbel_a35_bootblock.bin.
- unused fuse data moved under ifdef
- Add 3 fields to header (FIU_DRD_CFG for fiu 0, 1, 3). User can change these values in IGPS. bootblock does not check value is legal.
- Cleanup makefile.

version 0.3.7 - Nov 2nd 2023
=============
- Modify the Makefile to ensure compatibility with Linux compilation and incorporate a build.sh script.
- In NO_TIP mode: if training fails perform FSW to retry.
- In TIP mode: need to use TIP_FW 0.6.5 and up so that TIP will reset MC before bootblock to ansure no BMC access during reset MC.
- Update timer driver with registers and basic functunality.
- Update FIU divider on every reset, according to header.
- Set RDLEN to 0 on AHB6 and AHB13.