### PR TITLE
meta-nuvoton: trusted-firmware-a: update to v2.10

### DIFF
--- a/meta-nuvoton/conf/machine/include/npcm8xx.inc
+++ b/meta-nuvoton/conf/machine/include/npcm8xx.inc
@@ -45,7 +45,6 @@ require conf/machine/include/arm/armv8a/tune-cortexa35.inc
 
 COMPATIBLE_MACHINE:npcm8xx = "npcm8xx"
 TFA_PLATFORM = "npcm845x"
-PREFERRED_VERSION_trusted-firmware-a ?= "2.9.%"
 
 # Nuvoton prefers optee for BL32.
 TFA_SPD = "opteed"

--- a/meta-nuvoton/dynamic-layers/arm-layer/recipes-bsp/trusted-firmware-a/trusted-firmware-a_2.10.%.bbappend
+++ b/meta-nuvoton/dynamic-layers/arm-layer/recipes-bsp/trusted-firmware-a/trusted-firmware-a_2.10.%.bbappend
@@ -1,0 +1,3 @@
+SRC_URI:remove = "${SRC_URI_TRUSTED_FIRMWARE_A};name=tfa;branch=${SRCBRANCH}"
+SRC_URI:append = "git://github.com/Nuvoton-Israel/arm-trusted-firmware.git;protocol=https;name=tfa;branch=npcm_2_10"
+SRCREV_tfa = "bd1389a26c3db06353b24aaaf8276b3d6723a801"

--- a/meta-nuvoton/dynamic-layers/arm-layer/recipes-bsp/trusted-firmware-a/trusted-firmware-a_2.9.%.bbappend
+++ b/meta-nuvoton/dynamic-layers/arm-layer/recipes-bsp/trusted-firmware-a/trusted-firmware-a_2.9.%.bbappend
@@ -1,3 +1,0 @@
-SRC_URI:remove = "${SRC_URI_TRUSTED_FIRMWARE_A};name=tfa;branch=${SRCBRANCH}"
-SRC_URI:append = "git://github.com/Nuvoton-Israel/arm-trusted-firmware.git;protocol=https;name=tfa;branch=nuvoton"
-SRCREV_tfa = "ef86e361efaa8d59cb12bcf2dfc88c9994a8a16e"


### PR DESCRIPTION
Remove PREFERRED_VERSION_trusted-firmware-a ?= "2.9.%" in npcm8xx.inc, and create new 2.10.%.bbappend to align current version in arm layer.

Tested:
Device can boot successfully with correct version as below: NOTICE:  BL31: v2.10.0(release)