### PR TITLE
meta-nuvoton: npcm8xx-igps: update to 04.00.07

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.00.06.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.00.06.bb
@@ -1,4 +1,0 @@
-# tag IGPS_04.00.06
-SRCREV = "748e89d30787ba359464be11b6aecae4cb00b204"
-
-require npcm8xx-igps.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.00.07.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.00.07.bb
@@ -1,0 +1,4 @@
+# tag IGPS_04.00.07
+SRCREV = "d1a2b585de580028a74fda4b90729cc5192bc28f"
+
+require npcm8xx-igps.inc


### PR DESCRIPTION
IGPS 04.00.07 - Mar 4th 2024
============
- Bootblock 0.4.3
  * Bug fix: set cntfrq_el0 according to CPU frequancy. Previously it was hard-coded to 250000000.
- Uboot
  * Use ARM timer as system tick
- Hardening: update CSV parsing, update chip xml and update the tables
  * Leave them disable for now. Users may comment out the tables and test.
- Relocate combo 1 offset to key_settings_edit_me.py. Default is 512KB.
- Fix all linux path.
- exit(1) in case of failure in GenerateAll.py