### PR TITLE
meta-nuvoton: npcm8xx-bootblock: update to 0.4.1

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.9.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.3.9.bb
@@ -1,3 +1,0 @@
-SRCREV = "4a12209ba483f511a7bf5090ca5d3872e82299eb"
-
-require npcm8xx-bootblock.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.1.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.1.bb
@@ -1,0 +1,3 @@
+SRCREV = "a5763b9b6ec8f4f171f9c4a1c50d662e53037497"
+
+require npcm8xx-bootblock.inc


### PR DESCRIPTION
Changelog:

version 0.4.1 - Feb 5th 2024
=============
- Set PCI and GFX core clock to PLL1.

version 0.4.0 - Feb 1st 2024
=============
- Bug fix: GMAC frequency always set to 125MHz.
- PCI always 125MHZ, RC always 100MHz.
- If ECC enabled, force both CPU and MC to be the same frequency.
- Add two optional GPIO set after mtest, declared in the IGPS header.