### PR TITLE
meta-scm-npcm845: ipmi-host: update patches

### DIFF
--- a/meta-nuvoton-obmc/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0004-ipmi-warm-reset-command.patch
+++ b/meta-nuvoton-obmc/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0004-ipmi-warm-reset-command.patch
@@ -1,20 +1,20 @@
-From 3108eb27ee4284e6fd33ce89ca4b18b15f763e4b Mon Sep 17 00:00:00 2001
+From 71c179fc1db987b86c550491b70069bcf4c7448e Mon Sep 17 00:00:00 2001
 From: Stanley Chu <yschu@nuvoton.com>
 Date: Tue, 5 Jul 2022 12:56:01 +0800
-Subject: [PATCH] ipmi warm reset command
+Subject: [PATCH 03/14] ipmi warm reset command
 
 Upstream-Status: Inappropriate [oe-specific]
 
 Signed-off-by: Stanley Chu <yschu@nuvoton.com>
 ---
- globalhandler.cpp | 78 ++++++++++++++++++++++++++++++++++++++++++++++-
- 1 file changed, 77 insertions(+), 1 deletion(-)
+ globalhandler.cpp | 64 ++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 63 insertions(+), 1 deletion(-)
 
 diff --git a/globalhandler.cpp b/globalhandler.cpp
-index 7b64d42a..7ecf26ea 100644
+index 36cf0a48..ce05eb4c 100644
 --- a/globalhandler.cpp
 +++ b/globalhandler.cpp
-@@ -3,7 +3,12 @@
+@@ -3,13 +3,46 @@
  #include <phosphor-logging/lg2.hpp>
  #include <xyz/openbmc_project/State/BMC/server.hpp>
  
@@ -25,9 +25,7 @@ index 7b64d42a..7ecf26ea 100644
 +
 +static std::atomic_flag reset_queued = ATOMIC_FLAG_INIT;
  
- static constexpr auto bmcStateRoot = "/xyz/openbmc_project/state";
- static constexpr auto bmcStateIntf = "xyz.openbmc_project.State.BMC";
-@@ -14,7 +19,49 @@ using BMC = sdbusplus::server::xyz::openbmc_project::state::BMC;
+ using BMCState = sdbusplus::server::xyz::openbmc_project::state::BMC;
  
  void registerNetFnGlobalFunctions() __attribute__((constructor));
  
@@ -36,20 +34,6 @@ index 7b64d42a..7ecf26ea 100644
 +constexpr auto SYSTEMD_OBJ_PATH = "/org/freedesktop/systemd1";
 +constexpr auto SYSTEMD_INTERFACE = "org.freedesktop.systemd1.Manager";
 +constexpr auto SYSTEMD_WARM_RESET_TARGET = "phosphor-ipmi-warm-reset.target";
-+
-+void resetBMC()
-+{
-+    sdbusplus::bus_t bus{ipmid_get_sd_bus_connection()};
-+
-+    auto bmcStateObj = ipmi::getDbusObject(bus, bmcStateIntf, bmcStateRoot,
-+                                           match);
-+
-+    auto service = ipmi::getService(bus, bmcStateIntf, bmcStateObj.first);
-+
-+    ipmi::setDbusProperty(bus, service, bmcStateObj.first, bmcStateIntf,
-+                          reqTransition,
-+                          convertForMessage(BMC::Transition::Reboot));
-+}
 +
 +void warmResetBMC()
 +{
@@ -78,7 +62,7 @@ index 7b64d42a..7ecf26ea 100644
   *  @param - None
   *  @returns IPMI completion code.
   */
-@@ -44,11 +91,40 @@ ipmi::RspType<> ipmiGlobalReset(ipmi::Context::ptr ctx)
+@@ -42,11 +75,40 @@ ipmi::RspType<> ipmiGlobalReset(ipmi::Context::ptr ctx)
      return ipmi::responseSuccess();
  }
  
@@ -120,5 +104,5 @@ index 7b64d42a..7ecf26ea 100644
      return;
  }
 -- 
-2.43.0
+2.34.1
 

--- a/meta-nuvoton-obmc/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0009-Add-session-RemoteMACAddress-support.patch
+++ b/meta-nuvoton-obmc/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0009-Add-session-RemoteMACAddress-support.patch
@@ -40,10 +40,10 @@ index ddc6fa1b..98dd7116 100644
 -        // std::get<7>(details) = {{0}}; // default constructed to all 0
 +        std::get<7>(details) =
 +            ipmi::mappedVariant<std::vector<uint8_t>>(
-+                sessionProps, "RemoteMACAddress", std::vector<uint8_t>(6, 0));    
++                sessionProps, "RemoteMACAddress", std::vector<uint8_t>(6, 0));
          std::get<8>(details) =
 -            ipmi::mappedVariant<uint16_t>(sessionProps, "RemotePort", 0);
-+            ipmi::mappedVariant<uint16_t>(sessionProps, "RemotePort", 0);        
++            ipmi::mappedVariant<uint16_t>(sessionProps, "RemotePort", 0);
      }
  
      return ipmi::ccSuccess;

