### PR TITLE
meta-nuvoton: u-boot: move version to 2023.10

### DIFF
--- a/meta-nuvoton/conf/machine/evb-npcm845.conf
+++ b/meta-nuvoton/conf/machine/evb-npcm845.conf
@@ -2,12 +2,12 @@ KMACHINE = "nuvoton"
 KERNEL_DEVICETREE = "nuvoton/${KMACHINE}-npcm845-evb.dtb"
 
 # U-Boot 2021.04 (2021.04+npcm-v2021.04+)
-UBOOT_MACHINE ?= "ArbelEVB_defconfig"
+#UBOOT_MACHINE ?= "ArbelEVB_defconfig"
+#PREFERRED_VERSION_u-boot-nuvoton ??= "2021.04+npcm-v2021.04+"
+#PREFERRED_VERSION_u-boot-fw-utils-nuvoton ??= "2021.04+npcm-v2021.04+"
 # U-Boot 2023.10 (v2023.10+git)
-#UBOOT_MACHINE ?= "arbel_evb_defconfig"
+UBOOT_MACHINE ?= "arbel_evb_defconfig"
 UBOOT_DEVICETREE = "nuvoton-npcm845-evb"
-PREFERRED_VERSION_u-boot-nuvoton ??= "2021.04+npcm-v2021.04+"
-PREFERRED_VERSION_u-boot-fw-utils-nuvoton ??= "2021.04+npcm-v2021.04+"
 
 IGPS_MACHINE = "EB"
 DEVICE_GEN = "A1"


### PR DESCRIPTION
Remove preferred version for move U-Boot version from 2021.04 to 2023.10.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
