### PR TITLE
meta-nuvoton: npcm8xx: remove redundant append config

### DIFF
--- a/meta-nuvoton/conf/machine/include/npcm8xx.inc
+++ b/meta-nuvoton/conf/machine/include/npcm8xx.inc
@@ -43,8 +43,6 @@ MACHINEOVERRIDES .= ":npcm8xx"
 
 require conf/machine/include/arm/armv8a/tune-cortexa35.inc
 
-UBOOT_MKIMAGE:append:npcm8xx = " -E -B 8"
-
 COMPATIBLE_MACHINE:npcm8xx = "npcm8xx"
 TFA_PLATFORM = "npcm845x"
 PREFERRED_VERSION_trusted-firmware-a ?= "2.9.%"


### PR DESCRIPTION
This append config already include at linux-nuvoton.inc. No need to add this append here, thus remove it.

Tested:
Build pass and device boot up successfully.