### PR TITLE
meta-nuvoton: npcm8xx-bootblock: update to 0.5.0

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.8.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.4.8.bb
@@ -1,3 +1,0 @@
-SRCREV = "e18737d17d4cf5e7768598a291a7ef2b8a07a776"
-
-require npcm8xx-bootblock.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.5.0.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.5.0.bb
@@ -1,0 +1,3 @@
+SRCREV = "1500d172005fe379d5ae5a04c412d39c4ac58405"
+
+require npcm8xx-bootblock.inc


### PR DESCRIPTION
Changelog:

version 0.5.0 - July 7th 2024
=============
- Fix TRIM2 debug sweep.

Tested:
Build pass and boot up successful with BB latest version.