### PR TITLE
meta-nuvoton: npcm8xx-igps: update to 04.00.06

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.08.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_03.09.08.bb
@@ -1,4 +1,0 @@
-# tag IGPS_03.09.08
-SRCREV = "aeeda7d627744e79d1a66862476896dda57e614a"
-
-require npcm8xx-igps.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.00.06.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.00.06.bb
@@ -1,0 +1,4 @@
+# tag IGPS_04.00.06
+SRCREV = "748e89d30787ba359464be11b6aecae4cb00b204"
+
+require npcm8xx-igps.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps.inc
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps.inc
@@ -15,7 +15,7 @@ DEST = "${D}${datadir}/${BPN}"
 
 # Adjust paths for use with bitbake
 do_patch() {
-	sed -i -e 's,inputs/,,g' ${S}/py_scripts/ImageGeneration/references/*.xml \
+	sed -i -e 's,output_binaries/tmp/,,g' ${S}/py_scripts/ImageGeneration/references/*.xml \
 		${S}/py_scripts/ImageGeneration/inputs/*.xml
 }
 


### PR DESCRIPTION
Changelog:

IGPS 04.00.06 - Feb 5th 2024
============
- Bootblock 0.4.1
  * Set PCI and GFX core clock to PLL1.
- Add bootblock XML for MS (with GPIO enabled).
- Remove Z1 from signing flows. Add MS signing.