### PR TITLE
meta-nuvoton: npcm8xx-bootloader: srcrev bump 518d3f58f4...d3b7edaca6

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootloader_04.01.04.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootloader_04.01.04.bb
@@ -12,7 +12,7 @@ IGPS_BRANCH ?= "main"
 SRC_URI = " \
     git://github.com/Nuvoton-Israel/igps-npcm8xx;branch=${IGPS_BRANCH};protocol=https \
 "
-SRCREV = "518d3f58f4f157373a5b1aaebaf22f80bb13d0d9"
+SRCREV = "d3b7edaca6748b95e7fdcdf7b2fd1b06ce438f96"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Tali Perry (1):

IGPS 04.01.04 - Jul 22th 2024
============
- TIP_FW 0.7.2 L0 0.6.1 L1:
  * Bug fix flash protection: wrong settings for dual and quad read (should be on the white list)

- uboot v2023.10-npcm8xx-20240719
  * Remove System Counter register access
  * Add sgpio driver
  * Support SHA 512 hw acceleration
  * Fix dm_i2c_read/write error

- bootblock 0.5.0
  * Fix TRIM2 debug sweep

Tested:
Build pass and boot up successful with correct BB/TIP FW latest version