### PR TITLE
meta-nuvoton: npcm8xx-tip-fw: update to 0.6.8.0.5.7

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.6.8.0.5.7.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.6.8.0.5.7.bb
@@ -1,4 +1,4 @@
-SRCREV = "65c421f6bd7efb96c1d95fcaaf13425129fba2c0"
+SRCREV = "cf3ae603b6b2fd2e44b446105976e69f4a112c52"
 
 OUTPUT_BIN = "output_binaries_${DEVICE_GEN}_${IGPS_MACHINE}"
 


### PR DESCRIPTION
Changelog:

TIP_FW: 0.6.8 L0 0.5.7 L1
==============
- Optimize flash read. Include QUAD support code but currently disabled by default.
- Move TIP FW build version into a separate header file to avoid conflict with internal build versions.
- Add missing header file include in the uart_if.h to avoid order dependency.
- Support flash encryption (after code review).
- Update TIP EID back to 0x0B.
- Change version, delay for flush task and PRE_PRODUCTION.
- Put all manifests at the end of flash.
- Check stack overflow.
- Support hardening.
- Support BMC direct access.
- Support bootblock at offset 512KB or 2MB.
- Bug fix: touch WD during recovery delay.
- Bug fix: ENC header field must be 0x03 to start encryption.
- Support CFM.
- WD0RCRB.BMCBUS should be zero.
- Bug fix in handling SW and WD reset (avoid TIP reset).

Tested:
Build pass and boot up successful with correct TIP FW latest version.