### PR TITLE
meta-nuvoton-obmc: meta-evb-npcm845: update WORKDIR to UNPACKDIR

### DIFF
--- a/meta-nuvoton-obmc/meta-evb-npcm845/recipes-phosphor/configuration/entity-manager_%.bbappend
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/recipes-phosphor/configuration/entity-manager_%.bbappend
@@ -7,8 +7,8 @@ SRC_URI:append = " \
 
 do_install:append () {
     mkdir -p ${D}/etc/fru
-    install -m 0444 ${WORKDIR}/baseboard.fru.bin ${D}/etc/fru
+    install -m 0444 ${UNPACKDIR}/baseboard.fru.bin ${D}/etc/fru
     install -d ${D}${datadir}/entity-manager
-    install -m 0644 -D ${WORKDIR}/nuvoton_npcm8xx_evb.json \
+    install -m 0644 -D ${UNPACKDIR}/nuvoton_npcm8xx_evb.json \
         ${D}${datadir}/entity-manager/configurations/nuvoton_npcm8xx_evb.json
 }

--- a/meta-nuvoton-obmc/meta-evb-npcm845/recipes-phosphor/inventory/phosphor-inventory-manager_%.bbappend
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/recipes-phosphor/inventory/phosphor-inventory-manager_%.bbappend
@@ -5,5 +5,5 @@ DEPENDS:append = " evb-npcm845-inventory-cleanup"
 
 do_install:append() {
     install -d ${D}${base_datadir}
-    install -m 0755 ${WORKDIR}/associations.json ${D}${base_datadir}/associations.json
+    install -m 0755 ${UNPACKDIR}/associations.json ${D}${base_datadir}/associations.json
 }

--- a/meta-nuvoton-obmc/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config.bbappend
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-config.bbappend
@@ -6,8 +6,8 @@ SRC_URI:append = " file://channel_config.json"
 SRC_URI:append = " file://dev_id.json"
 
 do_install:append() {
-    install -m 0644 -D ${WORKDIR}/channel_config.json \
+    install -m 0644 -D ${UNPACKDIR}/channel_config.json \
         ${D}${datadir}/ipmi-providers/channel_config.json
-    install -m 0644 -D ${WORKDIR}/dev_id.json \
+    install -m 0644 -D ${UNPACKDIR}/dev_id.json \
         ${D}${datadir}/ipmi-providers/dev_id.json
 }

--- a/meta-nuvoton-obmc/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-ipmb_%.bbappend
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-ipmb_%.bbappend
@@ -5,7 +5,7 @@ FILES:${PN}:append = " ${datadir}/ipmbbridge/ipmb-channels.json"
 
 do_install:append() {
     install -d ${D}${datadir}/ipmbbridge
-    install -m 0644 -D ${WORKDIR}/ipmb-channels.json \
+    install -m 0644 -D ${UNPACKDIR}/ipmb-channels.json \
         ${D}${datadir}/ipmbbridge/ipmb-channels.json
 }
 

--- a/meta-nuvoton-obmc/meta-evb-npcm845/recipes-phosphor/sensors/phosphor-hwmon_%.bbappend
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/recipes-phosphor/sensors/phosphor-hwmon_%.bbappend
@@ -31,6 +31,6 @@ SYSTEMD_ENVIRONMENT_FILE:${PN} += " \
 
 do_install:append() {
         install -d ${D}${bindir}
-        install -m 0755 ${WORKDIR}/start_hwmon.sh ${D}${bindir}
+        install -m 0755 ${UNPACKDIR}/start_hwmon.sh ${D}${bindir}
 }
 


### PR DESCRIPTION
New yocto requires the use of UNPACKDIR
