### PR TITLE
meta-nuvoton: npcm8xx-tip-fw: update to 0.7.2.0.6.1

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.7.2.0.6.1.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.7.2.0.6.1.bb
@@ -1,4 +1,4 @@
-SRCREV = "bdbfc0324150c4471c77bafc2cf5f6f3c64cf814"
+SRCREV = "594b67c9b2c72cc83415d4deca55dcc8f0aeb09a"
 
 OUTPUT_BIN = "output_binaries_${DEVICE_GEN}_${IGPS_MACHINE}"
 


### PR DESCRIPTION
Changelog:

TIP_FW: 0.7.2 L0 0.6.1 L1
==============
- Bug fix flash protection: wrong settings for dual and quad read (should be on the white list).

Tested:
Build pass and boot up successful with correct TIP FW latest version.