### PR TITLE
meta-nuvoton: npcm8xx-bootblock: update to 0.4.6

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.3.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.3.bb
@@ -1,3 +1,0 @@
-SRCREV = "d300c35173a733a4cfa2f877477d5e72f9c3b538"
-
-require npcm8xx-bootblock.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.6.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.6.bb
@@ -1,0 +1,3 @@
+SRCREV = "b45a45bce6e557af49b43492904579edb5f084a3"
+
+require npcm8xx-bootblock.inc


### PR DESCRIPTION
Changelog:

version 0.4.6 - Mar 21th 2024
=============
- MC: Increase ECE priority to match VCD priority. Set ECE priority to 2.
- Fix errata: Errata fix: 1.7 eSPI FATAL_ERROR response