### PR TITLE
meta-evb: evb-npcm845: leds: remove unnecessary configuration

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/leds/phosphor-led-manager/LED_GroupManager.conf
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/leds/phosphor-led-manager/LED_GroupManager.conf
@@ -1,4 +1,0 @@
-[Unit]
-Wants=mapper-wait@-xyz-openbmc_project-led-physical.service
-After=mapper-wait@-xyz-openbmc_project-led-physical.service
-

--- a/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/leds/phosphor-led-manager_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-evb-npcm845/recipes-phosphor/leds/phosphor-led-manager_%.bbappend
@@ -1,5 +1,0 @@
-FILESEXTRAPATHS:prepend:evb-npcm845 := "${THISDIR}/${PN}:"
-
-SRC_URI:append:evb-npcm845 = " file://LED_GroupManager.conf"
-
-SYSTEMD_OVERRIDE:${PN}:evb-npcm845 += "LED_GroupManager.conf:xyz.openbmc_project.LED.GroupManager.service.d/LED_GroupManager.conf"


### PR DESCRIPTION
The content of `LED_GroupManager.conf` cannot make sure all physical LED services have started
before LED manager that will only wait for one of them. And `phosphor-led-sysfs` already handle it.
Thus, remove this unnecessary configuration.

Tested:
systemd[1]: Starting Phosphor LED Group Management Daemon...
systemd[1]: Started Phosphor sysfs LED controller.
systemd[1]: Started Phosphor sysfs LED controller.
systemd[1]: Started Phosphor sysfs LED controller.
systemd[1]: Started Phosphor LED Group Management Daemon.
systemd[1]: Starting Wait for /xyz/openbmc_project/led/groups/bmc_booted...
systemd[1]: Finished Wait for /xyz/openbmc_project/led/groups/bmc_booted.
systemd[1]: Finished Wait for /xyz/openbmc_project/led/groups.
systemd[1]: Starting Assert bmc_booted LED...
systemd[1]: Finished Assert bmc_booted LED.