### PR TITLE
meta-nuvoton-obmc: fix build warnings

### DIFF
--- a/meta-nuvoton-obmc/meta-buv-runbmc/recipes-buv-runbmc/usb-emmc-storage/usb-emmc-storage.bb
+++ b/meta-nuvoton-obmc/meta-buv-runbmc/recipes-buv-runbmc/usb-emmc-storage/usb-emmc-storage.bb
@@ -8,6 +8,9 @@ RDEPENDS:${PN} += "bash"
 SRC_URI += "file://usb_emmc_storage.sh \
            file://usb_emmc_storage.service"
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 do_install() {
     install -d ${D}/${sbindir}
     install -m 0755 ${UNPACKDIR}/usb_emmc_storage.sh ${D}/${sbindir}

--- a/meta-nuvoton-obmc/meta-buv-runbmc/recipes-buv-runbmc/usb-network/usb-network.bb
+++ b/meta-nuvoton-obmc/meta-buv-runbmc/recipes-buv-runbmc/usb-network/usb-network.bb
@@ -11,6 +11,9 @@ SRC_URI += "file://usb_network.sh \
            file://usb_network.service \
            file://00-bmc-usb0.network"
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 do_install() {
     install -d ${D}/${sbindir}
     install -m 0755 ${UNPACKDIR}/usb_network.sh ${D}/${sbindir}

--- a/meta-nuvoton-obmc/meta-buv-runbmc/recipes-devtools/rw-perf/rw-perf_1.0.0.bb
+++ b/meta-nuvoton-obmc/meta-buv-runbmc/recipes-devtools/rw-perf/rw-perf_1.0.0.bb
@@ -5,6 +5,9 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SRC_URI = "file://wr_perf_test file://rd_perf_test"
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_PACKAGE_STRIP = "1"
 

--- a/meta-nuvoton-obmc/meta-common/recipes-nuvoton/loadmcu/loadmcu.bb
+++ b/meta-nuvoton-obmc/meta-common/recipes-nuvoton/loadmcu/loadmcu.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "MCU F/W Programmer"
 PR = "r1"
 
 LICENSE = "GPL-2.0-or-later"
-LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 inherit systemd
 inherit obmc-phosphor-systemd

--- a/meta-nuvoton-obmc/meta-common/recipes-nuvoton/program-vbios/program-vbios.bb
+++ b/meta-nuvoton-obmc/meta-common/recipes-nuvoton/program-vbios/program-vbios.bb
@@ -17,6 +17,9 @@ SRC_URI += " file://program-vbios.service \
              file://dontload.conf \
            "
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "program-vbios.service"
 SYSTEMD_ENVIRONMENT_FILE:${PN} +="obmc/vbios/program_vbios"

--- a/meta-nuvoton-obmc/meta-common/recipes-phosphor/flash/phosphor-software-manager/disable-mmc-mirroruboot.patch
+++ b/meta-nuvoton-obmc/meta-common/recipes-phosphor/flash/phosphor-software-manager/disable-mmc-mirroruboot.patch
@@ -1,10 +1,18 @@
+From e5fc2cf05370a58e003a18db1348a065ff1cbb93 Mon Sep 17 00:00:00 2001
+From: Brian Ma <chma0@nuvoton.com>
+Date: Tue, 17 Dec 2024 09:19:15 +0800
+Subject: [PATCH] disable mmc mirroruboot
+
 Upstream-Status: Inappropriate [oe-specific]
+---
+ obmc-flash-bmc | 1 +
+ 1 file changed, 1 insertion(+)
 
 diff --git a/obmc-flash-bmc b/obmc-flash-bmc
-index 032096a..187f231 100644
+index 5e4c1e2..e51a589 100644
 --- a/obmc-flash-bmc
 +++ b/obmc-flash-bmc
-@@ -647,6 +647,7 @@ function mmc_setprimary() {
+@@ -650,6 +650,7 @@ function mmc_setprimary() {
  }
  
  function mmc_mirroruboot() {
@@ -12,3 +20,6 @@ index 032096a..187f231 100644
      # Get current boot device; 0-primary_bootdev device; 1 - alt_bootdev
      bootdev=$(cat /sys/kernel/debug/aspeed/sbc/abr_image)
      if [[ "${bootdev}" == "0" ]]; then
+-- 
+2.34.1
+

--- a/meta-nuvoton-obmc/meta-evb-npcm845/recipes-devtools/rw-perf/rw-perf_1.0.0.bb
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/recipes-devtools/rw-perf/rw-perf_1.0.0.bb
@@ -5,6 +5,9 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SRC_URI = "file://wr_perf_test file://rd_perf_test"
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_PACKAGE_STRIP = "1"
 

--- a/meta-nuvoton-obmc/meta-evb-npcm845/recipes-evb-npcm845/usb-emmc-storage/usb-emmc-storage.bb
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/recipes-evb-npcm845/usb-emmc-storage/usb-emmc-storage.bb
@@ -9,6 +9,9 @@ RDEPENDS:${PN} += "bash"
 SRC_URI += "file://usb_emmc_storage.sh \
            file://usb_emmc_storage.service"
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 do_install() {
     install -d ${D}/${sbindir}
     install -m 0755 ${UNPACKDIR}/usb_emmc_storage.sh ${D}/${sbindir}

--- a/meta-nuvoton-obmc/meta-evb-npcm845/recipes-evb-npcm845/usb-loopback/usb-loopback.bb
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/recipes-evb-npcm845/usb-loopback/usb-loopback.bb
@@ -9,6 +9,9 @@ RDEPENDS:${PN} += "bash"
 SRC_URI += "file://usb_loopback.sh \
            file://usb_loopback.service"
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 do_install() {
     install -d ${D}/${sbindir}
     install -m 0755 ${UNPACKDIR}/usb_loopback.sh ${D}/${sbindir}

--- a/meta-nuvoton-obmc/meta-evb-npcm845/recipes-evb-npcm845/usb-network/usb-network.bb
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/recipes-evb-npcm845/usb-network/usb-network.bb
@@ -10,6 +10,9 @@ SRC_URI += "file://usb_network.sh \
            file://usb_network.service \
            file://00-bmc-usb0.network"
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 do_install() {
     install -d ${D}/${sbindir}
     install -m 0755 ${UNPACKDIR}/usb_network.sh ${D}/${sbindir}

--- a/meta-nuvoton-obmc/meta-evb-npcm845/recipes-evb-npcm845/usb-tty/usb-tty.bb
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/recipes-evb-npcm845/usb-tty/usb-tty.bb
@@ -9,6 +9,9 @@ RDEPENDS:${PN} += "bash"
 SRC_URI += "file://usb_tty.sh \
            file://usb_tty.service"
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
 do_install() {
     install -d ${D}/${sbindir}
     install -m 0755 ${UNPACKDIR}/usb_tty.sh ${D}/${sbindir}


### PR DESCRIPTION
Update recipes after we replace WORKDIR with UNPACKDIR to fix warning.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
