### PR TITLE
meta-nuvoton: npcm8xx-tip-fw: update to 0.7.4.0.6.3

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.7.4.0.6.3.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-tip-fw_0.7.4.0.6.3.bb
@@ -1,4 +1,4 @@
-SRCREV = "594b67c9b2c72cc83415d4deca55dcc8f0aeb09a"
+SRCREV = "c0418a3e5df233bb9c69b805c60d606fa3066654"
 
 OUTPUT_BIN = "output_binaries_${DEVICE_GEN}_${IGPS_MACHINE}"
 


### PR DESCRIPTION
Changelog:

TIP_FW: 0.7.4 L0 0.6.3 L1
==============
- BMC_DIRECT: add command BMC_DIRECT_COMMAND_FL_READ_PARMAS. If flash not connected return error.
- WD1 init before uboot: currently disabled till uboot upgrade.
- WD1 init before bootblock run.
- When BMC reset - reload same FW (and not active image).
- Skip FIU1 CS1 in flash init. Not supported as a valid boot address in TIP_ROM.
- Disable LMS support.
- Restore flash protection.
- Clear alias key from PCI mailbox and shared attestation area.
- Dismiss verify fail in non-secure device.
- Temp: disable WD1 till uboot is ready.
- Bug fix: set CS1 drive strength to support 50MHz (merge issue).

Tested:
Build pass and boot up successful with correct TIP FW latest version.