### PR TITLE
meta-nuvoton: evb-npcm845: remove excess override syntaxes

### DIFF
--- a/meta-nuvoton/meta-evb-npcm845/recipes-kernel/linux/linux-nuvoton_%.bbappend
+++ b/meta-nuvoton/meta-evb-npcm845/recipes-kernel/linux/linux-nuvoton_%.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-nuvoton:"
 
-SRC_URI:append:evb-npcm845 = " file://evb-npcm845.cfg"
+SRC_URI:append = " file://evb-npcm845.cfg"

--- a/meta-nuvoton/meta-evb-npcm845/recipes-kernel/linux/linux-nuvoton_5.10%.bbappend
+++ b/meta-nuvoton/meta-evb-npcm845/recipes-kernel/linux/linux-nuvoton_5.10%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-nuvoton-510:${THISDIR}/linux-nuvoton:"
 
-SRC_URI:append:evb-npcm845 = " file://evb-npcm845.cfg"
-SRC_URI:append:evb-npcm845 = " file://enable-v4l2.cfg"
+SRC_URI:append = " file://evb-npcm845.cfg"
+SRC_URI:append = " file://enable-v4l2.cfg"
 
-SRC_URI:append:evb-npcm845 = " file://0001-dts-nuvoton-evb-npcm845-support-openbmc-partition.patch"
+SRC_URI:append = " file://0001-dts-nuvoton-evb-npcm845-support-openbmc-partition.patch"

--- a/meta-nuvoton/meta-evb-npcm845/recipes-kernel/linux/linux-nuvoton_5.15%.bbappend
+++ b/meta-nuvoton/meta-evb-npcm845/recipes-kernel/linux/linux-nuvoton_5.15%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-nuvoton-515:${THISDIR}/linux-nuvoton:"
 
-SRC_URI:append:evb-npcm845 = " file://evb-npcm845.cfg"
-SRC_URI:append:evb-npcm845 = " file://enable-v4l2.cfg"
-SRC_URI:append:evb-npcm845 = " file://luks.cfg"
+SRC_URI:append = " file://evb-npcm845.cfg"
+SRC_URI:append = " file://enable-v4l2.cfg"
+SRC_URI:append = " file://luks.cfg"
 
-SRC_URI:append:evb-npcm845 = " file://0001-dts-nuvoton-evb-npcm845-support-openbmc-partition.patch"
+SRC_URI:append = " file://0001-dts-nuvoton-evb-npcm845-support-openbmc-partition.patch"

--- a/meta-nuvoton/meta-evb-npcm845/recipes-kernel/linux/linux-nuvoton_6.1%.bbappend
+++ b/meta-nuvoton/meta-evb-npcm845/recipes-kernel/linux/linux-nuvoton_6.1%.bbappend
@@ -1,34 +1,34 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-nuvoton:"
 
-SRC_URI:append:evb-npcm845 = " file://evb-npcm845.cfg"
-SRC_URI:append:evb-npcm845 = " file://enable-v4l2.cfg"
-#SRC_URI:append:evb-npcm845 = " file://enable-legacy-kvm.cfg"
-SRC_URI:append:evb-npcm845 = " file://luks.cfg"
+SRC_URI:append = " file://evb-npcm845.cfg"
+SRC_URI:append = " file://enable-v4l2.cfg"
+#SRC_URI:append = " file://enable-legacy-kvm.cfg"
+SRC_URI:append = " file://luks.cfg"
 
-SRC_URI:append:evb-npcm845 = " file://0001-dts-nuvoton-evb-npcm845-support-openbmc-partition.patch"
-# SRC_URI:append:evb-npcm845 = " file://0016-support-CPLD-UART-16450.patch"
-# SRC_URI:append:evb-npcm845 = " file://0002-dts-nuvoton-evb-npcm845-boot-from-fiu0-cs1.patch"
+SRC_URI:append = " file://0001-dts-nuvoton-evb-npcm845-support-openbmc-partition.patch"
+# SRC_URI:append = " file://0016-support-CPLD-UART-16450.patch"
+# SRC_URI:append = " file://0002-dts-nuvoton-evb-npcm845-boot-from-fiu0-cs1.patch"
 
 # For gfx edid
