### PR TITLE
meta-nuvoton-obmc: fix build warnings

### DIFF
--- a/meta-nuvoton-obmc/meta-common/recipes-nuvoton/npcm400-fw-tool/npcm400-fw-tool_0.2.bb
+++ b/meta-nuvoton-obmc/meta-common/recipes-nuvoton/npcm400-fw-tool/npcm400-fw-tool_0.2.bb
@@ -7,7 +7,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171d
 #SRC_URI = "git://${HOME}/NpcmFwProg;protocol=file;branch=main"
 #SRCREV = "efe2304881e36a1bcaa5eccf668b6358b19c75d3"
 #PV = "1.0+git${SRCPV}"
-#S = "${WORKDIR}/git"
+S = "${WORKDIR}/git"
+UNPACKDIR = "${S}"
 
 # Or use direct download approach:
 FILENAME = "NpcmFwProg_${PV}.bmc"

--- a/meta-nuvoton-obmc/meta-evb-npcm845/recipes-devtools/ent/ent_1.0.0.bb
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/recipes-devtools/ent/ent_1.0.0.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "The program is useful for evaluating pseudorandom number generato
 HOMEPAGE = "https://www.fourmilab.ch/random/"
 
 DEPENDS += "busybox"
-LICENSE="MIT"
+LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${S}/ent.c;endline=24;md5=376f7f7194e74c2639d66ef5f0309ef7"
 SRC_URI = "file://ent.tar.bz2"
 

--- a/meta-nuvoton-obmc/meta-evb-npcm845/recipes-devtools/fputest/fputest_1.0.0.bb
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/recipes-devtools/fputest/fputest_1.0.0.bb
@@ -7,7 +7,7 @@ SRC_URI = "file://${BPN}"
 
 S = "${WORKDIR}/${BPN}"
 
-LDFLAGS="-lm -lrt"
+LDFLAGS = "-lm -lrt"
 CFLAGS:remove = "-O2 "
 CXXFLAGS:remove = "-O2 "
 CFLAGS:prepend = "-O3 "

--- a/meta-nuvoton-obmc/meta-evb-npcm845/recipes-evb-npcm845/cpfw/cpfw_git.bb
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/recipes-evb-npcm845/cpfw/cpfw_git.bb
@@ -12,7 +12,7 @@ INSANE_SKIP:${PN} = "arch"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_PACKAGE_STRIP = "1"
 
-firmware_dir="${nonarch_base_libdir}/firmware/"
+firmware_dir = "${nonarch_base_libdir}/firmware/"
 
 do_install() {
 	install -d ${D}${firmware_dir}

--- a/meta-nuvoton/recipes-nuvoton/program-edid/program-edid.bb
+++ b/meta-nuvoton/recipes-nuvoton/program-edid/program-edid.bb
@@ -13,6 +13,8 @@ SRC_URI = "file://program-edid.service \
            file://program-edid.sh \
            file://edid.json \
 "
+S = "${WORKDIR}/${BPN}"
+UNPACKDIR = "${S}"
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "program-edid.service"


### PR DESCRIPTION
Update recipe for fix follownig warnings:
lack of whitespace: ent, fputest, and cpfw
S variable doesn't exist: npcm400-fw-tool and program-edid.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
