### PR TITLE
evb-npcm845: bmcweb: enable sensor

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/interfaces/bmcweb_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/interfaces/bmcweb_%.bbappend
@@ -11,3 +11,9 @@ EXTRA_OEMESON:append:evb-npcm845  = " -Dhttp-body-limit=65"
 
 # Enable dbus rest API /xyz/
 EXTRA_OEMESON:append:evb-npcm845 = " -Drest=enabled"
+
+# Enalbe sensors
+EXTRA_OEMESON:append:evb-npcm845 = " -Dredfish-new-powersubsystem-thermalsubsystem=enabled"
+
+# Enable debug
+# EXTRA_OEMESON:append:evb-npcm845 = " -Dbmcweb-logging=enabled"


### PR DESCRIPTION
Now the sensor type EVB only have: voltage, fan_tach, and temperature need to be enalbed by redfish-new-powersubsystem-thermalsubsystem. Add this build config to fix we cannot find any sensor under redfish path redfish/v1/Chassis/EVB_ARBEL_NUVOTON/Sensors/.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
