### PR TITLE
meta-nuvoton: linux kernel 6.1 bump srcrev cbd6a5d3...ab38ca89

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_6.1.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_6.1.bb
@@ -1,7 +1,7 @@
 KSRC = "git://github.com/Nuvoton-Israel/linux;protocol=https;branch=${KBRANCH}"
 KBRANCH = "NPCM-6.1-OpenBMC"
 LINUX_VERSION = "6.1.12"
-SRCREV = "cbd6a5d387e951a5688cc7d75a66ffc59c281f6e"
+SRCREV = "ab38ca89232b61b23704593d38472def2ff19e43"
 
 require linux-nuvoton.inc
 


### PR DESCRIPTION
Ban Feng (2):
      soc: nuvoton: espi-vwgpio: add nuvoton,vwgpsm-wire-map property
      soc: nuvoton: espi-vwgpio: accept to get the value of VWGPSM

Brian Ma (2):
      npcm8xx: support changing USB PHY power
      Revert "npcm8xx: support changing USB PHY power"

Jim Liu (1):
      dt-bindings: gpio: add NPCM sgpio driver bindings

Joseph Liu (1):
      reset: npcm8xx: add 50 us delay for usb phy clock stable

Stanley Chu (4):
      i3c: svc: Fix wrong bus state after DAA process
      i3c: svc: Flush fifo before DAA process
      i3c: svc: Fix wrong dynamic address assigned during DAA
      misc: npcm8xx-jtag-master: Increase max transfer size

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
