### PR TITLE
scm-npcm845: remove patches to fix build break

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/phosphor-health-monitor_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/health/phosphor-health-monitor_%.bbappend
@@ -3,17 +3,18 @@ FILESEXTRAPATHS:prepend:scm-npcm845  := "${THISDIR}/files:"
 inherit obmc-phosphor-systemd
 RDEPENDS:${PN}:append:scm-npcm845 = "bash"
 SRC_URI:append:scm-npcm845 = " file://bmc_health_config.json"
-SRC_URI:append:scm-npcm845 = " file://0001-change-the-cpu-sensor-name-from-CPU-to-CPU_Utilizati.patch"
-SRC_URI:append:scm-npcm845 = " \
-  file://utilization-health-sel.sh \
-  file://utilization-health-sel@.service \
-  file://0002-Add-support-health-SEL-service.patch \
-"
-FILES:${PN}:append:scm-npcm845 = " ${systemd_system_unitdir}/utilization-health-sel@.service"
+# Due to health monitor code structure change, only keep this for reference
+#SRC_URI:append:scm-npcm845 = " \
+#  file://utilization-health-sel.sh \
+#  file://utilization-health-sel@.service \
+#  file://0001-change-the-cpu-sensor-name-from-CPU-to-CPU_Utilizati.patch \
+#  file://0002-Add-support-health-SEL-service.patch \
+#"
+#FILES:${PN}:append:scm-npcm845 = " ${systemd_system_unitdir}/utilization-health-sel@.service"
 
-do_install:append:scm-npcm845() {
-    install -d ${D}/${sysconfdir}/healthMon/
-    install -m 0644 ${WORKDIR}/bmc_health_config.json ${D}/${sysconfdir}/healthMon/
-    install -D -m 0644 ${WORKDIR}/utilization-health-sel@.service ${D}${systemd_system_unitdir}
-    install -D -m 0755 ${WORKDIR}/utilization-health-sel.sh ${D}/${bindir}/utilization-health-sel.sh
-}
+#do_install:append:scm-npcm845() {
+#    install -d ${D}/${sysconfdir}/healthMon/
+#    install -m 0644 ${WORKDIR}/bmc_health_config.json ${D}/${sysconfdir}/healthMon/
+#    install -D -m 0644 ${WORKDIR}/utilization-health-sel@.service ${D}${systemd_system_unitdir}
+#    install -D -m 0755 ${WORKDIR}/utilization-health-sel.sh ${D}/${bindir}/utilization-health-sel.sh
+#}


### PR DESCRIPTION
Due to phosphor-health-monitor code structure changes, keep the patches for reference, not apply it.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
