### PR TITLE
meta-scm-npcm845: u-boot: update patches

### DIFF
--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton/1111-boot-openbmc-form-emmc.patch
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton/1111-boot-openbmc-form-emmc.patch
@@ -1,33 +1,26 @@
-From f5a339e55e1a19061c5ab9c74a4b0a0b80764f7b Mon Sep 17 00:00:00 2001
+From d653c8fcc44ee36b4302418fbf61c8086653d921 Mon Sep 17 00:00:00 2001
 From: Stanley Chu <yschu@nuvoton.com>
 Date: Fri, 13 May 2022 16:43:18 +0800
 Subject: [PATCH] boot openbmc from emmc
 
+Add env for boot Openbmc from eMMC.
+
 Signed-off-by: Stanley Chu <yschu@nuvoton.com>
 ---
- include/configs/arbel.h | 8 +++++++-
- 1 file changed, 7 insertions(+), 1 deletion(-)
+ include/configs/arbel.h | 6 ++++++
+ 1 file changed, 6 insertions(+)
 
 diff --git a/include/configs/arbel.h b/include/configs/arbel.h
-index b4ebc54641..db6b46e943 100644
+index 01cf1c5e6e..0794024f85 100644
 --- a/include/configs/arbel.h
 +++ b/include/configs/arbel.h
-@@ -37,7 +37,7 @@
- #define SPI3_END_ADDR			0xBFFFFFFF
- 
- /* Default environemnt variables */
--#define CONFIG_BOOTCOMMAND "run common_bootargs; run romboot"
-+#define CONFIG_BOOTCOMMAND "run emmc_bootargs; run emmcboot"
- #define CONFIG_EXTRA_ENV_SETTINGS   "uimage_flash_addr=80400000\0"   \
- 		"stdin=serial\0"   \
- 		"stdout=serial\0"   \
-@@ -59,6 +59,12 @@
+@@ -60,6 +60,12 @@
  		"console=ttyS0,115200n8\0" \
  		"common_bootargs=setenv bootargs earlycon=${earlycon} root=/dev/ram " \
  		"console=${console} mem=${mem} ramdisk_size=48000 oops=panic panic=20\0" \
-+		"emmc_bootargs=setenv bootargs earlycon=${earlycon} console=${console} " \
++		"mmc_bootargs=setenv bootargs earlycon=${earlycon} console=${console} " \
 +		"rootwait root=PARTLABEL=rofs-a\0" \
-+		"emmcboot=echo Booting Kernel from eMMC; echo Using bootargs: ${bootargs};" \
++		"mmcboot=echo Booting Kernel from eMMC; echo Using bootargs: ${bootargs};" \
 +		"setenv loadaddr 0x10000000; setenv bootpart 2; " \
 +		"ext4load mmc 0:${bootpart} ${loadaddr} fitImage && bootm; " \
 +		"echo Error loading kernel FIT image\0" \
@@ -35,5 +28,5 @@ index b4ebc54641..db6b46e943 100644
  		"ftp_run=setenv ethact eth${eth_num}; dhcp; tftp 10000000 image-bmc; bootm 10200000\0"   \
  		"usb_prog=usb start; fatload usb 0 10000000 image-bmc; cp.b 10000000 80000000 ${filesize}\0"    \
 -- 
-2.17.1
+2.34.1
 

--- a/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton_%.bbappend
+++ b/meta-evb/meta-evb-nuvoton/meta-scm-npcm845/recipes-bsp/u-boot/u-boot-nuvoton_%.bbappend
@@ -10,7 +10,7 @@ SRC_URI:append:scm-npcm845 = " file://0002-add-i2c-voltage-1.8v-support.patch"
 
 SRC_URI:append:scm-npcm845 = " file://0001-uboot-scm-dts.patch"
 SRC_URI:append:scm-npcm845 = " \
-	${@emmc_enabled(d, 'file://1111-boot-openbmc-form-emmc.patch')}"
+	${@emmc_enabled(d, 'file://1111-boot-openbmc-form-emmc.patch file://mmc-boot.cfg')}"
 
 SRC_URI:append:m1120-c2195 = " file://m1120.dts;subdir=git/arch/arm/dts/"
 SRC_URI:append:m1120-c2195 = " file://m1120-pincfg.dtsi;subdir=git/arch/arm/dts/"

--- a/meta-nuvoton/recipes-bsp/u-boot/files/mmc-boot.cfg
+++ b/meta-nuvoton/recipes-bsp/u-boot/files/mmc-boot.cfg
@@ -1,0 +1,1 @@
+CONFIG_BOOTCOMMAND="run mmc_bootargs; run mmcboot"


### PR DESCRIPTION
Update patches to fix build break, and also add mmc-boot.cfg for set CONFIG_BOOTCOMMAND boot from eMMC.

