### PR TITLE
meta-nuvoton: npcm8xx-igps: update to 04.01.03

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.01.01.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.01.01.bb
@@ -1,4 +1,0 @@
-# tag IGPS_04.01.01
-SRCREV = "e40802335270a2af6744d9160c7eae15b5777217"
-
-require npcm8xx-igps.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.01.03.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-igps-native_04.01.03.bb
@@ -1,0 +1,4 @@
+# tag IGPS_04.01.03
+SRCREV = "ae5ddb6c8ff350835d411b9e3bfb4443db596067"
+
+require npcm8xx-igps.inc


### PR DESCRIPTION
Changelog:

IGPS 04.01.03 - May 29th 2024
============
- TIP_FW 0.7.1 L0 0.6.0 L1
  * Add flash protection on recovery image. Recovery region is now read-only.
  * Enable hardening tables:
  .\py_scripts\ImageGeneration\inputs\registers\registers_bootblock.csv
  .\py_scripts\ImageGeneration\inputs\registers\registers_bl31.csv

- Uboot
  * Fix IPv6 PXE boot

- Yocto build
  * Updated script for SA pre-signed combo0 support, just like TIP FW pre-signed combo0.
  * Add comment support for settings.
  * config_replacer: make comment handler more general Move comment handler from xml parser to load settings function.