### PR TITLE
meta-buv-runbmc: fix distro enable wrong usage

### DIFF
--- a/meta-nuvoton-obmc/meta-buv-runbmc/recipes-buv-runbmc/packagegroups/packagegroup-buv-runbmc-apps.bb
+++ b/meta-nuvoton-obmc/meta-buv-runbmc/recipes-buv-runbmc/packagegroups/packagegroup-buv-runbmc-apps.bb
@@ -61,8 +61,16 @@ RDEPENDS:${PN}-system:append = " \
 RDEPENDS:${PN}-system:append = " \
         ${@entity_enabled(d, 'phosphor-power-monitor-em', 'phosphor-power-monitor')} \
         "
+
+KDUMP_PACKAGES = " \
+  kexec-tools \
+  vmcore-dmesg \
+  kdump \
+  makedumpfile \
+  "
+
 RDEPENDS:${PN}-system:append = " \
-    ${@distro_enabled(d, 'kdump', 'kexec-tools vmcore-dmesg kdump makedumpfile')}"
+  ${@bb.utils.contains('DISTRO_FEATURES', 'kdump', '${KDUMP_PACKAGES}', '', d)}"
 
 
 SUMMARY:${PN}-entity = "BUV RunBMC entity"

--- a/meta-nuvoton-obmc/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton_5.15%.bbappend
+++ b/meta-nuvoton-obmc/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton_5.15%.bbappend
@@ -12,4 +12,4 @@ SRC_URI:append:buv-runbmc = " \
   "
 
 SRC_URI:append:buv-runbmc = " \
-  ${@distro_enabled(d, 'kdump', 'file://kdump.cfg')}"
+  ${@bb.utils.contains('DISTRO_FEATURES', 'kdump', 'file://kdump.cfg', '', d)}"

--- a/meta-nuvoton-obmc/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton_6.1%.bbappend
+++ b/meta-nuvoton-obmc/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton_6.1%.bbappend
@@ -3,7 +3,7 @@ inherit entity-utils
 
 SRC_URI:append:buv-runbmc = " file://buv-runbmc.cfg"
 SRC_URI:append:buv-runbmc = " file://enable-usb-xceiv.cfg"
-SRC_URI:append:buv-runbmc = " ${@distro_enabled(d, 'kdump', 'file://kdump.cfg')}"
+SRC_URI:append:buv-runbmc = " ${@bb.utils.contains('DISTRO_FEATURES', 'kdump', 'file://kdump.cfg', '', d)}"
 
 SRC_URI:append:buv-runbmc = " file://0008-driver-misc-seven-segment-display-gpio-driver.patch"
 


### PR DESCRIPTION
distro_enable is used for specific distro name, not for disto features. Use correct bb method to replace it.


