### PR TITLE
meta-nuvoton: linux kernel 6.6 bump srcrev 55e9820636..e727f4959a

### DIFF
--- a/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_6.6.bb
+++ b/meta-nuvoton/recipes-kernel/linux/linux-nuvoton_6.6.bb
@@ -1,7 +1,7 @@
 KSRC = "git://github.com/Nuvoton-Israel/linux;protocol=https;branch=${KBRANCH}"
 KBRANCH = "NPCM-6.6-OpenBMC"
 LINUX_VERSION = "6.6.22"
-SRCREV = "55e9820636c62da52fdf19d9bfce4c3258992991"
+SRCREV = "e727f4959a096d4fd79b547307b89b159cfd176b"
 
 require linux-nuvoton.inc
 


### PR DESCRIPTION
Ban Feng (1):
      soc: nuvoton: mmbi: modify the default value of b2h_d and h2b_d

Brian Ma (1):
      driver: pinctrl-npcm8xx: Set strict as true

Eason Yang (1):
      iio: adc: nct720x: add Nuvoton NCT7201/NCT7202 ADC driver

Jim Liu (1):
      ipmi: ssif_bmc: add slave disable/enable method

Stanley Chu (4):
      i3c: master: svc: workaround for i3c timing violation
      i3c: master: svc: fix stuck in svc_i3c_master_read
      i3c: master: svc: Ignore the ibi event during driver probe
      iio: adc: npcm: fix inappropriate error log

Tomer Maimon (9):
      watchdog: npcm: Add Nuvoton NPCM8xx support
      watchdog: npcm: Add DT restart priority and reset type support
      arm64: dts: nuvoton: remove npcm750 compatible WD node name
      arm64: dts: nuvoton: npcm845: set FIU UMA read
      iio: adc: Add calibration support to npcm ADC
      iio: adc: fix adc driver issue
      iio: adc: npcm: cover more module reset cases
      iio: adc: modify wake up function
      iio: adc: npcm: clear interrupt status at probe

Tested:
    Build pass on evb-npcm845

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
