### PR TITLE
meta-nuvoton: npcm8xx-tip-fw: update to 0.7.1.0.6.0

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.7.1.0.6.0.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.7.1.0.6.0.bb
@@ -1,4 +1,4 @@
-SRCREV = "0f7e299e0ab4153cd7ecdb511c1afd95c67fee47"
+SRCREV = "bdbfc0324150c4471c77bafc2cf5f6f3c64cf814"
 
 OUTPUT_BIN = "output_binaries_${DEVICE_GEN}_${IGPS_MACHINE}"
 


### PR DESCRIPTION
Changelog:

TIP_FW: 0.7.1 L0 0.6.0 L1
==============
- Add flash protection on recovery image.
  Recovery region is now read-only.

Tested:
Build pass and boot up successful with correct TIP FW latest version.