### PR TITLE
Fix Bitbake layer priorities and serial console configuration for Nuvoton platforms

### DIFF
--- a/meta-nuvoton-obmc/meta-common/conf/layer.conf
+++ b/meta-nuvoton-obmc/meta-common/conf/layer.conf
@@ -7,5 +7,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "common"
 BBFILE_PATTERN_common = "^${LAYERDIR}/"
-BBFILE_PRIORITY_common = "9"
+BBFILE_PRIORITY_common = "6"
 LAYERSERIES_COMPAT_common = "scarthgap styhead walnascar"

--- a/meta-nuvoton-obmc/meta-evb-npcm750/conf/layer.conf
+++ b/meta-nuvoton-obmc/meta-evb-npcm750/conf/layer.conf
@@ -7,6 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "evb-npcm750-stage-layer"
 BBFILE_PATTERN_evb-npcm750-stage-layer := "^${LAYERDIR}/"
+BBFILE_PRIORITY_evb-npcm750-stage-layer = "6"
 LAYERVERSION_evb-npcm750-stage-layer = "1"
 LAYERSERIES_COMPAT_evb-npcm750-stage-layer = "scarthgap styhead walnascar"
 LAYERDEPENDS_evb-npcm750-stage-layer = "evb-npcm750"

--- a/meta-nuvoton-obmc/meta-evb-npcm845/conf/layer.conf
+++ b/meta-nuvoton-obmc/meta-evb-npcm845/conf/layer.conf
@@ -7,6 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "evb-npcm845-stage-layer"
 BBFILE_PATTERN_evb-npcm845-stage-layer := "^${LAYERDIR}/"
+BBFILE_PRIORITY_evb-npcm845-stage-layer = "6"
 LAYERVERSION_evb-npcm845-stage-layer = "1"
 LAYERSERIES_COMPAT_evb-npcm845-stage-layer = "scarthgap styhead walnascar"
 LAYERDEPENDS_evb-npcm845-stage-layer = "evb-npcm845"

--- a/meta-nuvoton/conf/machine/include/npcm7xx.inc
+++ b/meta-nuvoton/conf/machine/include/npcm7xx.inc
@@ -24,7 +24,7 @@ FLASH_UBI_RWFS_TXT_SIZE = "6MiB"
 
 DEFAULTTUNE ?= "arm7a-novfp"
 
-SERIAL_CONSOLES = "115200;ttyS3"
+SERIAL_CONSOLES = "115200;ttyS0"
 
 SOC_FAMILY = "npcm7xx"
 include conf/machine/include/soc-family.inc


### PR DESCRIPTION
This PR includes two fixes for Nuvoton OpenBMC meta layers:

### Changes
1. **Standardize layer priorities** - Ensures consistent recipe precedence across all Nuvoton layers
   - Prevents overly high layer priority from overriding recipes in critical layers
   - Affects: meta-nuvoton-obmc (evb-npcm845, evb-npcm750)

2. **Fix serial console port** - Updates NPCM7XX serial console configuration
   - Changes serial console from ttyS3 to ttyS0 for correct port mapping
   - Affects: meta-nuvoton (npcm7xx)

### Checklist
- [O] Code follows project style guidelines
- [O] Changes have been tested
- [O] Documentation has been updated if needed