### PR TITLE
meta-nuvoton: npcm8xx-igps: update to 03.09.08

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.07.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.07.bb
@@ -1,4 +1,0 @@
-# tag IGPS_03.09.07
-SRCREV = "09b1162fef7783b6e681905f6a4ddb4c3ceb3694"
-
-require npcm8xx-igps.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.08.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.08.bb
@@ -1,0 +1,4 @@
+# tag IGPS_03.09.08
+SRCREV = "aeeda7d627744e79d1a66862476896dda57e614a"
+
+require npcm8xx-igps.inc


### PR DESCRIPTION
Changelog:

IGPS 03.09.08 - Nov 29th 2023
============
- Write key mask automatically by scripts.
- Bootblock version 0.3.9:
   * block PLL resetting in secondary boot.
   * PLLs are set only after PORST. (PLLs only, other dividers like FIU are set on any reset)
   * Change print of DRAM type.
   * Print all values in MHz (instead of Hz).
- XML:
   * XML mark the key_mask area as reserved.