### PR TITLE
meta-nuvoton: trusted-firmware-a: point to tfa upstream

### DIFF
--- a/meta-nuvoton/dynamic-layers/arm-layer/recipes-bsp/trusted-firmware-a/trusted-firmware-a_2.10.%.bbappend
+++ b/meta-nuvoton/dynamic-layers/arm-layer/recipes-bsp/trusted-firmware-a/trusted-firmware-a_2.10.%.bbappend
@@ -1,3 +1,2 @@
-SRC_URI:remove = "${SRC_URI_TRUSTED_FIRMWARE_A};name=tfa;branch=${SRCBRANCH}"
-SRC_URI:append = "git://github.com/Nuvoton-Israel/arm-trusted-firmware.git;protocol=https;name=tfa;branch=npcm_2_10"
-SRCREV_tfa = "113ec57b1cd7a2889151d06f0040a573a013fcb0"
+SRCREV_tfa = "753da8ce4500b1084be41a1d3bb034d47cdf2add"
+LIC_FILES_CHKSUM = "file://docs/license.rst;md5=b5fbfdeb6855162dded31fadcd5d4dc5"


### PR DESCRIPTION
The latest commit from our GitHub be merged into
TFA official GitHub v2.10.0. Point to upstream instead of local GitHub.

Tested:
Device can boot successfully with correct version as below:
NOTICE:  BL31: v2.10.0(release):v2.10.0-669-g753da8ce45
NOTICE:  BL31: Built : 14:07:01, Apr  1 2024