### PR TITLE
meta-nuvoton: npcm8xx-bootblock: update to 0.4.7

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock.inc
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock.inc
@@ -4,25 +4,36 @@ HOMEPAGE = "https://github.com/Nuvoton-Israel/npcm8xx-bootblock"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-BB_TIP = "arbel_a35_bootblock.bin"
-BB_NO_TIP = "arbel_a35_bootblock_no_tip.bin"
-
-OUTPUT_BB_TIP_BIN    = "Images/tip"
-OUTPUT_BB_NO_TIP_BIN = "Images/no_tip"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 S = "${WORKDIR}/git"
-
+B = "${S}/Sources"
+BB_BRANCH ?= "main"
 SRC_URI = " \
-    git://github.com/Nuvoton-Israel/npcm8xx-bootblock;branch=main;protocol=https"
+    git://github.com/Nuvoton-Israel/npcm8xx-bootblock;branch=${BB_BRANCH};protocol=https"
+
+export CROSS_COMPILE="${TARGET_PREFIX}"
+CFLAGS[unexport] = "1"
+LDFLAGS[unexport] = "1"
+AS[unexport] = "1"
+LD[unexport] = "1"
+do_configure[noexec] = "1"
+
+EXTRA_OEMAKE += "CROSS_COMPILER_INC=${STAGING_DIR_HOST}${includedir}"
+
+TIP = "${@'tip' if d.getVar("TIP_IMAGE") == 'True' else 'no_tip'}"
+BOOTBLOCK = "arbel_a35_bootblock"
+BOOTBLOCK .= "${@'_no_tip' if d.getVar("TIP_IMAGE") != 'True' else ''}"
+
+do_compile() {
+    oe_runmake "${BOOTBLOCK}" ENCLAVE="${TIP}"
+}
+do_compile[cleandirs] = "${B}/Images"
 
 inherit deploy
-
-do_deploy () {
-    if [ "${TIP_IMAGE}" = "True" ] ; then
-        install -D -m 644 ${OUTPUT_BB_TIP_BIN}/${BB_TIP} ${DEPLOYDIR}/${BB_TIP}
-    else
-        install -D -m 644 ${OUTPUT_BB_NO_TIP_BIN}/${BB_NO_TIP} ${DEPLOYDIR}/${BB_NO_TIP}
-    fi
+do_deploy() {
+    install -d ${DEPLOYDIR}
+    install -m 644 "${B}/Images/${TIP}/${BOOTBLOCK}.bin" "${DEPLOYDIR}/${BOOTBLOCK}.bin"
 }
 
 addtask deploy before do_build after do_compile

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.6.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.6.bb
@@ -1,3 +1,0 @@
-SRCREV = "b45a45bce6e557af49b43492904579edb5f084a3"
-
-require npcm8xx-bootblock.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.7.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.7.bb
@@ -1,0 +1,3 @@
+SRCREV = "4bee6bd07772b53697ba5f9771855ef359529224"
+
+require npcm8xx-bootblock.inc


### PR DESCRIPTION
Changelog:

version 0.4.7 - May 7th 2024
=============
- Fix DDP\SDP type print.
- Cleanup code for upstream.
- Fix print of reset type for TIP reset case.
- Bug fix: when using dlls_trim_clk override from header option INCR bit value is set to bit 7 instead of 6. Fixed to 6.
- Add mode non-ECC ranges (8 total).
- Fix build on Linux (change "Apps" folder to "apps").
- Upgrade compiler and compile by default with dwarf-3 (allow debugging with Lauterbach, for GDB switch to -ggdb).
- Compile optimization for speed.
- Fix Coverity issues.
- Cleanup makefile.
- Add bit (over scratchpad bits): INTCR2.HOST_INIT  (bit 11). This bit indicates host is initialized by bootblock. After host is set bit is set to prevent re-init.
- Bug fix: cntfrq_el0 was set back to 25000000 after warm boot, regardless of CPU frequency.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
