### PR TITLE
meta-nuvoton-obmc: qemu-native: use python-native

### DIFF
--- a/meta-nuvoton-obmc/meta-common/recipes-devtools/qemu/qemu-native/0010-configure-lookup-meson-exutable-from-PATH.patch
+++ b/meta-nuvoton-obmc/meta-common/recipes-devtools/qemu/qemu-native/0010-configure-lookup-meson-exutable-from-PATH.patch
@@ -1,0 +1,40 @@
+From d8aaa0280544dabd8014bd48e7eedd5e08e06aa5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Hundeb=C3=B8ll?= <martin@geanix.com>
+Date: Wed, 22 May 2024 14:02:55 +0200
+Subject: [PATCH] configure: lookup meson exutable from PATH
+
+Upstream-Status: Inappropriate [workaround, would need a real fix for upstream]
+---
+ configure | 16 +---------------
+ 1 file changed, 1 insertion(+), 15 deletions(-)
+
+diff --git a/configure b/configure
+index 82cace1bc9..9d4ca5609b 100755
+--- a/configure
++++ b/configure
+@@ -979,21 +979,7 @@ mkvenv="$python ${source_path}/python/scripts/mkvenv.py"
+ $mkvenv ensuregroup --dir "${source_path}/python/wheels" \
+      ${source_path}/pythondeps.toml meson || exit 1
+ 
+-# At this point, we expect Meson to be installed and available.
+-# We expect mkvenv or pip to have created pyvenv/bin/meson for us.
+-# We ignore PATH completely here: we want to use the venv's Meson
+-# *exclusively*.
+-
+-# for msys2
+-get_pwd() {
+-    if pwd -W >/dev/null 2>&1; then
+-        pwd -W
+-    else
+-        pwd
+-    fi
+-}
+-
+-meson="$(cd pyvenv/bin; get_pwd)/meson"
++meson=`which meson`
+ if [ -f "$meson$EXESUF" ]; then
+   meson="$meson$EXESUF"
+ fi
+-- 
+2.34.1
+

--- a/meta-nuvoton-obmc/meta-common/recipes-devtools/qemu/qemu-native_%.bbappend
+++ b/meta-nuvoton-obmc/meta-common/recipes-devtools/qemu/qemu-native_%.bbappend
@@ -8,6 +8,11 @@ SRCREV = "48e6aea0574f1dcca3c7bc8fb5ea68a92728144a"
 S = "${WORKDIR}/git"
 PV = "10.2.0+git${SRCPV}"
 
+SRC_URI:append = " \
+    file://0010-configure-lookup-meson-exutable-from-PATH.patch \
+    file://0011-qemu-Ensure-pip-and-the-python-venv-aren-t-used-for-.patch \
+    "
+
 # Since qemu-native runs on the build host and doesn't see machine overrides like npcm7xx/npcm8xx,
 # we must enable both ARM (for NPCM7xx) and AArch64 (for NPCM8xx) targets unconditionally.
 EXTRA_OECONF:append = " --target-list=aarch64-softmmu,aarch64-linux-user,arm-softmmu,arm-linux-user"
@@ -20,7 +25,7 @@ PACKAGECONFIG:remove = " gnutls"
 EXTRA_OECONF:remove = "--disable-static --disable-download"
 
 # Force use of host python to avoid shebang length limit issues with sysroot python
-EXTRA_OECONF:append = " --python=${HOSTTOOLS_DIR}/python3"
+#EXTRA_OECONF:append = " --python=${HOSTTOOLS_DIR}/python3"
 
 # Allow fetching subprojects during configure
 do_configure[network] = "1"


### PR DESCRIPTION
Use python-native instead of using python3 on host. This may cause some depend package missing. Upstream already have patches for this issue, just pick it up.


