### PR TITLE
nuvoton machines: keep using U-Boot 2021

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/machine/buv-runbmc.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/conf/machine/buv-runbmc.conf
@@ -14,6 +14,8 @@ FLASH_RWFS_OFFSET:flash-65536 = "62464"
 
 UBOOT_MACHINE = "PolegRunBMC_defconfig"
 UBOOT_DEVICETREE = "nuvoton-npcm750-buv"
+PREFERRED_VERSION_u-boot-nuvoton ??= "2021.04+npcm-v2021.04+"
+PREFERRED_VERSION_u-boot-fw-utils-nuvoton ??= "2021.04+npcm-v2021.04+"
 IGPS_MACHINE = "RunBMC"
 
 IMAGE_FSTYPES += " cpio.${INITRAMFS_CTYPE}.u-boot"

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/conf/machine/scm-npcm845.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/conf/machine/scm-npcm845.conf
@@ -1,8 +1,13 @@
 KMACHINE = "nuvoton"
 KERNEL_DEVICETREE = "nuvoton/${KMACHINE}-npcm845-scm.dtb"
 
-UBOOT_MACHINE = "ArbelEVB_defconfig"
+# U-Boot 2021.04 (2021.04+npcm-v2021.04+)
+UBOOT_MACHINE ?= "ArbelEVB_defconfig"
+# U-Boot 2023.10 (v2023.10+git)
+#UBOOT_MACHINE ?= "arbel_evb_defconfig"
 UBOOT_DEVICETREE = "nuvoton-npcm845-scm"
+PREFERRED_VERSION_u-boot-nuvoton ??= "2021.04+npcm-v2021.04+"
+PREFERRED_VERSION_u-boot-fw-utils-nuvoton ??= "2021.04+npcm-v2021.04+"
 
 IGPS_MACHINE = "EB"
 DEVICE_GEN = "A1"

--- a/meta-quanta/meta-olympus-nuvoton/conf/machine/olympus-nuvoton.conf
+++ b/meta-quanta/meta-olympus-nuvoton/conf/machine/olympus-nuvoton.conf
@@ -13,6 +13,8 @@ FLASH_RWFS_OFFSET:flash-65536 = "62464"
 
 UBOOT_MACHINE = "PolegRunBMC_defconfig"
 UBOOT_DEVICETREE = "nuvoton-npcm750-olympus"
+PREFERRED_VERSION_u-boot-nuvoton ??= "2021.04+npcm-v2021.04+"
+PREFERRED_VERSION_u-boot-fw-utils-nuvoton ??= "2021.04+npcm-v2021.04+"
 IGPS_MACHINE = "RunBMC"
 
 IMAGE_FSTYPES += " cpio.${INITRAMFS_CTYPE}.u-boot"


### PR DESCRIPTION
Poleg DUT: we have no request for update U-Boot, keep using stable one. Arbel DUT: we are debugging issues on U-Boot 2023. We should move to
           2023 after debug process.
