### PR TITLE
meta-nuvoton: npcm8xx-tip-fw: update to 0.6.9.0.5.8

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.6.9.0.5.8.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.6.9.0.5.8.bb
@@ -1,4 +1,4 @@
-SRCREV = "65c421f6bd7efb96c1d95fcaaf13425129fba2c0"
+SRCREV = "0f7e299e0ab4153cd7ecdb511c1afd95c67fee47"
 
 OUTPUT_BIN = "output_binaries_${DEVICE_GEN}_${IGPS_MACHINE}"
 


### PR DESCRIPTION
Changelog:

TIP_FW: 0.6.9 L0 0.5.8 L1
==============
- Disable CFM.
- Bug fix: if bootblock is at offset 2MB recovery image is not fully created. Fix the size of image measurement with the additional gap.
- Manifest root key is the last key in SKMT. Format is ECC DER.
- Hardening: limit up to 100 lines. check return status of hardening.
- In case of assert write to debug log.
- Bug fix: in BMC reset, if the reloading fails BMC will go to recovery.

Tested:
Build pass and boot up successful with correct TIP FW latest version.