### PR TITLE
meta-nuvoton: npcm8xx-bootblock: update to 0.4.3

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.1.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.1.bb
@@ -1,3 +1,0 @@
-SRCREV = "a5763b9b6ec8f4f171f9c4a1c50d662e53037497"
-
-require npcm8xx-bootblock.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.3.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.3.bb
@@ -1,0 +1,3 @@
+SRCREV = "d300c35173a733a4cfa2f877477d5e72f9c3b538"
+
+require npcm8xx-bootblock.inc


### PR DESCRIPTION
Changelog:

version 0.4.3 - Mar 4th 2024
=============
- Bug fix: set cntfrq_el0 according to CPU frequancy. Previously it was hard-coded to 250000000.

version 0.4.2 - Feb 28th 2024
=============
- MC: modified default priority setting.
- Bug fix: PIXEL clock always connected to PLLG.
- Change CLK_750MHZ_PLLCON0_2_REG_CFG 0x003C2201
- Set DENALI_CTL_91_INLINE_ECC_BANK_OFFSET to 1.