### PR TITLE
meta-phosphor: npcm8xx.bbclass: add SA TIP_FW to support mimic no_tip…

### DIFF
--- a/meta-nuvoton/conf/machine/include/npcm8xx.inc
+++ b/meta-nuvoton/conf/machine/include/npcm8xx.inc
@@ -31,6 +31,7 @@ OPTEE_ALIGN ?= "4096"
 UBOOT_ALIGN ?= "4096"
 ALIGN_END ?= "4096"
 PAD_ALIGN ?= "32"
+SA_ALIGN ?= "524288"
 
 SOC_FAMILY = "npcm8xx"
 include conf/machine/include/soc-family.inc
@@ -57,3 +58,5 @@ OPTEEMACHINE ?= "nuvoton"
 SECURED_IMAGE ?= "True"
 
 TIP_IMAGE ?= "True"
+
+SA_TIP_IMAGE ?= "False"

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw.inc
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw.inc
@@ -12,8 +12,12 @@ SRC_URI = "git://github.com/Nuvoton-Israel/npcm8xx-tip-fw;branch=main;protocol=h
 
 inherit deploy
 do_deploy () {
-    install -D -m 644 ${OUTPUT_BIN}/${TIP_FW} ${DEPLOYDIR}/${TIP_FW}
-    install -D -m 644 ${OUTPUT_BIN}/${SA_TIP_FW} ${DEPLOYDIR}/${SA_TIP_FW}
+    if [ "${TIP_IMAGE}" = "True" ] ; then
+        install -D -m 644 ${OUTPUT_BIN}/${TIP_FW} ${DEPLOYDIR}/${TIP_FW}
+    fi
+    if [ "${SA_TIP_IMAGE}" = "True" ] ; then
+        install -D -m 644 ${OUTPUT_BIN}/${SA_TIP_FW} ${DEPLOYDIR}/${SA_TIP_FW}
+    fi
 }
 
 addtask deploy before do_build after do_compile


### PR DESCRIPTION
… mode

SA (Stand Alone) is a special TIP_FW for Google.
It is meant to mimic NO_TIP feature on A1 device.

Tested:
* Set TIP_IMAGE = False and SA_TIP_IMAGE = True and build.
* Flash image-u-boot on A1 TIP device and can boot up successfully.
* Set TIP_IMAGE = False and SA_TIP_IMAGE = False and build.
* Flash image-u-boot on A2 NO_TIP device and can boot up successfully.