--- a/meta-nuvoton-obmc/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0011-fix-percentage-type-show.patch
+++ b/meta-nuvoton-obmc/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0011-fix-percentage-type-show.patch
@@ -1,7 +1,7 @@
-From 9f0b9d92c792434070efe5e728b06117c9dcbd3d Mon Sep 17 00:00:00 2001
+From 9a25d7d6cb3205e17b87230f34b587e758849654 Mon Sep 17 00:00:00 2001
 From: Joseph Liu <kwliu@nuvoton.com>
 Date: Tue, 3 Sep 2024 12:07:58 +0800
-Subject: [PATCH] fix percentage type show
+Subject: [PATCH 10/14] fix percentage type show
 
 Upstream-Status: Inappropriate [oe-specific]
 ---
@@ -9,10 +9,10 @@ Upstream-Status: Inappropriate [oe-specific]
  1 file changed, 20 insertions(+), 1 deletion(-)
 
 diff --git a/dbus-sdr/sensorcommands.cpp b/dbus-sdr/sensorcommands.cpp
-index bd96ea28..582edc80 100644
+index be7c3176..d3e82a05 100644
 --- a/dbus-sdr/sensorcommands.cpp
 +++ b/dbus-sdr/sensorcommands.cpp
-@@ -1789,6 +1789,18 @@ void constructSensorSdrHeaderKey(uint16_t sensorNum, uint16_t recordID,
+@@ -1817,6 +1817,18 @@ void constructSensorSdrHeaderKey(uint16_t sensorNum, uint16_t recordID,
      record.key.ownerLun = lun;
      record.key.sensorNumber = sensornumber;
  }
@@ -21,7 +21,7 @@ index bd96ea28..582edc80 100644
 +{
 +    const static std::string PERCENT =
 +        "xyz.openbmc_project.Sensor.Value.Unit.Percent";
-+    auto sensorObject = sensorMap.find(sensor::sensorInterface);
++    auto sensorObject = sensorMap.find(SensorValue::interface);
 +    std::string unit;
 +    unit = ipmi::mappedVariant<std::string>(sensorObject->second, "Unit",
 +                                            std::string());
@@ -31,7 +31,7 @@ index bd96ea28..582edc80 100644
  bool constructSensorSdr(
      ipmi::Context::ptr ctx,
      const std::unordered_set<std::string>& ipmiDecoratorPaths,
-@@ -1897,7 +1909,14 @@ bool constructSensorSdr(
+@@ -1925,7 +1937,14 @@ bool constructSensorSdr(
  
      // Set the analog reading byte interpretation accordingly
      record.body.sensorUnits1 = (bSigned ? 1 : 0) << 7;

--- a/meta-nuvoton-obmc/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0013-add-sensor-reading-factory-support.patch
+++ b/meta-nuvoton-obmc/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0013-add-sensor-reading-factory-support.patch
@@ -1,7 +1,7 @@
-From 4b9cf3c4b8c22131937826d8d8130e76fcb82cbf Mon Sep 17 00:00:00 2001
+From 198b3548315c43ef3ef4519a273100dafc3c53ac Mon Sep 17 00:00:00 2001
 From: Joseph Liu <kwliu@nuvoton.com>
 Date: Tue, 3 Sep 2024 12:01:16 +0800
-Subject: [PATCH] add sensor reading factory support
+Subject: [PATCH 12/14] add sensor reading factory support
 
 Upstream-Status: Inappropriate [oe-specific]
 
@@ -12,10 +12,10 @@ Signed-off-by: Joseph Liu <kwliu@nuvoton.com>
  1 file changed, 113 insertions(+)
 
 diff --git a/dbus-sdr/sensorcommands.cpp b/dbus-sdr/sensorcommands.cpp
-index ef5eb996..9f37b8ff 100644
+index 83a74a9d..cbc7663a 100644
 --- a/dbus-sdr/sensorcommands.cpp
 +++ b/dbus-sdr/sensorcommands.cpp
-@@ -2820,6 +2820,115 @@ ipmi::RspType<uint8_t,                // No of instances for requested id
+@@ -2858,6 +2858,115 @@ ipmi::RspType<uint8_t,                // No of instances for requested id
  
  } // namespace dcmi
  
@@ -43,7 +43,7 @@ index ef5eb996..9f37b8ff 100644
 +        return ipmi::responseResponseError();
 +    }
 +
-+    auto sensorObject = sensorMap.find(sensor::sensorInterface);
++    auto sensorObject = sensorMap.find(SensorValue::interface);
 +
 +    if (sensorObject == sensorMap.end() ||
 +        sensorObject->second.find("Value") == sensorObject->second.end())
@@ -131,7 +131,7 @@ index ef5eb996..9f37b8ff 100644
  /* end storage commands */
  
  void registerSensorFunctions()
-@@ -2914,5 +3023,9 @@ void registerSensorFunctions()
+@@ -2952,5 +3061,9 @@ void registerSensorFunctions()
                            ipmi::sensor_event::cmdGetSensorType,
                            ipmi::Privilege::User, ipmiSenGetSensorType);
  

--- a/meta-nuvoton-obmc/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0017-set-channel-security-keys.patch
+++ b/meta-nuvoton-obmc/meta-scm-npcm845/recipes-phosphor/ipmi/phosphor-ipmi-host/0017-set-channel-security-keys.patch
@@ -1,7 +1,7 @@
-From f863d22fef6d18583616762cfd602a9a46441a49 Mon Sep 17 00:00:00 2001
+From e0cb13cdd8229dd8e78270532a81a041ce0310c0 Mon Sep 17 00:00:00 2001
 From: Joseph Liu <kwliu@nuvoton.com>
 Date: Mon, 24 Mar 2025 15:08:25 +0800
-Subject: [PATCH] set channel security keys
+Subject: [PATCH 14/14] set channel security keys
 
 Upstream-Status: Inappropriate [oe-specific]
 
@@ -38,11 +38,11 @@ index a6b8703d..e9f24c9c 100644
 +}__attribute__((packed));
 +
 diff --git a/apphandler.cpp b/apphandler.cpp
-index 1e320615..e6116999 100644
+index 2fd31bb5..9ad2ce1c 100644
 --- a/apphandler.cpp
 +++ b/apphandler.cpp
 @@ -67,7 +67,21 @@ using Activation =
- using BMC = sdbusplus::server::xyz::openbmc_project::state::BMC;
+ using BMCState = sdbusplus::server::xyz::openbmc_project::state::BMC;
  namespace fs = std::filesystem;
  
 +#define MAXCH 15
@@ -63,7 +63,7 @@ index 1e320615..e6116999 100644
  typedef struct
  {
      uint8_t busId;
-@@ -1785,6 +1799,145 @@ ipmi::RspType<std::vector<uint8_t>> ipmiControllerWriteRead(
+@@ -1874,6 +1888,145 @@ ipmi::RspType<std::vector<uint8_t>> ipmiControllerWriteRead(
      return ipmi::responseSuccess(readBuf);
  }
  
@@ -209,7 +209,7 @@ index 1e320615..e6116999 100644
  void registerNetFnAppFunctions()
  {
      // <Get Device ID>
-@@ -1869,5 +2022,10 @@ void registerNetFnAppFunctions()
+@@ -1958,5 +2111,10 @@ void registerNetFnAppFunctions()
      ipmi::registerHandler(ipmi::prioOpenBmcBase, ipmi::netFnApp,
                            ipmi::app::cmdSetSystemInfoParameters,
                            ipmi::Privilege::Admin, ipmiAppSetSystemInfo);
@@ -221,10 +221,10 @@ index 1e320615..e6116999 100644
      return;
  }
 diff --git a/include/ipmid/api.h b/include/ipmid/api.h
-index fd6fee61..a1a00027 100644
+index 1a92322d..83b6ce70 100644
 --- a/include/ipmid/api.h
 +++ b/include/ipmid/api.h
-@@ -108,6 +108,11 @@ enum ipmi_return_codes
+@@ -107,6 +107,11 @@ enum ipmi_return_codes
      IPMI_WDOG_CC_NOT_INIT = 0x80,
      IPMI_CC_SYSTEM_INFO_PARAMETER_NOT_SUPPORTED = 0x80,
      IPMI_CC_SYSTEM_INFO_PARAMETER_SET_READ_ONLY = 0x82,
@@ -237,7 +237,7 @@ index fd6fee61..a1a00027 100644
      IPMI_CC_INVALID = 0xC1,
      IPMI_CC_TIMEOUT = 0xC3,
 diff --git a/user_channel/user_layer.cpp b/user_channel/user_layer.cpp
-index 5a2e7e02..92a13753 100644
+index ff1f9657..484301b0 100644
 --- a/user_channel/user_layer.cpp
 +++ b/user_channel/user_layer.cpp
 @@ -18,6 +18,14 @@
@@ -255,7 +255,7 @@ index 5a2e7e02..92a13753 100644
  
  namespace
  {
-@@ -223,4 +231,30 @@ Cc ipmiUserGetUserPayloadAccess(const uint8_t chNum, const uint8_t userId,
+@@ -234,4 +242,30 @@ Cc ipmiUserGetUserPayloadAccess(const uint8_t chNum, const uint8_t userId,
      return ccSuccess;
  }
  
@@ -302,5 +302,5 @@ index ad215e39..688b0eec 100644
  
  } // namespace ipmi
 -- 
-2.43.0
+2.34.1
 


### PR DESCRIPTION
Update meta-scm-npcm845 phosphor-ipmi-host patches to fix build break. 0004-ipmi-warm-reset-command.patch: remove unused resetBMC function 0009-Add-session-RemoteMACAddress-support.patch: remove white spaces 0011-fix-percentage-type-show.patch: update sensor API 0013-add-sensor-reading-factory-support.patch: update sensor API

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
