### PR TITLE
meta-nuvoton: npcm8xx-igps: update to 04.01.01

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.00.08.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.00.08.bb
@@ -1,4 +1,0 @@
-# tag IGPS_04.00.08
-SRCREV = "7e009f77dcc5b4cde80f1ba47b1cf5a010d7e197"
-
-require npcm8xx-igps.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.01.01.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.01.01.bb
@@ -1,0 +1,4 @@
+# tag IGPS_04.01.01
+SRCREV = "e40802335270a2af6744d9160c7eae15b5777217"
+
+require npcm8xx-igps.inc


### PR DESCRIPTION
Changelog:

IGPS 04.01.01 - May 21th 2024
============
- bootblock 0.4.8 Set cntfrq_el0 should be after calling serial_printf_init.

IGPS 04.01.00 - May 20th 2024
============
- skmt_map.xml: remove RSA key and add add ECC DER Key instead. This key should be manifest root key.
- TIP_FW 0.6.9 L0 0.5.8 L1:
  * Disable CFM.
  * Bug fix: if bootblock is at offset 2MB recovery image is not fully created. Fix the size of image measurement with the additional gap.
  * Manifest root key is the last key in SKMT. Format is ECC DER.
  * Hardening: limit up to 100 lines. check return status of hardening.
  * In case of assert write to debug log.
  * Bug fix: in BMC reset, if the reloading fails BMC will go to recovery.
- Remove MCR 180 from hardening register table.
- Apply one_igps in order to support yocto build with pre-signed image.