### PR TITLE
meta-phosphor: libvncserver: cleans up QA warnings

### DIFF
--- a/meta-phosphor/recipes-graphics/libvncserver/libvncserver_%.bbappend
+++ b/meta-phosphor/recipes-graphics/libvncserver/libvncserver_%.bbappend
@@ -1,1 +1,2 @@
 PACKAGECONFIG = "jpeg lzo systemd zlib openssl pthread"
+INSANE_SKIP:${PN}-dev += "buildpaths"


### PR DESCRIPTION
There is build WARNING libvncserver-0.9.14-r0 do_package_qa: QA Issue: File /usr/lib/cmake/LibVNCServer/LibVNCServerTargets.cmake in package libvncserver-dev contains reference to TMPDIR [buildpaths]