### PR TITLE
meta-nuvoton: npcm8xx-bootloader: update IGPS to 04.02.04

### DIFF
--- a/meta-nuvoton/recipes-bsp/images/npcm8xx-bootloader_04.02.04.bb
+++ b/meta-nuvoton/recipes-bsp/images/npcm8xx-bootloader_04.02.04.bb
@@ -12,7 +12,7 @@ IGPS_BRANCH ?= "main"
 SRC_URI = " \
     git://github.com/Nuvoton-Israel/igps-npcm8xx;branch=${IGPS_BRANCH};protocol=https \
 "
-SRCREV = "c36a02060f9f1cdb1382629bd1f54e43676bdebb"
+SRCREV = "4d04003852fa4e970bf96bd697dbe78f0832667a"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
IGPS 04.02.04 - Oct 15th 2024
============
- TIP_FW 0.7.5 L0 0.6.4 L1:
    * Support LMS.
    * Bug fix WDC=1 in recovery , also after reset.
    * Bug fix: after 3 WD1 resets (not 2) in under 10 minutes go to recovery.
    * Bug fix: L0 measurements and attestation hash recalc.

- LMS:
    * Add key_index_LMS & key_mask_lms to all XMLS (although they are not to be changed via XML)
    * Added LMS keys to arbel_fuse_map XML
    * OTP + SKMT keys: allow signing with any key (not fixed to key 2).

Tested:
Build pass and boot up successful with correct BB/TIP FW latest version