### PR TITLE
meta-nuvoton-obmc: common: ipmi: use default empty map

### DIFF
--- a/meta-nuvoton-obmc/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-config.bbappend
+++ b/meta-nuvoton-obmc/meta-common/recipes-phosphor/ipmi/phosphor-ipmi-config.bbappend
@@ -1,9 +1,0 @@
-ENTITY_MAPPING ?= "empty"
-
-do_install:append:nuvoton() {
-  # Set entity-map.json to empty json for Nuvoton BMC by default.
-  # Each system can override it if needed.
-  if [ "${ENTITY_MAPPING}" = "empty" ]; then
-    echo "[]" > ${D}${datadir}/ipmi-providers/entity-map.json
-  fi
-}


### PR DESCRIPTION
Change I69b9651ff36ecc0f0769b46fad94477d6f883786 eliminated the non-functional "example" entity-map and replaced it with an empty default. Therefore, remove the extra code and instead rely on the empty default in meta-phosphor.