### PR TITLE
meta-nuvoton: npcm8xx-tip-fw: update to 0.6.5.0.5.4

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw.inc
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw.inc
@@ -5,6 +5,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f789971f29c65e31dbb33ed209b4dc91"
 
 TIP_FW = "Kmt_TipFwL0_Skmt_TipFwL1.bin"
+SA_TIP_FW = "SA_Kmt_TipFwL0.bin"
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/Nuvoton-Israel/npcm8xx-tip-fw;branch=main;protocol=https"
@@ -12,6 +13,7 @@ SRC_URI = "git://github.com/Nuvoton-Israel/npcm8xx-tip-fw;branch=main;protocol=h
 inherit deploy
 do_deploy () {
     install -D -m 644 ${OUTPUT_BIN}/${TIP_FW} ${DEPLOYDIR}/${TIP_FW}
+    install -D -m 644 ${OUTPUT_BIN}/${SA_TIP_FW} ${DEPLOYDIR}/${SA_TIP_FW}
 }
 
 addtask deploy before do_build after do_compile

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.6.5.0.5.4.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.6.5.0.5.4.bb
@@ -1,4 +1,4 @@
-SRCREV = "4d8c0b36cdb6bdd227a6e5a7a0f53cd16c141de3"
+SRCREV = "a01f053b639e6665c392e720eeab73edabe0d8d9"
 
 OUTPUT_BIN = "output_binaries_${DEVICE_GEN}_${IGPS_MACHINE}"
 


### PR DESCRIPTION
Changelog:

TIP_FW: 0.6.5 L0 0.5.4 L1
==============
* MC reset, if needed, performed synchronously from TIP side while BMC is in reset.

Tested:
Build pass and boot up successful with correct TIP FW latest version.