### PR TITLE
meta-nuvoton: npcm8xx-igps: update to 04.00.08

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.00.07.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.00.07.bb
@@ -1,4 +1,0 @@
-# tag IGPS_04.00.07
-SRCREV = "d1a2b585de580028a74fda4b90729cc5192bc28f"
-
-require npcm8xx-igps.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.00.08.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.00.08.bb
@@ -1,0 +1,4 @@
+# tag IGPS_04.00.08
+SRCREV = "7e009f77dcc5b4cde80f1ba47b1cf5a010d7e197"
+
+require npcm8xx-igps.inc


### PR DESCRIPTION
IGPS 04.00.08 - Mar 19th 2024
============
- bl31
  * remove change clock frequency
- TIP_FW: 0.6.8 L0 0.5.7 L1
  * Optimize flash read. Include QUAD support code but currently disabled by default.
  * Move TIP FW build version into a separate header file to avoid conflict with internal build versions.
  * Add missing header file include in the uart_if.h to avoid order dependency.
  * Support flash encryption (after code review).
  * Update TIP EID back to 0x0B.
  * Change version, delay for flush task and PRE_PRODUCTION.
  * Put all manifests at the end of flash. * Check stack overflow. * Support hardening. * Support BMC direct access. * Support bootblock at offset 512KB or 2MB. * Bug fix: touch WD during recovery delay. * Bug fix: ENC header field must be 0x03 to start encryption. * Support CFM. * WD0RCRB.BMCBUS should be zero. * Bug fix in handling SW and WD reset (avoid TIP reset).
- Scripts: fix ReplaceComponent.bat.
- Update comments in bootblock XMLs.
- bootblock 0.4.6
  * MC: Increase ECE priority to match VCD priority. Set ECE priority to 2.
  * Fix errata: Errata fix: 1.7 eSPI FATAL_ERROR response