### PR TITLE
evb-npcm845: usb-network: update script

### DIFF
--- a/meta-nuvoton-obmc/meta-evb-npcm845/recipes-evb-npcm845/usb-network/files/usb_network.sh
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/recipes-evb-npcm845/usb-network/files/usb_network.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-cd /sys/kernel/config/usb_gadget
+cd /sys/kernel/config/usb_gadget || exit 1
 
 version_above_5(){
   MAJOR_VERSION=$(uname -r | awk -F '.' '{print $1}')
-  if [ $MAJOR_VERSION -ge 6 ]  ; then
+  if [ "$MAJOR_VERSION" -ge 6 ]  ; then
     return 0
   else
     return 1
@@ -19,7 +19,7 @@ fi
 
 if [ ! -f "g1" ]; then
     mkdir g1
-    cd g1
+    cd g1 || exit 1
 
     echo 0x1d6b > idVendor  # Linux foundation
     echo 0x0104 > idProduct # Multifunction composite gadget
@@ -31,8 +31,12 @@ if [ ! -f "g1" ]; then
     echo 100 > configs/c.1/MaxPower
     mkdir -p configs/c.1/strings/0x409
     echo "RNDIS" > configs/c.1/strings/0x409/configuration
-    
-    mkdir -p functions/rndis.usb0 
+
+    mkdir -p functions/rndis.usb0
+    # In order to be compatible with Windows
+    echo ef > functions/rndis.usb0/class
+    echo 04 > functions/rndis.usb0/subclass
+    echo 01 > functions/rndis.usb0/protocol
     
     ln -s functions/rndis.usb0 configs/c.1
     


### PR DESCRIPTION
Update usb network shell script for Windows RNDIS driver support.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
