### PR TITLE
meta-evb: meta-evb-nuvoton: fix build WARNING from ent recipe

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-devtools/ent/ent_1.0.0.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-devtools/ent/ent_1.0.0.bb
@@ -10,6 +10,7 @@ SRC_URI = "file://ent.tar.bz2"
 S = "${WORKDIR}/${PN}"
 EXTRA_OEMAKE = "CROSS_COMPILE=${TARGET_PREFIX} CC="${CC}""
 INSANE_SKIP:${PN} += "ldflags"
+INSANE_SKIP:${PN}-dbg += "buildpaths"
 
 do_install () {
 	install -d ${D}${bindir}/

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-devtools/ent/ent_1.0.0.bb
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-devtools/ent/ent_1.0.0.bb
@@ -10,6 +10,7 @@ SRC_URI = "file://ent.tar.bz2"
 S = "${WORKDIR}/${PN}"
 EXTRA_OEMAKE = "CROSS_COMPILE=${TARGET_PREFIX} CC="${CC}""
 INSANE_SKIP:${PN} += "ldflags"
+INSANE_SKIP:${PN}-dbg += "buildpaths"
 
 do_install () {
 	install -d ${D}${bindir}/


### PR DESCRIPTION
There is build WARNING ent-1.0.0-r0 do_package_qa: QA Issue: File /usr/bin/.debug/ent in package ent-dbg contains reference to TMPDIR. Due to build paths are currenlty embedded, thus we can use INSANE_SKIP to fix.