### PR TITLE
meta-nuvoton: npcm7xx-bingo: update to 0.0.6

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm7xx-bingo-native_0.0.6.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm7xx-bingo-native_0.0.6.bb
@@ -1,13 +1,13 @@
 SUMMARY = "XML-based binary image generator"
 DESCRIPTION = "XML-based binary image generator"
 HOMEPAGE = "https://github.com/Nuvoton-Israel/bingo"
-PR = "r1"
-PV = "0.1+git${SRCPV}"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRC_URI = "git://github.com/Nuvoton-Israel/bingo;branch=master;protocol=https"
-SRCREV = "7c35658b667d04d6cc78b7ed569f4401168ae133"
+
+# tag Bingo_0.0.6
+SRCREV = "1692a12d38f1c62ef7d870a8d2687e70888e1779"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Bingo_0.0.6 - Jul 24th 2023
==============

- For nibble parity- use only option of singular 0xff or 0x00 mask. no matter what content format it has.
- For secded parity - no more usage of maskAllSizes, use only option of singular 0xff or 0x00 mask.
