### PR TITLE
meta-nuvoton: npcm8xx-bootloader: update IGPS to 04.02.03

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootloader_04.02.03.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootloader_04.02.03.bb
@@ -12,7 +12,7 @@ IGPS_BRANCH ?= "main"
 SRC_URI = " \
     git://github.com/Nuvoton-Israel/igps-npcm8xx;branch=${IGPS_BRANCH};protocol=https \
 "
-SRCREV = "d3b7edaca6748b95e7fdcdf7b2fd1b06ce438f96"
+SRCREV = "c36a02060f9f1cdb1382629bd1f54e43676bdebb"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
IGPS 04.02.03 - Oct 6th 2024
============
- TIP_FW 0.7.4 L0 0.6.3 L1:
  * BMC_DIRECT: add command BMC_DIRECT_COMMAND_FL_READ_PARMAS. If flash not connected return error.
  * WD1 init before uboot: currently disabled till uboot upgrade.
  * WD1 init before bootblock run.
  * When BMC reset - reload same FW (and not active image).
  * Skip FIU1 CS1 in flash init. Not supported as a valid boot address in TIP_ROM.
  * Disable LMS support.
  * Restore flash protection.
  * Clear alias key from PCI mailbox and shared attestation area.
  * Dismiss verify fail in non-secure device.
  * Temp: disable WD1 till uboot is ready.
  * Bug fix: set CS1 drive strength to support 50MHz (merge issue).

- bootblock 0.5.2
  * Bug fix: Errata fix: 1.7 eSPI FATAL_ERROR: Set ESPI_ESPI_ENG to 0x40 (remove RMW to set bit 6).
  * Update CP init code (disabled by default, under SEARCH_CP_ON_FLASH_0 flag).
  * In case of traps and unexpected IRQs and FIQ: clear GIC registers.
  * In case of TRAP: notify TIP (TIP mode), or FSW (NO_TIP mode).
  * Update GIC driver and GIC table.

- Uboot:
  * Clear all gpio events
  * Change env and uImage flash address
  * Add stopwdt command in default environment

- LMS: changed (only for A2) that all images will be signed (if wanted) with skmt_lms_key2.

- OTP_Programmer_Monitor : 1.1.3 that can print the LMS keys full info (fix is needed for LMS users only).

- L0 version increment to 1.

Tested:
Build pass and boot up successful with correct BB/TIP FW latest version