### PR TITLE
meta-nuvoton: npcm8xx-bootblock: update to 0.3.9

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.8.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.8.bb
@@ -1,3 +1,0 @@
-SRCREV = "282a8a1f0af17bbb517d31e846c0626c42b9673c"
-
-require npcm8xx-bootblock.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.9.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.9.bb
@@ -1,0 +1,3 @@
+SRCREV = "4a12209ba483f511a7bf5090ca5d3872e82299eb"
+
+require npcm8xx-bootblock.inc


### PR DESCRIPTION
Changelog:

version 0.3.9 - Nov 29th 2023
=============
- block PLL resetting in secondary boot.
- PLLs are set only after PORST. (PLLs only, other dividers like FIU are set on any reset).
- Change print of DRAM type.
- Print all values in MHz (instead of Hz).