### PR TITLE
meta-scm-npcm845: fix build error

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/conf/templates/default/bblayers.conf.sample
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/conf/templates/default/bblayers.conf.sample
@@ -13,6 +13,7 @@ BBLAYERS ?= " \
   ##OEROOT##/meta-phosphor \
   ##OEROOT##/meta-arm/meta-arm \
   ##OEROOT##/meta-arm/meta-arm-toolchain \
+  ##OEROOT##/meta-arm/meta-arm-bsp \
   ##OEROOT##/meta-nuvoton \
   ##OEROOT##/meta-evb \
   ##OEROOT##/meta-evb/meta-evb-nuvoton \


### PR DESCRIPTION
Fix build error cannot find TF-A 2.9 by include more layer.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
