### PR TITLE
meta-phosphor: image_types_phosphor_nuvoton: add mmc support

### DIFF
--- a/meta-phosphor/classes/image_types_phosphor_nuvoton.bbclass
+++ b/meta-phosphor/classes/image_types_phosphor_nuvoton.bbclass
@@ -40,3 +40,4 @@ do_make_ubi:append() {
 do_make_ubi[depends] += "${PN}:do_prepare_bootloaders"
 do_generate_ubi_tar[depends] += "${PN}:do_prepare_bootloaders"
 do_generate_static_tar[depends] += "${PN}:do_prepare_bootloaders"
+do_generate_ext4_tar[depends] += "${PN}:do_prepare_bootloaders"


### PR DESCRIPTION
Make sure u-boot.bin.merge is created before generate mmc image.


