### PR TITLE
meta-nuvoton: npcm8xx-bootblock: update to 0.5.1

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.5.0.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.5.0.bb
@@ -1,3 +1,0 @@
-SRCREV = "1500d172005fe379d5ae5a04c412d39c4ac58405"
-
-require npcm8xx-bootblock.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.5.1.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.5.1.bb
@@ -1,0 +1,3 @@
+SRCREV = "e5d886049b1b06c61a6df792c8f4617c572abce1"
+
+require npcm8xx-bootblock.inc


### PR DESCRIPTION
Changelog:

version 0.5.1 - Aug 5th 2024
=============
- Improve boot speed. 1.8 sec 1GB no ECC, 2 sec with ECC.
- NOTIP only: Reset slow periphrals on every reset (including UART, I2C etc.)
- NOTIP only: don't reset PCIMBX, CP1 and BMCBUS.
- Disable WDT in case of debug sweeps.
- Remove some prints and normalize line endings in log.

Tested:
Build pass and boot up successful with BB latest version.