### PR TITLE
meta-nuvoton: npcm8xx-bootblock: update to 0.4.8

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.7.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.7.bb
@@ -1,3 +1,0 @@
-SRCREV = "4bee6bd07772b53697ba5f9771855ef359529224"
-
-require npcm8xx-bootblock.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.8.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.8.bb
@@ -1,0 +1,3 @@
+SRCREV = "b42684013eca57f7b4599a5da04d6b8792f20c85"
+
+require npcm8xx-bootblock.inc


### PR DESCRIPTION
Changelog:

version 0.4.8 - May 21th 2024
=============
- Set cntfrq_el0 should be after calling serial_printf_init.

version 0.4.7 - May 7th 2024
=============
- Fix DDP\SDP type print.
- Cleanup code for upstream.
- Fix print of reset type for TIP reset case.
- Bug fix: when using dlls_trim_clk override from header option INCR bit value is set to bit 7 instead of 6. Fixed to 6.
- Add mode non-ECC ranges (8 total).
- Fix build on Linux (change "Apps" folder to "apps").
- Upgrade compiler and compile by default with dwarf-3 (allow debugging with Lauterbach, for GDB switch to -ggdb).
- Compile optimization for speed.
- Fix Coverity issues.
- Cleanup makefile.
- Add bit (over scratchpad bits): INTCR2.HOST_INIT  (bit 11). This bit indicates host is initialized by bootblock. After host is set bit is set to prevent re-init.
- Bug fix: cntfrq_el0 was set back to 25000000 after warm boot, regardless of CPU frequency.