### PR TITLE
meta-nuvoton: npcm8xx-tip-fw: update to 0.6.7.0.5.6

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.6.7.0.5.6.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.6.7.0.5.6.bb
@@ -1,4 +1,4 @@
-SRCREV = "a01f053b639e6665c392e720eeab73edabe0d8d9"
+SRCREV = "65c421f6bd7efb96c1d95fcaaf13425129fba2c0"
 
 OUTPUT_BIN = "output_binaries_${DEVICE_GEN}_${IGPS_MACHINE}"
 


### PR DESCRIPTION
Changelog:

TIP_FW: 0.6.7 L0 0.5.6 L1
==============
- Disable attestation.
- Fix Macronix issue: if BMC changes to wrong command set FIU_DRD_CFG RD_CMD back to a valid value.
- Move manifests to the end of the flash.
- Format manifests when needed.
- Enhance logging during malloc\stack failure.
- Increase BMC_task stack.
- Limit SKMT to 10 keys (final number TBD).
- Limit KMT to 4 keys (final number is TBD).
- Restore FIU_DRD_CFG (bug fix for Macronix flash).
- Total wipe: enhance logging.
- key_mask: instead of writing 1<<key_index to key_mask: IGPS sets the relevant bit without changing other bits in key_mask.

Tested:
Build pass and boot up successful with correct TIP FW latest version.