### PR TITLE
meta-nuvoton: oom-test: simulating out-of-memory errors

### DIFF
--- a/meta-nuvoton/recipes-nuvoton/oom-test/files/COPYING.MIT
+++ b/meta-nuvoton/recipes-nuvoton/oom-test/files/COPYING.MIT
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in 
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+THE SOFTWARE.

--- a/meta-nuvoton/recipes-nuvoton/oom-test/files/Makefile
+++ b/meta-nuvoton/recipes-nuvoton/oom-test/files/Makefile
@@ -1,0 +1,15 @@
+EXE     = oom-test
+CFILE  = *.c
+DEPPKGS = gio-unix-2.0 glib-2.0
+CC      ?= $(CROSS_COMPILE)g++
+CFLAGS += $(shell pkg-config --cflags $(DEPPKGS))
+CFLAGS += -std=c++1z
+LIBS += $(shell pkg-config --libs $(LIBPKGS))
+LIBS += -fPIC
+
+all: $(EXE)
+$(EXE): $(CFILE)
+	$(CC) -g  $(CFLAGS) $(INCLUDES) -o $@ $^ -lstdc++ $(LIBS)
+
+clean:
+	rm -f $(EXE) *.o *.d

--- a/meta-nuvoton/recipes-nuvoton/oom-test/files/oom_test.c
+++ b/meta-nuvoton/recipes-nuvoton/oom-test/files/oom_test.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main()
+{
+   char *fptr;
+   long i, k;
+
+   i = 50000000000L;
+
+   do {
+      if(( fptr = (char *)malloc(i)) == NULL) {
+         i = i - 1000;
+      }
+   }
+   while (( fptr == NULL) && (i > 0));
+
+   sleep(15);  /* for time to observe */
+   for (k = 0; k < i; k++) {   /* so that the memory really gets allocated and not just reserved */
+      fptr[k] = (char) (k & 255);
+   }
+
+   sleep(60);  /* O.K. now you have 1 minute */
+   free(fptr); /* clean up, if we get here */
+
+   return(0);
+}

--- a/meta-nuvoton/recipes-nuvoton/oom-test/oom-test.bb
+++ b/meta-nuvoton/recipes-nuvoton/oom-test/oom-test.bb
@@ -1,0 +1,18 @@
+SUMMARY = "oom test"
+DESCRIPTION = "oom test tool"
+PR = "r1"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+S = "${WORKDIR}"
+
+SRC_URI = "file://Makefile \
+           file://oom_test.c \
+           file://COPYING.MIT \
+          "
+
+do_install() {
+        install -Dm755 ${S}/oom-test ${D}/${sbindir}/oom-test
+}


### PR DESCRIPTION
Use a C program to allocate as much memory as possible, then gradually actually uses it, resulting in "Killed" from the OOM protection.