### PR TITLE
meta-scm-npcm845: update patches to fix build break

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/0102-Add-driver-for-HDC302x.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-kernel/linux/linux-nuvoton/0102-Add-driver-for-HDC302x.patch
@@ -1,4 +1,4 @@
-From cd310d183a1e9d332e1e2d84886587571fcdcd01 Mon Sep 17 00:00:00 2001
+From f09b070cf3f6621ad6031f91fe76b09b441b2b54 Mon Sep 17 00:00:00 2001
 From: Angela TH Lin <angela_th_lin@wiwynn.com>
 Date: Tue, 7 Mar 2023 11:22:55 +0800
 Subject: [PATCH] Add driver for HDC302x
@@ -11,12 +11,12 @@ Subject: [PATCH] Add driver for HDC302x
  create mode 100644 drivers/hwmon/hdc302x.c
 
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index e5866419261c..50c73202bcbd 100644
+index b71a51c2b502..0c5f86b31ece 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
-@@ -683,6 +683,17 @@ config SENSORS_GPIO_FAN
- 	  This driver can also be built as a module. If so, the module
- 	  will be called gpio-fan.
+@@ -723,6 +723,17 @@ config SENSORS_GXP_FAN_CTRL
+ 	  The GXP controls fan function via the CPLD through the use of PWM
+ 	  registers. This driver reports status and pwm setting of the fans.
  
 +config SENSORS_HDC302X
 +	tristate "Texas Instruments HDC3020 and compatibles"
@@ -33,14 +33,14 @@ index e5866419261c..50c73202bcbd 100644
  	tristate "Honeywell Humidicon HIH-6130 humidity/temperature sensor"
  	depends on I2C
 diff --git a/drivers/hwmon/Makefile b/drivers/hwmon/Makefile
-index a4eee1103b9c..e9647a737275 100644
+index 2d62ba3ab674..0b577e76bf8a 100644
 --- a/drivers/hwmon/Makefile
 +++ b/drivers/hwmon/Makefile
-@@ -80,6 +80,7 @@ obj-$(CONFIG_SENSORS_GL518SM)	+= gl518sm.o
- obj-$(CONFIG_SENSORS_GL520SM)	+= gl520sm.o
+@@ -84,6 +84,7 @@ obj-$(CONFIG_SENSORS_GL520SM)	+= gl520sm.o
  obj-$(CONFIG_SENSORS_GSC)	+= gsc-hwmon.o
  obj-$(CONFIG_SENSORS_GPIO_FAN)	+= gpio-fan.o
-+obj-$(CONFIG_SENSORS_HDC302X)	+= hdc302x.o
+ obj-$(CONFIG_SENSORS_GXP_FAN_CTRL) += gxp-fan-ctrl.o
++obj-$(CONFIG_SENSORS_HDC302X)  += hdc302x.o
  obj-$(CONFIG_SENSORS_HIH6130)	+= hih6130.o
  obj-$(CONFIG_SENSORS_ULTRA45)	+= ultra45_env.o
  obj-$(CONFIG_SENSORS_I5500)	+= i5500_temp.o
@@ -291,3 +291,6 @@ index 000000000000..ed5fe03a96d9
 +MODULE_DESCRIPTION("Texas Instruments HDC302x relative humidity and temperature sensor driver");
 +MODULE_LICENSE("GPL");
 \ No newline at end of file
+-- 
+2.34.1
+

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0001-add-NIC-temp-sensor.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-phosphor/sensors/dbus-sensors/0001-add-NIC-temp-sensor.patch
@@ -1,7 +1,7 @@
-From ce68bceede6675e647e1a6ad8f07b1cf7429476c Mon Sep 17 00:00:00 2001
+From 6cd849f04abe74094baef28ce47c3898e1ea81ea Mon Sep 17 00:00:00 2001
 From: Stanley Chu <yschu@nuvoton.com>
 Date: Mon, 15 Aug 2022 14:42:20 +0800
-Subject: [PATCH] add NIC temp sensor
+Subject: [PATCH 1/5] add NIC temp sensor
 
 Signed-off-by: Stanley Chu <yschu@nuvoton.com>
 ---
@@ -10,7 +10,7 @@ Signed-off-by: Stanley Chu <yschu@nuvoton.com>
  2 files changed, 83 insertions(+), 7 deletions(-)
 
 diff --git a/src/MCUTempSensor.cpp b/src/MCUTempSensor.cpp
-index e82c80fb..201be188 100644
+index fef23e92..1e02abe6 100644
 --- a/src/MCUTempSensor.cpp
 +++ b/src/MCUTempSensor.cpp
 @@ -55,12 +55,12 @@ MCUTempSensor::MCUTempSensor(std::shared_ptr<sdbusplus::asio::connection>& conn,
@@ -29,7 +29,7 @@ index e82c80fb..201be188 100644
  {
      sensorInterface = objectServer.add_interface(
          "/xyz/openbmc_project/sensors/temperature/" + name,
-@@ -95,6 +95,55 @@ void MCUTempSensor::init(void)
+@@ -95,6 +95,55 @@ void MCUTempSensor::init()
      read();
  }
  
@@ -82,10 +82,10 @@ index e82c80fb..201be188 100644
 +    return 0;
 +}
 +
- void MCUTempSensor::checkThresholds(void)
+ void MCUTempSensor::checkThresholds()
  {
      thresholds::checkThresholds(this);
-@@ -167,10 +216,20 @@ void MCUTempSensor::read(void)
+@@ -167,10 +216,20 @@ void MCUTempSensor::read()
              return;
          }
          int32_t temp = 0;
@@ -138,7 +138,7 @@ index e82c80fb..201be188 100644
                  sensor->init();
              }
 diff --git a/src/MCUTempSensor.hpp b/src/MCUTempSensor.hpp
-index 40075464..0c28c21b 100644
+index 2948af33..ae0189d3 100644
 --- a/src/MCUTempSensor.hpp
 +++ b/src/MCUTempSensor.hpp
 @@ -16,7 +16,8 @@ struct MCUTempSensor : public Sensor
@@ -150,7 +150,7 @@ index 40075464..0c28c21b 100644
 +                  uint8_t tempRegWidth, uint16_t scale);
      ~MCUTempSensor() override;
  
-     void checkThresholds(void) override;
+     void checkThresholds() override;
 @@ -26,9 +27,12 @@ struct MCUTempSensor : public Sensor
      uint8_t busId;
      uint8_t mcuAddress;


### PR DESCRIPTION
Update kernel patch and dbus sensor patch due to version upgrade.