-SRC_URI:append:evb-npcm845 = " file://0001-dts-npcm845-evb-enable-slave-eeprom-on-i2c11.patch"
+SRC_URI:append = " file://0001-dts-npcm845-evb-enable-slave-eeprom-on-i2c11.patch"
 
 # for i3c slave test
-# SRC_URI:append:evb-npcm845 = " file://0001-dts-i3c-slave.patch"
-# SRC_URI:append:evb-npcm845 = " file://i3c_mctp.cfg"
+# SRC_URI:append = " file://0001-dts-i3c-slave.patch"
+# SRC_URI:append = " file://i3c_mctp.cfg"
 
 # for af_mctp test
-SRC_URI:append:evb-npcm845 = " file://0001-dts-mctp-i2c-controller.patch"
-SRC_URI:append:evb-npcm845 = " file://0002-dts-mctp-i3c-controller.patch"
-SRC_URI:append:evb-npcm845 = " file://0004-dts-evb-npcm845-enable-udc8.patch"
-SRC_URI:append:evb-npcm845 = " file://mctp.cfg"
+SRC_URI:append = " file://0001-dts-mctp-i2c-controller.patch"
+SRC_URI:append = " file://0002-dts-mctp-i3c-controller.patch"
+SRC_URI:append = " file://0004-dts-evb-npcm845-enable-udc8.patch"
+SRC_URI:append = " file://mctp.cfg"
 
 # Support af_mctp over pcie vdm
-# SRC_URI:append:evb-npcm845 = " file://mctp_vdm.cfg"
-# SRC_URI:append:evb-npcm845 = " file://0001-kernel-dts-support-for-MCTP-verification.patch"
+# SRC_URI:append = " file://mctp_vdm.cfg"
+# SRC_URI:append = " file://0001-kernel-dts-support-for-MCTP-verification.patch"
 
 # for i3c hub
-SRC_URI:append:evb-npcm845 = " file://i3c_hub.cfg"
-SRC_URI:append:evb-npcm845 = " file://0001-dts-add-i3c-hub-node-to-support-two-bic-slave-device.patch"
+SRC_URI:append = " file://i3c_hub.cfg"
+SRC_URI:append = " file://0001-dts-add-i3c-hub-node-to-support-two-bic-slave-device.patch"
 
 # for npcm bic
-# SRC_URI:append:evb-npcm845 = " file://0001-i3c-master-svc-add-delay-for-NPCM-BIC.patch"
+# SRC_URI:append = " file://0001-i3c-master-svc-add-delay-for-NPCM-BIC.patch"

--- a/meta-nuvoton/meta-evb-npcm845/recipes-phosphor/configuration/evb-npcm845-yaml-config.bb
+++ b/meta-nuvoton/meta-evb-npcm845/recipes-phosphor/configuration/evb-npcm845-yaml-config.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/Apache-2.0;md5
 
 inherit allarch
 
-SRC_URI:evb-npcm845 = " \
+SRC_URI = " \
     file://evb-npcm845-ipmi-fru.yaml \
     file://evb-npcm845-ipmi-fru-properties.yaml \
     file://evb-npcm845-ipmi-sensors.yaml \
@@ -14,7 +14,7 @@ SRC_URI:evb-npcm845 = " \
 
 S = "${WORKDIR}"
 
-do_install:evb-npcm845() {
+do_install() {
     install -m 0644 -D evb-npcm845-ipmi-fru-properties.yaml \
         ${D}${datadir}/${BPN}/ipmi-extra-properties.yaml
     install -m 0644 -D evb-npcm845-ipmi-fru.yaml \

--- a/meta-nuvoton/meta-evb-npcm845/recipes-phosphor/sensors/dbus-sensors_%.bbappend
+++ b/meta-nuvoton/meta-evb-npcm845/recipes-phosphor/sensors/dbus-sensors_%.bbappend
@@ -1,4 +1,4 @@
-PACKAGECONFIG:evb-npcm845 = " \
+PACKAGECONFIG = " \
     hwmontempsensor \
     fansensor \
     adcsensor \


### PR DESCRIPTION
Align with the other meta-machine layer rule. When a bbappend file is already in a meta-machine layer, there is no reason for extra ":machine" override syntax. Remove them all in bb/bbappend files.