### PR TITLE
meta-nuvoton: linux kernel 6.1 bump srcrev 697fe27280..cc61f98d52

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_6.1.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_6.1.bb
@@ -1,7 +1,7 @@
 KSRC = "git://github.com/Nuvoton-Israel/linux;protocol=https;branch=${KBRANCH}"
 KBRANCH = "NPCM-6.1-OpenBMC"
 LINUX_VERSION = "6.1.51"
-SRCREV = "697fe27280f32bd682c38b0bb1ace126b30f5e6e"
+SRCREV = "cc61f98d52d2f3194b6110f58f885b75b3ba43e3"
 
 require linux-nuvoton.inc
 


### PR DESCRIPTION
Ban Feng (1):
      soc: nuvoton: mmbi: modify the default value of b2h_d and h2b_d

Brian Ma (2):
      driver: pinctrl-npcm8xx: Set strict as true
      i2c: npcm: adjust SCL low time and high time

Jeremy Kerr (2):
      i3c: Allow OF-alias-based persistent bus numbering
      net: mctp: copy skb ext data when fragmenting

Jim Liu (1):
      ipmi: ssif_bmc: add slave disable/enable method

Stanley Chu (2):
      i3c: master: svc: fix stuck in svc_i3c_master_read
      i3c: master: svc: Ignore the ibi event during driver probe

Tomer Maimon (1):
      arm64: dts: nuvoton: npcm845: set FIU UMA read

Tested:
    Build and boot OK on evb-npcm845.
