### PR TITLE
meta-nuvoton: npcm8xx-bootblock: update to 0.5.2

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.5.1.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.5.1.bb
@@ -1,3 +1,0 @@
-SRCREV = "e5d886049b1b06c61a6df792c8f4617c572abce1"
-
-require npcm8xx-bootblock.inc

--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.5.2.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootblock_0.5.2.bb
@@ -1,0 +1,3 @@
+SRCREV = "20ed3835913a05ae335aff83c11ecc85c84f0cbc"
+
+require npcm8xx-bootblock.inc


### PR DESCRIPTION
Changelog:

version 0.5.2 - Sep 15th 2024
=============
- Bug fix: Errata fix: 1.7 eSPI FATAL_ERROR: Set ESPI_ESPI_ENG to 0x40 (remove RMW to set bit 6).
- Update CP init code (disabled by default, under SEARCH_CP_ON_FLASH_0 flag).
- In case of traps and unexpected IRQs and FIQ: clear GIC registers.
- In case of TRAP: notify TIP (TIP mode), or FSW (NO_TIP mode).
- Update GIC driver and GIC table.

Tested:
Build pass and boot up successful with BB latest version.