### PR TITLE
meta-nuvoton: trusted-firmware-a: fix the version at v2.9.0

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/conf/templates/default/bblayers.conf.sample
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/conf/templates/default/bblayers.conf.sample
@@ -13,6 +13,7 @@ BBLAYERS ?= " \
   ##OEROOT##/meta-phosphor \
   ##OEROOT##/meta-arm/meta-arm \
   ##OEROOT##/meta-arm/meta-arm-toolchain \
+  ##OEROOT##/meta-arm/meta-arm-bsp \
   ##OEROOT##/meta-nuvoton \
   ##OEROOT##/meta-nuvoton/meta-evb-npcm845 \
   ##OEROOT##/meta-evb \

--- a/meta-nuvoton/conf/machine/include/npcm8xx.inc
+++ b/meta-nuvoton/conf/machine/include/npcm8xx.inc
@@ -47,6 +47,7 @@ UBOOT_MKIMAGE:append:npcm8xx = " -E -B 8"
 
 COMPATIBLE_MACHINE:npcm8xx = "npcm8xx"
 TFA_PLATFORM = "npcm845x"
+PREFERRED_VERSION_trusted-firmware-a ?= "2.9.%"
 
 # Nuvoton prefers optee for BL32.
 TFA_SPD = "opteed"


### PR DESCRIPTION
Currently, openbmc upstream already update tfa to version v2.10.0 For compatibling with latest openbmc, we need to fix the version at v2.9.0 We will revert this commit, once we've finished move to v2.10.0

Note:
If you meet build error about No recipes in default aviable, please delete your local build/evb-npcm845/bblayers.conf and execute build setup script again. For example: . setup evb-npcm845

Tested:
Build pass with latest openbmc upstream